### PR TITLE
feat: app shell primitives — Sidebar, PageHeader, Toolbar, ContextRail (1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] — 2026-04-30
+
+### Added
+
+- `<Sidebar>` — compound primitive for the app shell sidebar (240px). Subcomponents: `Header`, `Logo`, `Slot`, `Body`, `Section`, `Item` (with `asChild` and `active`), `Footer`, `UserMenu`, `UserMenuItem`. Cross-product nav surface; consumers slot their own logo, org-switcher, language switcher, etc.
+- `<PageHeader>` — per-page imperative header with breadcrumbs, title, optional subtitle, optional eyebrow, and an actions slot.
+- `<Toolbar>` — compound primitive for list-page toolbars. Subcomponents: `Search`, `Filters`, `FilterChip` (with `active`), `Right`, `Count`. Pages compose what they need; bulk-action mode is the existing `<BulkActionBar>` (no changes).
+- `<ContextRail>` — collapsible right-rail chrome (44 ↔ 360px) with viewport-aware default and `localStorage` persistence via `storageKey`. Subcomponents `Header`, `Section`, `Footer` exported for consumer use.
+
 ## [1.1.0] — 2026-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/context-rail/context-rail.stories.tsx
+++ b/src/components/context-rail/context-rail.stories.tsx
@@ -1,0 +1,82 @@
+// src/components/context-rail/context-rail.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { History, Info, Monitor, ShieldCheck, Zap } from "lucide-react";
+import { ContextRail } from "./context-rail";
+
+const meta = {
+	title: "Components/ContextRail",
+	component: ContextRail,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ContextRail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => (
+		<ContextRail>
+			<ContextRail.Header eyebrow="User" title="Jana Schmid" />
+			<ContextRail.Section
+				id="details"
+				icon={<Info size={14} />}
+				label="Details"
+			>
+				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+					Role: Admin · 2FA: On · ID: usr_abc123
+				</p>
+			</ContextRail.Section>
+			<ContextRail.Section
+				id="security"
+				icon={<ShieldCheck size={14} />}
+				label="Security"
+			>
+				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+					Last sign-in: 2 hours ago
+				</p>
+			</ContextRail.Section>
+			<ContextRail.Section
+				id="sessions"
+				icon={<Monitor size={14} />}
+				label="Active Sessions"
+			>
+				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+					3 devices
+				</p>
+			</ContextRail.Section>
+			<ContextRail.Section
+				id="activity"
+				icon={<History size={14} />}
+				label="Recent Activity"
+			>
+				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+					Updated profile · 1 day ago
+				</p>
+			</ContextRail.Section>
+			<ContextRail.Section
+				id="actions"
+				icon={<Zap size={14} />}
+				label="Quick Actions"
+			>
+				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+					Reset password · Suspend
+				</p>
+			</ContextRail.Section>
+			<ContextRail.Footer>
+				<button type="button">Open detail →</button>
+			</ContextRail.Footer>
+		</ContextRail>
+	),
+};
+
+export const CollapsedByDefault: Story = {
+	render: () => {
+		if (typeof window !== "undefined") {
+			localStorage.setItem("storybook.rail.collapsed", "true");
+		}
+		return (
+			<ContextRail storageKey="storybook.rail.collapsed">
+				<ContextRail.Header eyebrow="User" title="Jana Schmid" />
+			</ContextRail>
+		);
+	},
+};

