### PR TITLE
fix: resolve semantic-token CSS vars and inject Sidebar.Item icon under asChild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.0] — 2026-05-01
+
+### Fixed
+
+- **Semantic color tokens now resolve to CSS variables.** Every top-level token (`bg-canvas`, `bg-surface`, `bg-subtle`, `bg-muted`, `default`, `inverted`, `emphasized`, `muted`, `subtle`, `border`, `accent`, `success`, `error`, `bg-accent*`, `on-accent*`) was declared with bare scale strings like `"gray.50"`. Chakra v3 stored those verbatim into the emitted CSS variable, so `--chakra-colors-bg-canvas` evaluated to the literal text `gray.50` — invalid CSS. Consumer styles fell back to `transparent` (for `bg`) and `currentColor` (for `border`), making sidebars look white and borders look near-black. References are now wrapped as `{colors.gray.50}` so Chakra emits proper `var(--chakra-colors-gray-50)` references. Visual regression test added.
+- **`Sidebar.Item` now renders the `icon` prop when used with `asChild`.** The previous implementation computed `iconEl` but did not pass it as a child to `React.cloneElement`, so every `<Sidebar.Item asChild>` link rendered without its icon. Fixed by injecting `iconEl` as the first child while preserving the original child content. Test added.
+
+### Added
+
+- `border-muted` semantic token (`gray.100` / `gray.800`) — referenced by `Sidebar.Header` / `Sidebar.Footer` separators since 1.2.0 but never defined; previously fell back to `currentColor` (near-black).
+
 ## [1.2.0] — 2026-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -107,6 +107,26 @@ describe("Sidebar", () => {
 		expect(link.getAttribute("href")).toBe("/users");
 	});
 
