### PR TITLE
feat: add AuthCard primitive (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] — 2026-04-30
+
+### Added
+
+- `<AuthCard>` — a layout primitive for centered-card auth screens (Login, Register, LoggedOut, etc.). Provides slots for logo, topbar-right content, eyebrow, title, subtitle, footer, and body. Two width presets (`md` 440px, `lg` 480px). Optional dot-grid background and topbar can be hidden for embedded or printable contexts.
+
 ## [1.0.0] — 2026-04-30
 
 First stable release. Adopts the refined design-system value set across all token layers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/auth-card.stories.tsx
+++ b/src/components/auth-card.stories.tsx
@@ -1,0 +1,84 @@
+// src/components/auth-card.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../atoms/button";
+import { TextInput } from "../atoms/text-input";
+import { Heading, Text } from "../primitives/typography";
+import { AuthCard } from "./auth-card";
+
+const meta = {
+	title: "Components/AuthCard",
+	component: AuthCard,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof AuthCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleLogo = () => (
+	<Heading as="span" size="md" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+const SampleTopBarRight = () => (
+	<>
+		<Text fontSize="xs" color="muted">
+			Hilfe
+		</Text>
+		<Text fontSize="xs" color="muted">
+			DE / EN
+		</Text>
+	</>
+);
+
+export const Default: Story = {
+	args: {
+		logo: <SampleLogo />,
+		topBarRight: <SampleTopBarRight />,
+		eyebrow: "ANMELDUNG",
+		title: "Anmelden bei knk",
+		subtitle: "Gib deine E-Mail ein, um fortzufahren.",
+		children: (
+			<>
+				<TextInput placeholder="jana.schmid@knk.de" mb="4" />
+				<Button colorPalette="primary" variant="solid" w="full">
+					Weiter
+				</Button>
+			</>
+		),
+	},
+};
+
+export const WithFooter: Story = {
+	args: {
+		...Default.args,
+		footer: (
+			<Text fontSize="xs">
+				Noch kein Konto? <a href="/register">Anmelden</a>
+			</Text>
+		),
+	},
+};
+
+export const Wide: Story = {
+	args: {
+		...Default.args,
+		size: "lg",
+		title: "Konto erstellen",
+		subtitle: "Wähle ein Passwort, um dein Konto zu sichern.",
+	},
+};
+
+export const NoTopBar: Story = {
+	args: {
+		...Default.args,
+		hideTopBar: true,
+	},
+};
+
+export const NoBackground: Story = {
+	args: {
+		...Default.args,
+		hideBackground: true,
+	},
+};

--- a/src/components/auth-card.test.tsx
+++ b/src/components/auth-card.test.tsx
@@ -1,0 +1,122 @@
+// src/components/auth-card.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuthCard } from "./auth-card";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("AuthCard", () => {
+	it("renders the title", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in">
+				<div>body</div>
+			</AuthCard>,
+		);
+		expect(
+			screen.getByRole("heading", { name: "Sign in" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the children inside the card body", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in">
+				<button type="button">Continue</button>
+			</AuthCard>,
+		);
+		expect(
+			screen.getByRole("button", { name: "Continue" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders subtitle when provided", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in" subtitle="Enter your email">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByText("Enter your email")).toBeInTheDocument();
+	});
+
+	it("renders eyebrow when provided", () => {
+		renderWithChakra(
+			<AuthCard eyebrow="ANMELDUNG" title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByText("ANMELDUNG")).toBeInTheDocument();
+	});
+
+	it("renders footer when provided", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in" footer={<a href="/register">Sign up</a>}>
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByRole("link", { name: "Sign up" })).toBeInTheDocument();
+	});
+
+	it("does not render footer when not provided", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.queryByTestId("auth-card-footer")).not.toBeInTheDocument();
+	});
+
+	it("renders logo and topBarRight slots in the topbar", () => {
+		renderWithChakra(
+			<AuthCard
+				logo={<span>knk</span>}
+				topBarRight={<a href="/help">Help</a>}
+				title="Sign in"
+			>
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByText("knk")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Help" })).toBeInTheDocument();
+	});
+
+	it("hides the topbar when hideTopBar=true", () => {
+		renderWithChakra(
+			<AuthCard hideTopBar logo={<span>knk</span>} title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.queryByText("knk")).not.toBeInTheDocument();
+	});
+
+	it("exposes data-size='md' by default", () => {
+		renderWithChakra(
+			<AuthCard title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByTestId("auth-card")).toHaveAttribute("data-size", "md");
+	});
+
+	it("exposes data-size='lg' when size='lg'", () => {
+		renderWithChakra(
+			<AuthCard size="lg" title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByTestId("auth-card")).toHaveAttribute("data-size", "lg");
+	});
+
+	it("exposes data-background='hidden' when hideBackground=true", () => {
+		renderWithChakra(
+			<AuthCard hideBackground title="Sign in">
+				<div />
+			</AuthCard>,
+		);
+		expect(screen.getByTestId("auth-card-canvas")).toHaveAttribute(
+			"data-background",
+			"hidden",
+		);
+	});
+});