--- a/src/components/context-rail/context-rail.test.tsx
+++ b/src/components/context-rail/context-rail.test.tsx
@@ -1,0 +1,154 @@
+// src/components/context-rail/context-rail.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ContextRail } from "./context-rail";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("ContextRail", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("renders the root with data-testid='context-rail'", () => {
+		renderWithChakra(<ContextRail>content</ContextRail>);
+		expect(screen.getByTestId("context-rail")).toBeInTheDocument();
+	});
+
+	it("renders children when expanded", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		renderWithChakra(
+			<ContextRail>
+				<div data-testid="rail-body">body</div>
+			</ContextRail>,
+		);
+		expect(screen.getByTestId("rail-body")).toBeInTheDocument();
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"false",
+		);
+	});
+
+	it("starts collapsed when viewport is narrower than 1440px", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1024,
+			configurable: true,
+		});
+		renderWithChakra(<ContextRail>body</ContextRail>);
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+	});
+
+	it("toggles between expanded and collapsed when toggle button clicked", async () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		const user = userEvent.setup();
+		renderWithChakra(<ContextRail>body</ContextRail>);
+
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"false",
+		);
+
+		await user.click(screen.getByTestId("context-rail-toggle"));
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+
+		await user.click(screen.getByTestId("context-rail-toggle"));
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"false",
+		);
+	});
+
+	it("persists collapse state to localStorage when storageKey is provided", async () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		const user = userEvent.setup();
+		renderWithChakra(<ContextRail storageKey="test.rail">body</ContextRail>);
+
+		await user.click(screen.getByTestId("context-rail-toggle"));
+		expect(localStorage.getItem("test.rail")).toBe("true");
+
+		await user.click(screen.getByTestId("context-rail-toggle"));
+		expect(localStorage.getItem("test.rail")).toBe("false");
+	});
+
+	it("reads initial state from localStorage when storageKey is provided", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		localStorage.setItem("test.rail", "true");
+		renderWithChakra(<ContextRail storageKey="test.rail">body</ContextRail>);
+		expect(screen.getByTestId("context-rail")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+	});
+
+	it("renders ContextRail.Header eyebrow and title", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Header eyebrow="User" title="Preview" />
+			</ContextRail>,
+		);
+		expect(screen.getByText("User")).toBeInTheDocument();
+		expect(screen.getByText("Preview")).toBeInTheDocument();
+	});
+
+	it("renders ContextRail.Section label and content", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Section id="details" icon={<span>i</span>} label="Details">
+					<div data-testid="section-content">body</div>
+				</ContextRail.Section>
+			</ContextRail>,
+		);
+		expect(screen.getByText("Details")).toBeInTheDocument();
+		expect(screen.getByTestId("section-content")).toBeInTheDocument();
+	});
+
+	it("renders ContextRail.Footer children", () => {
+		Object.defineProperty(window, "innerWidth", {
+			value: 1600,
+			configurable: true,
+		});
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Footer>
+					<button type="button">Open detail</button>
+				</ContextRail.Footer>
+			</ContextRail>,
+		);
+		expect(
+			screen.getByRole("button", { name: "Open detail" }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/context-rail/context-rail.tsx
+++ b/src/components/context-rail/context-rail.tsx
@@ -1,0 +1,168 @@
+// src/components/context-rail/context-rail.tsx
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { IconButton } from "../../atoms/button";
+import { Box, Flex } from "../../primitives/layout";
+import { Heading, Text } from "../../primitives/typography";
+
+const COLLAPSED_WIDTH = "44px";
+const EXPANDED_WIDTH = "360px";
+const COLLAPSE_BREAKPOINT = 1440;
+
+function getInitialCollapsed(storageKey?: string): boolean {
+	if (typeof window === "undefined") return false;
+	if (storageKey) {
+		const stored = window.localStorage.getItem(storageKey);
+		if (stored === "true") return true;
+		if (stored === "false") return false;
+	}
+	return window.innerWidth < COLLAPSE_BREAKPOINT;
+}
+
+export interface ContextRailProps {
+	storageKey?: string;
+	children: React.ReactNode;
+}
+
+const ContextRailRoot = ({ storageKey, children }: ContextRailProps) => {
+	const [collapsed, setCollapsed] = useState(() =>
+		getInitialCollapsed(storageKey),
+	);
+
+	useEffect(() => {
+		if (storageKey) {
+			window.localStorage.setItem(storageKey, String(collapsed));
+		}
+	}, [collapsed, storageKey]);
+
+	return (
+		<Box
+			data-testid="context-rail"
+			data-collapsed={collapsed ? "true" : "false"}
+			w={collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}
+			minH="100vh"
+			bg="bg-surface"
+			borderLeftWidth="1px"
+			borderLeftColor="border"
+			transition="width 250ms ease-out"
+			overflow="hidden"
+			position="relative"
+		>
+			{collapsed ? (
+				<Flex direction="column" align="center" pt="3" gap="3">
+					<IconButton
+						data-testid="context-rail-toggle"
+						aria-label="Expand context rail"
+						variant="ghost"
+						size="sm"
+						onClick={() => setCollapsed(false)}
+					>
+						<PanelRightOpen size={16} />
+					</IconButton>
+				</Flex>
+			) : (
+				<Flex direction="column" h="full">
+					<Flex justify="flex-end" px="3" pt="3">
+						<IconButton
+							data-testid="context-rail-toggle"
+							aria-label="Collapse context rail"
+							variant="ghost"
+							size="sm"
+							onClick={() => setCollapsed(true)}
+						>
+							<PanelRightClose size={16} />
+						</IconButton>
+					</Flex>
+					<Box flex="1" overflowY="auto" px="4" pb="4">
+						{children}
+					</Box>
+				</Flex>
+			)}
+		</Box>
+	);
+};
+ContextRailRoot.displayName = "ContextRail";
+
+// Header
+export interface ContextRailHeaderProps {
+	eyebrow?: React.ReactNode;
+	title: React.ReactNode;
+	onClose?: () => void;
+}
+
+const ContextRailHeader = ({
+	eyebrow,
+	title,
+	onClose: _onClose,
+}: ContextRailHeaderProps) => (
+	<Box mb="4">
+		{eyebrow && (
+			<Text
+				fontSize="2xs"
+				fontWeight="semibold"
+				letterSpacing="wider"
+				textTransform="uppercase"
+				color="muted"
+				mb="1"
+			>
+				{eyebrow}
+			</Text>
+		)}
+		<Heading
+			as="h2"
+			fontSize="lg"
+			fontWeight="semibold"
+			color="default"
+			letterSpacing="-0.01em"
+		>
+			{title}
+		</Heading>
+	</Box>
+);
+ContextRailHeader.displayName = "ContextRail.Header";
+
+// Section
+export interface ContextRailSectionProps {
+	id: string;
+	icon?: React.ReactNode;
+	label: string;
+	children: React.ReactNode;
+}
+
+const ContextRailSection = ({
+	id,
+	icon,
+	label,
+	children,
+}: ContextRailSectionProps) => (
+	<Box mb="4" data-section-id={id}>
+		<Flex align="center" gap="2" mb="2">
+			{icon && (
+				<Box display="inline-flex" alignItems="center" color="muted">
+					{icon}
+				</Box>
+			)}
+			<Heading as="h3" fontSize="sm" fontWeight="semibold" color="default">
+				{label}
+			</Heading>
+		</Flex>
+		<Box>{children}</Box>
+	</Box>
+);
+ContextRailSection.displayName = "ContextRail.Section";
+
+// Footer
+const ContextRailFooter = ({ children }: { children: React.ReactNode }) => (
+	<Box mt="4" pt="4" borderTopWidth="1px" borderTopColor="border-muted">
+		{children}
+	</Box>
+);
+ContextRailFooter.displayName = "ContextRail.Footer";
+
+// Compose
+export const ContextRail = Object.assign(ContextRailRoot, {
+	Header: ContextRailHeader,
+	Section: ContextRailSection,
+	Footer: ContextRailFooter,
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,13 @@ export { CardListItem } from "./card-list-item";
 // ChipPicker
 export type { ChipPickerProps } from "./chip-picker";
 export { ChipPicker } from "./chip-picker";
+// ContextRail
+export type {
+	ContextRailHeaderProps,
+	ContextRailProps,
+	ContextRailSectionProps,
+} from "./context-rail/context-rail";
+export { ContextRail } from "./context-rail/context-rail";
 // DataTable + DataTable Cells
 export type {
 	ActionCellAction,
@@ -76,6 +83,9 @@ export { LabeledSwitch } from "./labeled-switch";
 // Modal
 export type { ModalProps } from "./modal";
 export { Modal } from "./modal";
+// PageHeader
+export type { PageHeaderBreadcrumb, PageHeaderProps } from "./page-header";
+export { PageHeader } from "./page-header";
 // Pagination
 export type { PaginationProps } from "./pagination";
 export { Pagination } from "./pagination";
@@ -87,6 +97,16 @@ export type {
 	SelectableCardThumbnailProps,
 } from "./selectable-card";
 export { SelectableCard } from "./selectable-card";
+// Sidebar (compound)
+export type {
+	SidebarItemProps,
+	SidebarLogoProps,
+	SidebarProps,
+	SidebarSectionProps as SidebarNavSectionProps,
+	SidebarUserMenuItemProps,
+	SidebarUserMenuProps,
+} from "./sidebar/sidebar";
+export { Sidebar } from "./sidebar/sidebar";
 // SidebarSection
 export type { SidebarSectionProps } from "./sidebar-section";
 export { SidebarSection } from "./sidebar-section";
@@ -139,6 +159,12 @@ export {
 	TimelineSeparator,
 	TimelineTitle,
 } from "./timeline";
+// Toolbar (compound)
+export type {
+	ToolbarFilterChipProps,
+	ToolbarSearchProps,
+} from "./toolbar";
+export { Toolbar } from "./toolbar";
 // TreeView
 export type {
 	TreeCollection,

--- a/src/components/page-header.stories.tsx
+++ b/src/components/page-header.stories.tsx
@@ -1,0 +1,59 @@
+// src/components/page-header.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Upload, UserPlus } from "lucide-react";
+import { Button } from "../atoms/button";
+import { PageHeader } from "./page-header";
+
+const meta = {
+	title: "Components/PageHeader",
+	component: PageHeader,
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
+		title: "Users",
+	},
+};
+
+export const WithSubtitle: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
+		title: "Users",
+		subtitle: "Manage workspace members and roles.",
+	},
+};
+
+export const WithActions: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
+		title: "Users",
+		actions: (
+			<>
+				<Button variant="outline" size="sm">
+					<Upload size={14} /> Import CSV
+				</Button>
+				<Button variant="solid" colorPalette="primary" size="sm">
+					<UserPlus size={14} /> Invite user
+				</Button>
+			</>
+		),
+	},
+};
+
+export const NoBreadcrumbs: Story = {
+	args: {
+		title: "Settings",
+	},
+};
+
+export const WithEyebrow: Story = {
+	args: {
+		eyebrow: "BETA",
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
+		title: "Users",
+	},
+};

--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -1,0 +1,79 @@
+// src/components/page-header.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageHeader } from "./page-header";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("PageHeader", () => {
+	it("renders the title", () => {
+		renderWithChakra(<PageHeader title="Users" />);
+		expect(screen.getByRole("heading", { name: "Users" })).toBeInTheDocument();
+	});
+
+	it("renders subtitle when provided", () => {
+		renderWithChakra(
+			<PageHeader title="Users" subtitle="Manage workspace members" />,
+		);
+		expect(screen.getByText("Manage workspace members")).toBeInTheDocument();
+	});
+
+	it("does not render subtitle when not provided", () => {
+		renderWithChakra(<PageHeader title="Users" />);
+		expect(
+			screen.queryByTestId("page-header-subtitle"),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders breadcrumbs as plain text when no `to`", () => {
+		renderWithChakra(
+			<PageHeader
+				breadcrumbs={[{ label: "Identity" }, { label: "Users" }]}
+				title="Users"
+			/>,
+		);
+		expect(screen.getByText("Identity")).toBeInTheDocument();
+		expect(screen.getAllByText("Users").length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("renders breadcrumb with `to` as a link", () => {
+		renderWithChakra(
+			<PageHeader
+				breadcrumbs={[
+					{ label: "Identity", to: "/identity" },
+					{ label: "Users" },
+				]}
+				title="Users"
+			/>,
+		);
+		expect(screen.getByRole("link", { name: "Identity" })).toHaveAttribute(
+			"href",
+			"/identity",
+		);
+	});
+
+	it("renders actions slot", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Users"
+				actions={<button type="button">Invite</button>}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Invite" })).toBeInTheDocument();
+	});
+
+	it("renders eyebrow when provided", () => {
+		renderWithChakra(<PageHeader eyebrow="BETA" title="Users" />);
+		expect(screen.getByText("BETA")).toBeInTheDocument();
+	});
+
+	it("does not render breadcrumbs container when breadcrumbs not provided", () => {
+		renderWithChakra(<PageHeader title="Users" />);
+		expect(
+			screen.queryByTestId("page-header-breadcrumbs"),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,122 @@
+// src/components/page-header.tsx
+import type React from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Heading, Link, Text } from "../primitives/typography";
+
+export interface PageHeaderBreadcrumb {
+	label: string;
+	to?: string;
+}
+
+export interface PageHeaderProps {
+	breadcrumbs?: PageHeaderBreadcrumb[];
+	title: React.ReactNode;
+	subtitle?: React.ReactNode;
+	actions?: React.ReactNode;
+	eyebrow?: React.ReactNode;
+}
+
+export const PageHeader = ({
+	breadcrumbs,
+	title,
+	subtitle,
+	actions,
+	eyebrow,
+}: PageHeaderProps) => {
+	const hasCrumbs = !!breadcrumbs && breadcrumbs.length > 0;
+	const hasActions = !!actions;
+
+	return (
+		<Box
+			py="4"
+			px="8"
+			borderBottomWidth="1px"
+			borderBottomColor="border"
+			bg="bg-surface"
+		>
+			{eyebrow && (
+				<Text
+					fontSize="2xs"
+					fontWeight="semibold"
+					letterSpacing="wider"
+					textTransform="uppercase"
+					color="muted"
+					mb="1"
+				>
+					{eyebrow}
+				</Text>
+			)}
+
+			{hasCrumbs && (
+				<Flex
+					data-testid="page-header-breadcrumbs"
+					align="center"
+					gap="1"
+					mb="1"
+					fontSize="xs"
+					color="muted"
+				>
+					{breadcrumbs.map((c, idx) => {
+						const isLast = idx === breadcrumbs.length - 1;
+						const sep = !isLast ? <span aria-hidden> › </span> : null;
+						const node = c.to ? (
+							<Link
+								key={`crumb-link-${c.label}`}
+								href={c.to}
+								color="muted"
+								_hover={{ color: "default" }}
+							>
+								{c.label}
+							</Link>
+						) : (
+							<Text
+								key={`crumb-text-${c.label}`}
+								as="span"
+								color={isLast ? "default" : "muted"}
+								fontWeight={isLast ? "medium" : "normal"}
+							>
+								{c.label}
+							</Text>
+						);
+						return (
+							<Flex key={`crumb-wrap-${c.label}`} align="center" gap="1">
+								{node}
+								{sep}
+							</Flex>
+						);
+					})}
+				</Flex>
+			)}
+
+			<Flex align="center" justify="space-between" gap="4">
+				<Box flex="1" minW="0">
+					<Heading
+						as="h1"
+						fontSize="2xl"
+						fontWeight="semibold"
+						color="default"
+						letterSpacing="-0.02em"
+					>
+						{title}
+					</Heading>
+					{subtitle && (
+						<Text
+							data-testid="page-header-subtitle"
+							fontSize="sm"
+							color="muted"
+							mt="1"
+						>
+							{subtitle}
+						</Text>
+					)}
+				</Box>
+				{hasActions && (
+					<Flex align="center" gap="2" flexShrink={0}>
+						{actions}
+					</Flex>
+				)}
+			</Flex>
+		</Box>
+	);
+};
+PageHeader.displayName = "PageHeader";

--- a/src/components/sidebar/sidebar.stories.tsx
+++ b/src/components/sidebar/sidebar.stories.tsx
@@ -1,0 +1,54 @@
+// src/components/sidebar/sidebar.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+	Building2,
+	ClipboardList,
+	KeyRound,
+	Users,
+	Webhook,
+} from "lucide-react";
+import { Sidebar } from "./sidebar";
+
+const meta = {
+	title: "Components/Sidebar",
+	component: Sidebar,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => (
+		<Sidebar>
+			<Sidebar.Header>
+				<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
+			</Sidebar.Header>
+			<Sidebar.Body>
+				<Sidebar.Section label="Identity">
+					<Sidebar.Item icon={<Users size={16} />} active>
+						Users
+					</Sidebar.Item>
+				</Sidebar.Section>
+				<Sidebar.Section label="Access">
+					<Sidebar.Item icon={<KeyRound size={16} />}>
+						OAuth Clients
+					</Sidebar.Item>
+					<Sidebar.Item icon={<Webhook size={16} />}>Webhooks</Sidebar.Item>
+				</Sidebar.Section>
+				<Sidebar.Section label="Organization">
+					<Sidebar.Item icon={<Building2 size={16} />}>Settings</Sidebar.Item>
+					<Sidebar.Item icon={<ClipboardList size={16} />}>
+						Audit Log
+					</Sidebar.Item>
+				</Sidebar.Section>
+			</Sidebar.Body>
+			<Sidebar.Footer>
+				<Sidebar.UserMenu user={{ name: "Jana Schmid", email: "jana@knk.de" }}>
+					<Sidebar.UserMenuItem>Personal Settings</Sidebar.UserMenuItem>
+					<Sidebar.UserMenuItem>Sign out</Sidebar.UserMenuItem>
+				</Sidebar.UserMenu>
+			</Sidebar.Footer>
+		</Sidebar>
+	),
+};

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -1,0 +1,197 @@
+// src/components/sidebar/sidebar.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Sidebar } from "./sidebar";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("Sidebar", () => {
+	it("renders the root with data-testid='sidebar'", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toBeInTheDocument();
+	});
+
+	it("renders Sidebar.Logo wordmark and subtitle", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Header>
+					<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
+				</Sidebar.Header>
+				<Sidebar.Body />
+			</Sidebar>,
+		);
+		expect(screen.getByText("Odon")).toBeInTheDocument();
+		expect(screen.getByText("Identity Provider")).toBeInTheDocument();
+	});
+
+	it("renders Sidebar.Logo without subtitle when omitted", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Header>
+					<Sidebar.Logo wordmark="Odon" />
+				</Sidebar.Header>
+				<Sidebar.Body />
+			</Sidebar>,
+		);
+		expect(screen.getByText("Odon")).toBeInTheDocument();
+		expect(screen.queryByText("Identity Provider")).not.toBeInTheDocument();
+	});
+
+	it("renders Sidebar.Slot children", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Header>
+					<Sidebar.Slot>
+						<span data-testid="slot-content">switcher</span>
+					</Sidebar.Slot>
+				</Sidebar.Header>
+				<Sidebar.Body />
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("slot-content")).toBeInTheDocument();
+	});
+
+	it("renders Sidebar.Section label and children", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<span data-testid="item">A</span>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByText("Identity")).toBeInTheDocument();
+		expect(screen.getByTestId("item")).toBeInTheDocument();
+	});
+
+	it("renders Sidebar.Item with icon and children", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item icon={<span data-testid="icon">i</span>}>
+							Users
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("icon")).toBeInTheDocument();
+		expect(screen.getByText("Users")).toBeInTheDocument();
+	});
+
+	it("Sidebar.Item with asChild forwards to its child element", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item asChild icon={<span>i</span>}>
+							<a href="/users" data-testid="link">
+								Users
+							</a>
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		const link = screen.getByTestId("link");
+		expect(link).toBeInTheDocument();
+		expect(link.getAttribute("href")).toBe("/users");
+	});
+
+	it("Sidebar.Item active=true exposes data-active attribute", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item active icon={<span>i</span>}>
+							Users
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar-item")).toHaveAttribute(
+			"data-active",
+			"true",
+		);
+	});
+
+	it("Sidebar.Item without active prop has no data-active='true' attribute", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item icon={<span>i</span>}>Users</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		const item = screen.getByTestId("sidebar-item");
+		expect(item.getAttribute("data-active")).not.toBe("true");
+	});
+
+	it("renders Sidebar.UserMenu with user name and email", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body />
+				<Sidebar.Footer>
+					<Sidebar.UserMenu
+						user={{ name: "Jana Schmid", email: "jana@knk.de" }}
+					>
+						<Sidebar.UserMenuItem>Sign out</Sidebar.UserMenuItem>
+					</Sidebar.UserMenu>
+				</Sidebar.Footer>
+			</Sidebar>,
+		);
+		expect(screen.getByText("Jana Schmid")).toBeInTheDocument();
+		expect(screen.getByText("jana@knk.de")).toBeInTheDocument();
+	});
+
+	it("opens the user menu on click and renders Sidebar.UserMenuItem children", async () => {
+		const user = userEvent.setup();
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body />
+				<Sidebar.Footer>
+					<Sidebar.UserMenu user={{ name: "Jana", email: "jana@knk.de" }}>
+						<Sidebar.UserMenuItem>Personal Settings</Sidebar.UserMenuItem>
+						<Sidebar.UserMenuItem>Sign out</Sidebar.UserMenuItem>
+					</Sidebar.UserMenu>
+				</Sidebar.Footer>
+			</Sidebar>,
+		);
+		await user.click(screen.getByTestId("sidebar-user-menu-trigger"));
+		expect(await screen.findByText("Personal Settings")).toBeInTheDocument();
+		expect(screen.getByText("Sign out")).toBeInTheDocument();
+	});
+
+	it("Sidebar.UserMenuItem onClick fires", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body />
+				<Sidebar.Footer>
+					<Sidebar.UserMenu user={{ name: "Jana", email: "jana@knk.de" }}>
+						<Sidebar.UserMenuItem onClick={onClick}>
+							Sign out
+						</Sidebar.UserMenuItem>
+					</Sidebar.UserMenu>
+				</Sidebar.Footer>
+			</Sidebar>,
+		);
+		await user.click(screen.getByTestId("sidebar-user-menu-trigger"));
+		await user.click(await screen.findByText("Sign out"));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+});

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -1,7 +1,6 @@
 // src/components/sidebar/sidebar.test.tsx
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./sidebar";
 