+	it("Sidebar.Item asChild renders the icon inside the cloned element", () => {
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item asChild icon={<span data-testid="nav-icon">i</span>}>
+							<a href="/users" data-testid="link">
+								Users
+							</a>
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		const link = screen.getByTestId("link");
+		const icon = screen.getByTestId("nav-icon");
+		expect(link).toContainElement(icon);
+		expect(link.textContent).toContain("Users");
+	});
+
 	it("Sidebar.Item active=true exposes data-active attribute", () => {
 		renderWithChakra(
 			<Sidebar>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -153,23 +153,28 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 	) : null;
 
 	if (asChild) {
-		// Clone the single child, merging our style props onto it.
-		// We do NOT override data-testid — the child's own props win.
-		// We set data-active from our side.
+		// Clone the single child, merging our style props and prepending the
+		// icon as the first rendered child while keeping the original content.
 		const child = React.Children.only(children) as React.ReactElement<
 			React.HTMLAttributes<HTMLElement> & {
 				href?: string;
 				"data-testid"?: string;
 				"data-active"?: string;
+				children?: React.ReactNode;
 			}
 		>;
-		return React.cloneElement(child, {
-			"data-active": active ? "true" : "false",
-			style: {
-				...styleProps,
-				...(child.props.style as React.CSSProperties | undefined),
+		return React.cloneElement(
+			child,
+			{
+				"data-active": active ? "true" : "false",
+				style: {
+					...styleProps,
+					...(child.props.style as React.CSSProperties | undefined),
+				},
 			},
-		});
+			iconEl,
+			child.props.children,
+		);
 	}
 
 	return (

--- a/src/theme/tokens/semantic.test.ts
+++ b/src/theme/tokens/semantic.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import system from "../index";
+
+/**
+ * Regression test for the bare-string token bug.
+ *
+ * Pre-1.3, semantic tokens were declared as `{ value: { base: "gray.50" } }`.
+ * Chakra v3 stored the literal `"gray.50"` into the emitted CSS variable —
+ * `--chakra-colors-bg-canvas: gray.50` — which is invalid CSS, so consumers
+ * fell back to `transparent` (for bg) and `currentColor` (for borders).
+ *
+ * Wrapping the reference in `{colors.X}` makes Chakra resolve the path and
+ * emit a `var(--chakra-colors-X)` reference. We assert the tokenMap value
+ * for each top-level semantic token starts with `var(` so the bug can't
+ * regress silently.
+ */
+
+const SEMANTIC_TOKENS = [
+	"bg-canvas",
+	"bg-surface",
+	"bg-subtle",
+	"bg-muted",
+	"default",
+	"inverted",
+	"emphasized",
+	"muted",
+	"subtle",
+	"border",
+	"border-muted",
+	"accent",
+	"success",
+	"error",
+	"bg-accent",
+	"bg-accent-subtle",
+	"bg-accent-muted",
+];
+
+describe("semantic tokens", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: probing Chakra v3 internals
+	const tm = (system as any).tokens.tokenMap as Map<string, { value: string }>;
+
+	for (const name of SEMANTIC_TOKENS) {
+		it(`colors.${name} resolves to a var() reference (not a bare scale string)`, () => {
+			const entry = tm.get(`colors.${name}`);
+			expect(entry, `colors.${name} should be registered`).toBeDefined();
+			// A correctly-braced reference resolves to `var(--chakra-colors-X)`.
+			// A bare string like "gray.50" remains the literal "gray.50" — invalid CSS.
+			expect(entry?.value, `colors.${name} resolves to a CSS var`).toMatch(
+				/^var\(/,
+			);
+		});
+	}
+});

--- a/src/theme/tokens/semantic.ts
+++ b/src/theme/tokens/semantic.ts
@@ -4,50 +4,54 @@
  * These map abstract names (bg-canvas, accent, border, etc.) to raw color
  * scale values, with automatic light/dark mode variants.
  *
- * Shadows are consolidated here from the legacy `foundations/shadows.ts`
- * (static strings) and `foundations/tokens.ts` (responsive token objects).
- * Only the token-based system is kept.
+ * Cross-token references must use {colors.X} brace syntax so Chakra v3
+ * emits them as `var(--chakra-colors-X)` references. Bare strings like
+ * `"gray.50"` are stored verbatim into the CSS custom property and yield
+ * invalid CSS at runtime.
  */
 const semanticTokens = {
 	colors: {
 		"bg-canvas": {
-			value: { base: "gray.50", _dark: "gray.900" },
+			value: { base: "{colors.gray.50}", _dark: "{colors.gray.900}" },
 		},
 		"bg-surface": {
-			value: { base: "white", _dark: "gray.800" },
+			value: { base: "{colors.white}", _dark: "{colors.gray.800}" },
 		},
 		"bg-subtle": {
-			value: { base: "gray.50", _dark: "gray.700" },
+			value: { base: "{colors.gray.50}", _dark: "{colors.gray.700}" },
 		},
 		"bg-muted": {
-			value: { base: "gray.100", _dark: "gray.600" },
+			value: { base: "{colors.gray.100}", _dark: "{colors.gray.600}" },
 		},
 		default: {
-			value: { base: "gray.900", _dark: "white" },
+			value: { base: "{colors.gray.900}", _dark: "{colors.white}" },
 		},
 		inverted: {
-			value: { base: "white", _dark: "gray.900" },
+			value: { base: "{colors.white}", _dark: "{colors.gray.900}" },
 		},
 		emphasized: {
-			value: { base: "gray.700", _dark: "gray.100" },
+			value: { base: "{colors.gray.700}", _dark: "{colors.gray.100}" },
 		},
 		muted: {
-			value: { base: "gray.600", _dark: "gray.300" },
+			value: { base: "{colors.gray.600}", _dark: "{colors.gray.300}" },
 		},
 		subtle: {
-			value: { base: "gray.500", _dark: "gray.400" },
+			value: { base: "{colors.gray.500}", _dark: "{colors.gray.400}" },
 		},
 		border: {
-			value: { base: "gray.200", _dark: "gray.700" },
+			value: { base: "{colors.gray.200}", _dark: "{colors.gray.700}" },
+		},
+		"border-muted": {
+			value: { base: "{colors.gray.100}", _dark: "{colors.gray.800}" },
 		},
 		accent: {
-			value: { base: "primary.700", _dark: "primary.300" },
+			value: { base: "{colors.primary.700}", _dark: "{colors.primary.300}" },
 		},
 		success: {
-			value: { base: "green.600", _dark: "green.200" },
+			value: { base: "{colors.green.600}", _dark: "{colors.green.200}" },
 		},
 		error: {
-			value: { base: "red.600", _dark: "red.200" },
+			value: { base: "{colors.red.600}", _dark: "{colors.red.200}" },
 		},
 		// Color palette tokens for colorPalette="primary" (required by Chakra v3
 		// for solid/subtle/outline/ghost button variants and other components)
@@ -147,19 +151,21 @@ const semanticTokens = {
 			},
 		},
 		// Accent surface tokens
-		"bg-accent": { value: { base: "primary.700", _dark: "primary.400" } },
+		"bg-accent": {
+			value: { base: "{colors.primary.700}", _dark: "{colors.primary.400}" },
+		},
 		"bg-accent-subtle": {
-			value: { base: "primary.700", _dark: "primary.500" },
+			value: { base: "{colors.primary.700}", _dark: "{colors.primary.500}" },
 		},
 		"bg-accent-muted": {
-			value: { base: "primary.500", _dark: "primary.600" },
+			value: { base: "{colors.primary.500}", _dark: "{colors.primary.600}" },
 		},
 		"on-accent": { value: { base: "white", _dark: "white" } },
 		"on-accent-muted": {
-			value: { base: "primary.50", _dark: "primary.100" },
+			value: { base: "{colors.primary.50}", _dark: "{colors.primary.100}" },
 		},
 		"on-accent-subtle": {
-			value: { base: "primary.100", _dark: "primary.200" },
+			value: { base: "{colors.primary.100}", _dark: "{colors.primary.200}" },
 		},
 	},
 	shadows: {


### PR DESCRIPTION
## Summary

Two visual regressions surfaced during odon's UI redesign rollout — both root-caused to Anker, both fixed here. Bumps to `1.3.0`.

### 1. Semantic color tokens never reached the DOM as CSS variables

Every top-level token (`bg-canvas`, `bg-surface`, `border`, `default`, `muted`, `accent`, `success`, `error`, `bg-accent*`, `on-accent*`) was declared with a bare scale reference:

```ts
"bg-canvas": { value: { base: "gray.50", _dark: "gray.900" } }
```

Chakra v3 stored that verbatim into the emitted CSS variable:

```css
--chakra-colors-bg-canvas: gray.50;   /* invalid CSS */
```

So `bg="bg-canvas"` resolved to `background-color: var(--chakra-colors-bg-canvas)` → *invalid* → fallback to `transparent`. `borderColor: "border"` (set globally on `*, *::before, *::after`) → fallback to `currentColor` (= near-black body text). End result: sidebar surface looks white, every border looks black.

The `primary` and `secondary` palette blocks already used the correct brace syntax (`{colors.primary.700}`) — copying that pattern across the rest fixes it.

### 2. `Sidebar.Item` lost its icon when used with `asChild`

`SidebarItem` computed `iconEl` correctly but `React.cloneElement(child, props)` was called with two args only — `cloneElement` then keeps the child's *original* children, so the icon was never rendered. Fix: pass `iconEl` and `child.props.children` as the cloned element's children.

### 3. Added missing `border-muted` token

`Sidebar.Header` and `Sidebar.Footer` reference `borderColor="border-muted"` (since 1.2.0) but the token was never defined — fell through to `currentColor` for the same reason as (1). Now defined as `gray.100` / `gray.800`.

## Tests

- `src/theme/tokens/semantic.test.ts` — new. Probes `system.tokens.tokenMap` and asserts every top-level semantic token's resolved `value` is a `var(...)` reference, not a bare scale string. Verified locally that this test fails on the previous `gray.50` form and passes with `{colors.gray.50}`.
- `src/components/sidebar/sidebar.test.tsx` — added an assertion that the `icon` prop renders *inside* the cloned `<a>` when `asChild`. The existing test only verified the link renders.

Full suite: 76 tests pass, lint clean (only pre-existing warnings), build clean, typecheck clean.

## Test plan

- [x] `npx vitest run` — 76 pass
- [x] `npm run lint` — no new errors
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] After merge: bump odon to 1.3.0, deploy, verify in Chrome that bg-canvas resolves, borders are gray.200, sidebar icons render

🤖 Generated with [Claude Code](https://claude.com/claude-code)