--- a/src/components/auth-card.tsx
+++ b/src/components/auth-card.tsx
@@ -14,7 +14,11 @@ export interface AuthCardProps {
 	hideBackground?: boolean;
 	/** Small uppercase eyebrow above the title. */
 	eyebrow?: React.ReactNode;
-	/** Card title (h3, 24px, semibold, default color). */
+	/**
+	 * Card title. Accepts a string or inline element — the component wraps
+	 * it in an `<h3>` (semantic heading, 24px, semibold, default color).
+	 * Avoid passing block elements (e.g. `<div>`) or pre-built headings.
+	 */
 	title?: React.ReactNode;
 	/** Subtitle below title (14px, muted color, centered). */
 	subtitle?: React.ReactNode;
@@ -61,7 +65,7 @@ export const AuthCard = ({
 						justify="space-between"
 						px="8"
 						py="4"
-						bg="rgba(255,255,255,0.85)"
+						bg="bg-surface/85"
 						backdropFilter="blur(4px)"
 						borderBottom="1px solid"
 						borderColor="border"
@@ -111,7 +115,7 @@ export const AuthCard = ({
 							</Text>
 						)}
 
-						<Box>{children}</Box>
+						{children}
 
 						{footer && (
 							<Box

--- a/src/components/auth-card.tsx
+++ b/src/components/auth-card.tsx
@@ -1,0 +1,136 @@
+// src/components/auth-card.tsx
+import type React from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+
+export interface AuthCardProps {
+	/** Logo or wordmark, far-left of the topbar. */
+	logo?: React.ReactNode;
+	/** Right-side topbar content (help link, locale switcher, etc.). */
+	topBarRight?: React.ReactNode;
+	/** Hide the topbar entirely (rare — e.g. embedded preview). */
+	hideTopBar?: boolean;
+	/** Hide the dot-grid background (rare — e.g. printable). */
+	hideBackground?: boolean;
+	/** Small uppercase eyebrow above the title. */
+	eyebrow?: React.ReactNode;
+	/** Card title (h3, 24px, semibold, default color). */
+	title?: React.ReactNode;
+	/** Subtitle below title (14px, muted color, centered). */
+	subtitle?: React.ReactNode;
+	/** Card width preset. md = 440px (default), lg = 480px. */
+	size?: "md" | "lg";
+	/** Card footer slot. Bottom-bordered inside the card. */
+	footer?: React.ReactNode;
+	/** Page content inside the card body. */
+	children: React.ReactNode;
+}
+
+const SIZE_TO_WIDTH: Record<NonNullable<AuthCardProps["size"]>, string> = {
+	md: "440px",
+	lg: "480px",
+};
+
+const DOT_PATTERN_BG =
+	"radial-gradient(var(--chakra-colors-primary-200) 1px, transparent 1px)";
+
+export const AuthCard = ({
+	logo,
+	topBarRight,
+	hideTopBar = false,
+	hideBackground = false,
+	eyebrow,
+	title,
+	subtitle,
+	size = "md",
+	footer,
+	children,
+}: AuthCardProps) => {
+	return (
+		<Box data-testid="auth-card" data-size={size} minH="100vh" bg="bg-canvas">
+			<Box
+				data-testid="auth-card-canvas"
+				data-background={hideBackground ? "hidden" : "visible"}
+				minH="100vh"
+				bgImage={hideBackground ? undefined : DOT_PATTERN_BG}
+				bgSize="24px 24px"
+			>
+				{!hideTopBar && (
+					<Flex
+						align="center"
+						justify="space-between"
+						px="8"
+						py="4"
+						bg="rgba(255,255,255,0.85)"
+						backdropFilter="blur(4px)"
+						borderBottom="1px solid"
+						borderColor="border"
+					>
+						<Box>{logo}</Box>
+						<Flex gap="4" fontSize="xs" color="muted">
+							{topBarRight}
+						</Flex>
+					</Flex>
+				)}
+
+				<Flex justify="center" pt="16" px="4">
+					<Box
+						w="full"
+						maxW={SIZE_TO_WIDTH[size]}
+						bg="bg-surface"
+						borderRadius="lg"
+						shadow="md"
+						p="8"
+					>
+						{eyebrow && (
+							<Text
+								textStyle="overline"
+								color="muted"
+								textAlign="center"
+								mb="2"
+							>
+								{eyebrow}
+							</Text>
+						)}
+						{title && (
+							<Heading
+								as="h3"
+								size="2xl"
+								fontWeight="semibold"
+								color="default"
+								textAlign="center"
+								mb="2"
+								letterSpacing="-0.02em"
+							>
+								{title}
+							</Heading>
+						)}
+						{subtitle && (
+							<Text color="muted" textAlign="center" fontSize="sm" mb="6">
+								{subtitle}
+							</Text>
+						)}
+
+						<Box>{children}</Box>
+
+						{footer && (
+							<Box
+								data-testid="auth-card-footer"
+								mt="6"
+								pt="4"
+								borderTop="1px solid"
+								borderColor="border"
+								textAlign="center"
+								fontSize="xs"
+								color="emphasized"
+							>
+								{footer}
+							</Box>
+						)}
+					</Box>
+				</Flex>
+			</Box>
+		</Box>
+	);
+};
+AuthCard.displayName = "AuthCard";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,6 @@
+// AuthCard
+export type { AuthCardProps } from "./auth-card";
+export { AuthCard } from "./auth-card";
 // BulkActionBar
 export type {
 	BulkActionBarProps,


### PR DESCRIPTION
## Summary

Adds a new `<AuthCard>` layout primitive — a centered-card frame for auth screens (Login, Register, LoggedOut, MFA, etc.). First addition since 1.0.0.

- Slots: `logo`, `topBarRight` (topbar), `eyebrow`, `title`, `subtitle`, `footer`, `children` (body).
- Width presets: `size: \"md\"` (440px, default) / `\"lg\"` (480px).
- Optional `hideTopBar` and `hideBackground` toggles for embedded / printable contexts.
- Theme-aware: topbar bg uses `bg-surface/85` (works in light + dark mode); dot-grid uses `primary.200`.

Bumps to **1.1.0** (additive — no breaking changes since 1.0.0).

## Context

First sub-project of a multi-step UI redesign happening in [odon](https://github.com/knkcs/odon). The full design spec is at `odon:docs/superpowers/specs/2026-04-30-ui-redesign-foundation-design.md`. Future Anker work will follow as separate PRs (PageHeader, Toolbar, ContextRail in sub-project #3; visual tweaks discovered during sub-project #2; etc.).

## Test plan

- [x] 11 unit tests covering every prop's behavior — all pass
- [x] 5 Storybook stories: \`Default\`, \`WithFooter\`, \`Wide\`, \`NoTopBar\`, \`NoBackground\`
- [x] \`npm run build\` clean (tsup ESM + DTS)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean for new files
- [x] \`AuthCard\` and \`AuthCardProps\` exported from the components barrel — verified in \`dist/index.d.ts\`
- [ ] Visual check in Storybook (\`npm run dev\` → Components / AuthCard) — please verify before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)