@@ -158,7 +157,6 @@ describe("Sidebar", () => {
 	});
 
 	it("opens the user menu on click and renders Sidebar.UserMenuItem children", async () => {
-		const user = userEvent.setup();
 		renderWithChakra(
 			<Sidebar>
 				<Sidebar.Body />
@@ -170,14 +168,13 @@ describe("Sidebar", () => {
 				</Sidebar.Footer>
 			</Sidebar>,
 		);
-		await user.click(screen.getByTestId("sidebar-user-menu-trigger"));
+		fireEvent.click(screen.getByTestId("sidebar-user-menu-trigger"));
 		expect(await screen.findByText("Personal Settings")).toBeInTheDocument();
 		expect(screen.getByText("Sign out")).toBeInTheDocument();
 	});
 
 	it("Sidebar.UserMenuItem onClick fires", async () => {
 		const onClick = vi.fn();
-		const user = userEvent.setup();
 		renderWithChakra(
 			<Sidebar>
 				<Sidebar.Body />
@@ -190,8 +187,8 @@ describe("Sidebar", () => {
 				</Sidebar.Footer>
 			</Sidebar>,
 		);
-		await user.click(screen.getByTestId("sidebar-user-menu-trigger"));
-		await user.click(await screen.findByText("Sign out"));
+		fireEvent.click(screen.getByTestId("sidebar-user-menu-trigger"));
+		fireEvent.click(await screen.findByText("Sign out"));
 		expect(onClick).toHaveBeenCalledOnce();
 	});
 });

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,304 @@
+// src/components/sidebar/sidebar.tsx
+import React, { useRef, useState } from "react";
+import { Button } from "../../atoms/button";
+import { Box, Flex } from "../../primitives/layout";
+import { Heading, Text } from "../../primitives/typography";
+
+// Root
+export interface SidebarProps {
+	children: React.ReactNode;
+}
+
+const SidebarRoot = ({ children }: SidebarProps) => (
+	<Flex
+		data-testid="sidebar"
+		direction="column"
+		w="240px"
+		minH="100vh"
+		bg="bg-canvas"
+		borderRightWidth="1px"
+		borderRightColor="border"
+	>
+		{children}
+	</Flex>
+);
+SidebarRoot.displayName = "Sidebar";
+
+// Header / Body / Footer
+const SidebarHeader = ({ children }: { children: React.ReactNode }) => (
+	<Box p="4" borderBottomWidth="1px" borderBottomColor="border-muted">
+		{children}
+	</Box>
+);
+SidebarHeader.displayName = "Sidebar.Header";
+
+const SidebarBody = ({ children }: { children?: React.ReactNode }) => (
+	<Box flex="1" overflowY="auto" py="3">
+		{children}
+	</Box>
+);
+SidebarBody.displayName = "Sidebar.Body";
+
+const SidebarFooter = ({ children }: { children: React.ReactNode }) => (
+	<Box p="3" borderTopWidth="1px" borderTopColor="border-muted">
+		{children}
+	</Box>
+);
+SidebarFooter.displayName = "Sidebar.Footer";
+
+// Logo
+export interface SidebarLogoProps {
+	wordmark: string;
+	subtitle?: string;
+}
+
+const SidebarLogo = ({ wordmark, subtitle }: SidebarLogoProps) => (
+	<Box mb={subtitle ? "3" : "0"}>
+		<Heading
+			as="span"
+			fontSize="lg"
+			fontWeight="bold"
+			color="primary.700"
+			letterSpacing="tight"
+		>
+			{wordmark}
+		</Heading>
+		{subtitle && (
+			<Text
+				fontSize="2xs"
+				fontWeight="semibold"
+				letterSpacing="wider"
+				textTransform="uppercase"
+				color="muted"
+				mt="0.5"
+			>
+				{subtitle}
+			</Text>
+		)}
+	</Box>
+);
+SidebarLogo.displayName = "Sidebar.Logo";
+
+// Slot
+const SidebarSlot = ({ children }: { children: React.ReactNode }) => (
+	<Box mt="3">{children}</Box>
+);
+SidebarSlot.displayName = "Sidebar.Slot";
+
+// Section — nav group
+export interface SidebarSectionProps {
+	label: string;
+	children: React.ReactNode;
+}
+
+const SidebarSection = ({ label, children }: SidebarSectionProps) => (
+	<Box mb="4" px="3">
+		<Text
+			fontSize="2xs"
+			fontWeight="semibold"
+			letterSpacing="wider"
+			textTransform="uppercase"
+			color="muted"
+			px="2"
+			mb="1"
+		>
+			{label}
+		</Text>
+		<Flex direction="column" gap="0.5">
+			{children}
+		</Flex>
+	</Box>
+);
+SidebarSection.displayName = "Sidebar.Section";
+
+// Item — nav link with active state
+export interface SidebarItemProps {
+	icon?: React.ReactNode;
+	children: React.ReactNode;
+	asChild?: boolean;
+	active?: boolean;
+}
+
+const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
+	const dataProps = {
+		"data-testid": "sidebar-item",
+		"data-active": active ? "true" : "false",
+	};
+
+	const styleProps = {
+		display: "flex" as const,
+		alignItems: "center",
+		gap: "2",
+		px: "3",
+		py: "2",
+		borderRadius: "md",
+		fontSize: "sm",
+		fontWeight: "medium",
+		color: active ? "primary.700" : "default",
+		bg: active ? "primary.50" : "transparent",
+		position: "relative" as const,
+		textDecoration: "none",
+	};
+
+	const iconEl = icon ? (
+		<Box display="inline-flex" alignItems="center">
+			{icon}
+		</Box>
+	) : null;
+
+	if (asChild) {
+		// Clone the single child, merging our style props onto it.
+		// We do NOT override data-testid — the child's own props win.
+		// We set data-active from our side.
+		const child = React.Children.only(children) as React.ReactElement<
+			React.HTMLAttributes<HTMLElement> & {
+				href?: string;
+				"data-testid"?: string;
+				"data-active"?: string;
+			}
+		>;
+		return React.cloneElement(child, {
+			"data-active": active ? "true" : "false",
+			style: {
+				...styleProps,
+				...(child.props.style as React.CSSProperties | undefined),
+			},
+		});
+	}
+
+	return (
+		<Box {...dataProps} {...styleProps}>
+			{iconEl}
+			{children}
+		</Box>
+	);
+};
+SidebarItem.displayName = "Sidebar.Item";
+
+// UserMenu — simple state-based dropdown (avoids Zag/Ark state machine incompatibility in jsdom)
+export interface SidebarUserMenuProps {
+	user: { name?: string; email?: string };
+	children: React.ReactNode;
+}
+
+const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
+	const [open, setOpen] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const initials = (user.name ?? user.email ?? "")
+		.split(/\s+/)
+		.slice(0, 2)
+		.map((s) => s[0]?.toUpperCase() ?? "")
+		.join("");
+
+	return (
+		<Box position="relative" ref={containerRef}>
+			<Button
+				data-testid="sidebar-user-menu-trigger"
+				variant="ghost"
+				size="md"
+				w="full"
+				justifyContent="flex-start"
+				px="2"
+				onClick={() => setOpen((v) => !v)}
+				aria-haspopup="menu"
+				aria-expanded={open}
+			>
+				<Flex align="center" gap="2" w="full">
+					<Flex
+						align="center"
+						justify="center"
+						w="32px"
+						h="32px"
+						borderRadius="full"
+						bg="primary.700"
+						color="white"
+						fontSize="xs"
+						fontWeight="semibold"
+						flexShrink={0}
+					>
+						{initials || "?"}
+					</Flex>
+					<Box textAlign="start" flex="1" minW="0">
+						<Text
+							fontSize="sm"
+							fontWeight="medium"
+							color="default"
+							lineClamp={1}
+						>
+							{user.name ?? user.email}
+						</Text>
+						{user.email && user.name && (
+							<Text fontSize="xs" color="muted" lineClamp={1}>
+								{user.email}
+							</Text>
+						)}
+					</Box>
+				</Flex>
+			</Button>
+			{open && (
+				<Box
+					role="menu"
+					position="absolute"
+					bottom="100%"
+					left="0"
+					right="0"
+					bg="bg-surface"
+					borderWidth="1px"
+					borderColor="border"
+					borderRadius="md"
+					shadow="md"
+					py="1"
+					zIndex="dropdown"
+				>
+					{children}
+				</Box>
+			)}
+		</Box>
+	);
+};
+SidebarUserMenu.displayName = "Sidebar.UserMenu";
+
+// UserMenuItem
+export interface SidebarUserMenuItemProps {
+	asChild?: boolean;
+	onClick?: () => void;
+	children: React.ReactNode;
+}
+
+const SidebarUserMenuItem = ({
+	asChild: _asChild,
+	onClick,
+	children,
+}: SidebarUserMenuItemProps) => {
+	return (
+		<Button
+			role="menuitem"
+			variant="ghost"
+			w="full"
+			justifyContent="flex-start"
+			px="3"
+			py="2"
+			fontSize="sm"
+			fontWeight="normal"
+			borderRadius="0"
+			onClick={onClick}
+		>
+			{children}
+		</Button>
+	);
+};
+SidebarUserMenuItem.displayName = "Sidebar.UserMenuItem";
+
+// Compose
+export const Sidebar = Object.assign(SidebarRoot, {
+	Header: SidebarHeader,
+	Body: SidebarBody,
+	Footer: SidebarFooter,
+	Logo: SidebarLogo,
+	Slot: SidebarSlot,
+	Section: SidebarSection,
+	Item: SidebarItem,
+	UserMenu: SidebarUserMenu,
+	UserMenuItem: SidebarUserMenuItem,
+});

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,7 +1,13 @@
 // src/components/sidebar/sidebar.tsx
-import React, { useRef, useState } from "react";
+import React from "react";
 import { Button } from "../../atoms/button";
 import { Box, Flex } from "../../primitives/layout";
+import {
+	MenuContent,
+	MenuItem,
+	MenuRoot,
+	MenuTrigger,
+} from "../../primitives/menu";
 import { Heading, Text } from "../../primitives/typography";
 
 // Root
@@ -175,16 +181,13 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 };
 SidebarItem.displayName = "Sidebar.Item";
 
-// UserMenu — simple state-based dropdown (avoids Zag/Ark state machine incompatibility in jsdom)
+// UserMenu
 export interface SidebarUserMenuProps {
 	user: { name?: string; email?: string };
 	children: React.ReactNode;
 }
 
 const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
-	const [open, setOpen] = useState(false);
-	const containerRef = useRef<HTMLDivElement>(null);
-
 	const initials = (user.name ?? user.email ?? "")
 		.split(/\s+/)
 		.slice(0, 2)
@@ -192,69 +195,51 @@ const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
 		.join("");
 
 	return (
-		<Box position="relative" ref={containerRef}>
-			<Button
-				data-testid="sidebar-user-menu-trigger"
-				variant="ghost"
-				size="md"
-				w="full"
-				justifyContent="flex-start"
-				px="2"
-				onClick={() => setOpen((v) => !v)}
-				aria-haspopup="menu"
-				aria-expanded={open}
-			>
-				<Flex align="center" gap="2" w="full">
-					<Flex
-						align="center"
-						justify="center"
-						w="32px"
-						h="32px"
-						borderRadius="full"
-						bg="primary.700"
-						color="white"
-						fontSize="xs"
-						fontWeight="semibold"
-						flexShrink={0}
-					>
-						{initials || "?"}
-					</Flex>
-					<Box textAlign="start" flex="1" minW="0">
-						<Text
-							fontSize="sm"
-							fontWeight="medium"
-							color="default"
-							lineClamp={1}
-						>
-							{user.name ?? user.email}
-						</Text>
-						{user.email && user.name && (
-							<Text fontSize="xs" color="muted" lineClamp={1}>
-								{user.email}
-							</Text>
-						)}
-					</Box>
-				</Flex>
-			</Button>
-			{open && (
-				<Box
-					role="menu"
-					position="absolute"
-					bottom="100%"
-					left="0"
-					right="0"
-					bg="bg-surface"
-					borderWidth="1px"
-					borderColor="border"
-					borderRadius="md"
-					shadow="md"
-					py="1"
-					zIndex="dropdown"
+		<MenuRoot>
+			<MenuTrigger asChild>
+				<Button
+					data-testid="sidebar-user-menu-trigger"
+					variant="ghost"
+					size="md"
+					w="full"
+					justifyContent="flex-start"
+					px="2"
 				>
-					{children}
-				</Box>
-			)}
-		</Box>
+					<Flex align="center" gap="2" w="full">
+						<Flex
+							align="center"
+							justify="center"
+							w="32px"
+							h="32px"
+							borderRadius="full"
+							bg="primary.700"
+							color="white"
+							fontSize="xs"
+							fontWeight="semibold"
+							flexShrink={0}
+						>
+							{initials || "?"}
+						</Flex>
+						<Box textAlign="start" flex="1" minW="0">
+							<Text
+								fontSize="sm"
+								fontWeight="medium"
+								color="default"
+								lineClamp={1}
+							>
+								{user.name ?? user.email}
+							</Text>
+							{user.email && user.name && (
+								<Text fontSize="xs" color="muted" lineClamp={1}>
+									{user.email}
+								</Text>
+							)}
+						</Box>
+					</Flex>
+				</Button>
+			</MenuTrigger>
+			<MenuContent portalled={false}>{children}</MenuContent>
+		</MenuRoot>
 	);
 };
 SidebarUserMenu.displayName = "Sidebar.UserMenu";
@@ -267,25 +252,25 @@ export interface SidebarUserMenuItemProps {
 }
 
 const SidebarUserMenuItem = ({
-	asChild: _asChild,
+	asChild,
 	onClick,
 	children,
 }: SidebarUserMenuItemProps) => {
+	if (asChild) {
+		const child = React.Children.only(children) as React.ReactElement;
+		return (
+			<MenuItem value="link" onClick={onClick}>
+				{React.cloneElement(child, {})}
+			</MenuItem>
+		);
+	}
 	return (
-		<Button
-			role="menuitem"
-			variant="ghost"
-			w="full"
-			justifyContent="flex-start"
-			px="3"
-			py="2"
-			fontSize="sm"
-			fontWeight="normal"
-			borderRadius="0"
+		<MenuItem
+			value={typeof children === "string" ? children : "item"}
 			onClick={onClick}
 		>
 			{children}
-		</Button>
+		</MenuItem>
 	);
 };
 SidebarUserMenuItem.displayName = "Sidebar.UserMenuItem";

--- a/src/components/toolbar.stories.tsx
+++ b/src/components/toolbar.stories.tsx
@@ -1,0 +1,50 @@
+// src/components/toolbar.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { KeyRound, ShieldCheck, UserCircle } from "lucide-react";
+import { useState } from "react";
+import { Toolbar } from "./toolbar";
+
+const meta = {
+	title: "Components/Toolbar",
+	component: Toolbar,
+} satisfies Meta<typeof Toolbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => {
+		const [q, setQ] = useState("");
+		const [role, setRole] = useState(false);
+		return (
+			<Toolbar>
+				<Toolbar.Search
+					placeholder="Search by name or email…"
+					value={q}
+					onChange={setQ}
+				/>
+				<Toolbar.Filters>
+					<Toolbar.FilterChip
+						icon={<UserCircle size={14} />}
+						active={role}
+						onClick={() => setRole((v) => !v)}
+					>
+						Role
+					</Toolbar.FilterChip>
+					<Toolbar.FilterChip icon={<KeyRound size={14} />} onClick={() => {}}>
+						Application
+					</Toolbar.FilterChip>
+					<Toolbar.FilterChip
+						icon={<ShieldCheck size={14} />}
+						onClick={() => {}}
+					>
+						2FA
+					</Toolbar.FilterChip>
+				</Toolbar.Filters>
+				<Toolbar.Right>
+					<Toolbar.Count>7 of 12</Toolbar.Count>
+				</Toolbar.Right>
+			</Toolbar>
+		);
+	},
+};

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -1,0 +1,102 @@
+// src/components/toolbar.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Toolbar } from "./toolbar";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("Toolbar", () => {
+	it("renders the root with data-testid='toolbar'", () => {
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Right>right</Toolbar.Right>
+			</Toolbar>,
+		);
+		expect(screen.getByTestId("toolbar")).toBeInTheDocument();
+	});
+
+	it("Toolbar.Search renders with placeholder and value", () => {
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Search placeholder="Find" value="abc" onChange={() => {}} />
+			</Toolbar>,
+		);
+		const input = screen.getByPlaceholderText("Find") as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+		expect(input.value).toBe("abc");
+	});
+
+	it("Toolbar.Search calls onChange with new value", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Search placeholder="Find" value="" onChange={onChange} />
+			</Toolbar>,
+		);
+		await user.type(screen.getByPlaceholderText("Find"), "z");
+		expect(onChange).toHaveBeenCalledWith("z");
+	});
+
+	it("Toolbar.FilterChip renders icon and children", () => {
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Filters>
+					<Toolbar.FilterChip
+						icon={<span data-testid="chip-icon">i</span>}
+						onClick={() => {}}
+					>
+						Role
+					</Toolbar.FilterChip>
+				</Toolbar.Filters>
+			</Toolbar>,
+		);
+		expect(screen.getByTestId("chip-icon")).toBeInTheDocument();
+		expect(screen.getByText("Role")).toBeInTheDocument();
+	});
+
+	it("Toolbar.FilterChip onClick fires", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Filters>
+					<Toolbar.FilterChip onClick={onClick}>Role</Toolbar.FilterChip>
+				</Toolbar.Filters>
+			</Toolbar>,
+		);
+		await user.click(screen.getByText("Role"));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("Toolbar.FilterChip active=true exposes data-active='true'", () => {
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Filters>
+					<Toolbar.FilterChip active onClick={() => {}}>
+						Role
+					</Toolbar.FilterChip>
+				</Toolbar.Filters>
+			</Toolbar>,
+		);
+		expect(screen.getByTestId("filter-chip")).toHaveAttribute(
+			"data-active",
+			"true",
+		);
+	});
+
+	it("Toolbar.Count renders text content", () => {
+		renderWithChakra(
+			<Toolbar>
+				<Toolbar.Right>
+					<Toolbar.Count>5 of 12</Toolbar.Count>
+				</Toolbar.Right>
+			</Toolbar>,
+		);
+		expect(screen.getByText("5 of 12")).toBeInTheDocument();
+	});
+});

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,0 +1,138 @@
+// src/components/toolbar.tsx
+import { Search } from "lucide-react";
+import type React from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Text } from "../primitives/typography";
+
+// Root
+const ToolbarRoot = ({ children }: { children: React.ReactNode }) => (
+	<Flex
+		data-testid="toolbar"
+		align="center"
+		gap="4"
+		px="4"
+		h="48px"
+		bg="bg-subtle"
+		borderBottomWidth="1px"
+		borderBottomColor="border"
+	>
+		{children}
+	</Flex>
+);
+ToolbarRoot.displayName = "Toolbar";
+
+// Search
+export interface ToolbarSearchProps {
+	placeholder?: string;
+	value: string;
+	onChange: (next: string) => void;
+}
+
+const ToolbarSearch = ({
+	placeholder,
+	value,
+	onChange,
+}: ToolbarSearchProps) => (
+	<Flex align="center" gap="2" w="260px" position="relative">
+		<Box position="absolute" left="2" color="muted" pointerEvents="none">
+			<Search size={14} />
+		</Box>
+		<input
+			type="text"
+			placeholder={placeholder}
+			value={value}
+			onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+				onChange(e.target.value)
+			}
+			style={{
+				height: "32px",
+				paddingLeft: "2rem",
+				paddingRight: "0.5rem",
+				width: "100%",
+				borderWidth: "1px",
+				borderStyle: "solid",
+				borderRadius: "var(--chakra-radii-md)",
+				fontSize: "var(--chakra-font-sizes-sm)",
+				background: "var(--chakra-colors-bg-surface, white)",
+				outline: "none",
+			}}
+		/>
+	</Flex>
+);
+ToolbarSearch.displayName = "Toolbar.Search";
+
+// Filters
+const ToolbarFilters = ({ children }: { children: React.ReactNode }) => (
+	<Flex align="center" gap="2">
+		{children}
+	</Flex>
+);
+ToolbarFilters.displayName = "Toolbar.Filters";
+
+// FilterChip
+export interface ToolbarFilterChipProps {
+	icon?: React.ReactNode;
+	active?: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}
+
+const ToolbarFilterChip = ({
+	icon,
+	active,
+	onClick,
+	children,
+}: ToolbarFilterChipProps) => (
+	<button
+		type="button"
+		data-testid="filter-chip"
+		data-active={active ? "true" : "false"}
+		onClick={onClick}
+		style={{
+			display: "inline-flex",
+			alignItems: "center",
+			gap: "4px",
+			padding: "0 10px",
+			height: "28px",
+			fontSize: "var(--chakra-font-sizes-xs)",
+			fontWeight: "var(--chakra-font-weights-medium)",
+			borderWidth: "1px",
+			borderStyle: "solid",
+			borderRadius: "var(--chakra-radii-md)",
+			cursor: "pointer",
+		}}
+	>
+		{icon && (
+			<Box display="inline-flex" alignItems="center">
+				{icon}
+			</Box>
+		)}
+		{children}
+	</button>
+);
+ToolbarFilterChip.displayName = "Toolbar.FilterChip";
+
+// Right slot
+const ToolbarRight = ({ children }: { children: React.ReactNode }) => (
+	<Flex align="center" gap="2" ml="auto">
+		{children}
+	</Flex>
+);
+ToolbarRight.displayName = "Toolbar.Right";
+
+// Count
+const ToolbarCount = ({ children }: { children: React.ReactNode }) => (
+	<Text fontSize="xs" color="muted">
+		{children}
+	</Text>
+);
+ToolbarCount.displayName = "Toolbar.Count";
+
+// Compose
+export const Toolbar = Object.assign(ToolbarRoot, {
+	Search: ToolbarSearch,
+	Filters: ToolbarFilters,
+	FilterChip: ToolbarFilterChip,
+	Right: ToolbarRight,
+	Count: ToolbarCount,
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,3 +9,34 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 		disconnect() {}
 	};
 }
+
+// Node 25 exposes a built-in localStorage that requires --localstorage-file to
+// work properly, but its API surface differs from the Web Storage spec (e.g.
+// no .clear()). Swap in a simple in-memory Map-based implementation so tests
+// can call getItem/setItem/removeItem/clear without hitting the Node runtime.
+const _storage = new Map<string, string>();
+const localStorageMock: Storage = {
+	get length() {
+		return _storage.size;
+	},
+	key(index: number) {
+		return Array.from(_storage.keys())[index] ?? null;
+	},
+	getItem(key: string) {
+		return _storage.get(key) ?? null;
+	},
+	setItem(key: string, value: string) {
+		_storage.set(key, String(value));
+	},
+	removeItem(key: string) {
+		_storage.delete(key);
+	},
+	clear() {
+		_storage.clear();
+	},
+};
+Object.defineProperty(globalThis, "localStorage", {
+	value: localStorageMock,
+	writable: true,
+	configurable: true,
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement ResizeObserver; mock it to prevent unhandled errors
+// from Zag's floating-ui popper positioning code in tests.
+if (typeof globalThis.ResizeObserver === "undefined") {
+	globalThis.ResizeObserver = class ResizeObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	};
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost/",
+      },
+    },
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
     css: false,


### PR DESCRIPTION
## Summary

Adds four new layout primitives for the app shell pattern. All additive — no breaking changes since 1.1.0.

- **`<Sidebar>`** — compound primitive (240px). Subcomponents: \`Header\`, \`Logo\`, \`Slot\`, \`Body\`, \`Section\`, \`Item\` (with \`asChild\` and \`active\`), \`Footer\`, \`UserMenu\`, \`UserMenuItem\`. Cross-product nav surface; consumers slot their own logo, org-switcher, language switcher, etc. Note: the existing top-level \`<SidebarSection>\` (collapsible labeled section used in CMS detail rails) is unchanged and still exported.
- **\`<PageHeader>\`** — per-page imperative header with breadcrumbs, title, optional subtitle, optional eyebrow, and an actions slot.
- **\`<Toolbar>\`** — compound primitive for list-page toolbars. Subcomponents: \`Search\`, \`Filters\`, \`FilterChip\` (with \`active\`), \`Right\`, \`Count\`. Pages compose what they need; bulk-action mode reuses the existing \`<BulkActionBar>\` (no changes).
- **\`<ContextRail>\`** — collapsible right-rail chrome (44 ↔ 360px) with viewport-aware default and \`localStorage\` persistence via \`storageKey\`. Subcomponents \`Header\`, \`Section\`, \`Footer\` exported for consumer use.

Bumps to **1.2.0** (additive minor).

## Context

Sub-project #3 of the larger UI redesign in [odon](https://github.com/knkcs/odon). The full spec is at \`odon:docs/superpowers/specs/2026-04-30-ui-redesign-app-shell-design.md\`. Sub-projects #4 (admin index template), #5 (detail/rail content), and #6 (settings) build on these primitives.

## Test plan

- [x] 36 new unit tests across the four primitives — all pass (full suite 58/58)
- [x] Storybook stories for each primitive (Sidebar, PageHeader [5 stories], Toolbar, ContextRail [Default + CollapsedByDefault])
- [x] \`npm run build\` clean (tsup ESM + DTS)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean for new files (pre-existing warnings unrelated)
- [x] All four primitives + their prop types exported from \`dist/components/index.d.ts\`
- [ ] Visual check in Storybook (\`npm run dev\` → Components / Sidebar, PageHeader, Toolbar, ContextRail) — please verify before merge

## Test setup tweaks (additive)

- \`src/test/setup.ts\` now mocks \`ResizeObserver\` (Chakra v3 / Zag.js menu code calls it under jsdom) and provides an in-memory \`localStorage\` implementation (Node 25's built-in needs a flag to work; the mock makes the test env consistent).
- \`vitest.config.ts\` adds \`environmentOptions.jsdom.url\` so \`window.location\` is defined in test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)