### PR TITLE
fix(sidebar): apply active-state styling as plain CSS so it survives asChild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0] — 2026-05-01
+
+### Fixed
+
+- **`Sidebar.Item` active-state styling now actually applies under `asChild`.** Previously the styling object used Chakra prop shorthand (`bg="primary.50"`, `borderRadius="md"`, `color="primary.700"`, `px="3"` …) and was passed through `React.cloneElement(..., { style: ... })`. Browsers silently drop those properties — they only resolve through Chakra components, not as inline DOM CSS. Result: active and inactive nav items rendered visually identical, and inactive items lost their padding too. Style values are now plain CSS using Chakra's emitted CSS variables (`var(--chakra-colors-primary-700)`, `var(--chakra-spacing-3)`, `var(--chakra-radii-sm)`, …). Test added asserting the active link has primary.700 color, bg-surface background, and an inset border shadow as inline style.
+
+### Changed
+
+- **`Sidebar.Item` active appearance updated to match the design handoff.** Active background is now `bg-surface` (white) with an inset 1px border (`var(--chakra-colors-border)`) and a subtle drop shadow, replacing the previous flat `primary.50` chip. Adds a 3px × 14px rounded indicator pill in `primary.700` at the trailing edge of the row, matching the handoff spec.
+
 ## [1.3.0] — 2026-05-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -127,6 +127,43 @@ describe("Sidebar", () => {
 		expect(link.textContent).toContain("Users");
 	});
 
+	it("Sidebar.Item asChild applies active styling as inline CSS variables", () => {
+		// Regression: prior versions passed Chakra prop shorthand (bg="primary.50",
+		// borderRadius="md", color="primary.700") through `style={...}`, which
+		// the browser silently dropped — active items were visually identical to
+		// inactive ones. Styles must be CSS-var references to survive inline.
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item active asChild icon={<span>i</span>}>
+							<a href="/users" data-testid="active-link">
+								Users
+							</a>
+						</Sidebar.Item>
+						<Sidebar.Item asChild icon={<span>i</span>}>
+							<a href="/oauth" data-testid="inactive-link">
+								OAuth
+							</a>
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		const active = screen.getByTestId("active-link");
+		const inactive = screen.getByTestId("inactive-link");
+		// Active state: primary.700 color + bg-surface background + inset shadow
+		expect(active.style.color).toContain("var(--chakra-colors-primary-700)");
+		expect(active.style.background).toContain(
+			"var(--chakra-colors-bg-surface)",
+		);
+		expect(active.style.boxShadow).toContain("var(--chakra-colors-border)");
+		// Inactive: transparent bg, no shadow
+		expect(inactive.style.background).toBe("transparent");
+		expect(inactive.style.boxShadow).toBe("");
+		expect(inactive.style.color).toContain("var(--chakra-colors-default)");
+	});
+
 	it("Sidebar.Item active=true exposes data-active attribute", () => {
 		renderWithChakra(
 			<Sidebar>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -126,35 +126,56 @@ export interface SidebarItemProps {
 }
 
 const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
-	const dataProps = {
-		"data-testid": "sidebar-item",
-		"data-active": active ? "true" : "false",
-	};
-
-	const styleProps = {
-		display: "flex" as const,
+	// Styles must be plain CSS so they survive `style={...}` inline styling on
+	// the cloned asChild element (e.g. <NavLink>). Chakra prop shorthand like
+	// `bg="primary.50"` or `borderRadius="md"` is silently dropped by the
+	// browser when applied as inline CSS — it only resolves through Chakra
+	// components. We reference Chakra's emitted CSS variables directly.
+	const itemStyle: React.CSSProperties = {
+		display: "flex",
 		alignItems: "center",
-		gap: "2",
-		px: "3",
-		py: "2",
-		borderRadius: "md",
-		fontSize: "sm",
-		fontWeight: "medium",
-		color: active ? "primary.700" : "default",
-		bg: active ? "primary.50" : "transparent",
-		position: "relative" as const,
+		gap: "var(--chakra-spacing-2)",
+		paddingInline: "var(--chakra-spacing-3)",
+		paddingBlock: "var(--chakra-spacing-2)",
+		borderRadius: "var(--chakra-radii-sm)",
+		fontSize: "var(--chakra-font-sizes-sm)",
+		fontWeight: active
+			? "var(--chakra-font-weights-medium)"
+			: "var(--chakra-font-weights-normal)",
+		color: active
+			? "var(--chakra-colors-primary-700)"
+			: "var(--chakra-colors-default)",
+		background: active ? "var(--chakra-colors-bg-surface)" : "transparent",
+		boxShadow: active
+			? "inset 0 0 0 1px var(--chakra-colors-border), 0 1px 2px rgba(0,0,0,0.04)"
+			: undefined,
+		position: "relative",
 		textDecoration: "none",
 	};
 
 	const iconEl = icon ? (
-		<Box display="inline-flex" alignItems="center">
+		<Box display="inline-flex" alignItems="center" flexShrink={0}>
 			{icon}
 		</Box>
 	) : null;
 
+	// Right-tab indicator on active items, matching the design handoff
+	// (3px × 14px primary.700 pill at the trailing edge of the row).
+	const activeTab = active ? (
+		<span
+			aria-hidden="true"
+			style={{
+				width: 3,
+				height: 14,
+				background: "var(--chakra-colors-primary-700)",
+				borderRadius: 999,
+				flexShrink: 0,
+				marginInlineStart: "auto",
+			}}
+		/>
+	) : null;
+
 	if (asChild) {
-		// Clone the single child, merging our style props and prepending the
-		// icon as the first rendered child while keeping the original content.
 		const child = React.Children.only(children) as React.ReactElement<
 			React.HTMLAttributes<HTMLElement> & {
 				href?: string;
@@ -168,19 +189,25 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 			{
 				"data-active": active ? "true" : "false",
 				style: {
-					...styleProps,
+					...itemStyle,
 					...(child.props.style as React.CSSProperties | undefined),
 				},
 			},
 			iconEl,
 			child.props.children,
+			activeTab,
 		);
 	}
 
 	return (
-		<Box {...dataProps} {...styleProps}>
+		<Box
+			data-testid="sidebar-item"
+			data-active={active ? "true" : "false"}
+			style={itemStyle}
+		>
 			{iconEl}
 			{children}
+			{activeTab}
 		</Box>
 	);
 };


### PR DESCRIPTION
## Summary

Fixes a second visual regression on `Sidebar.Item`: the active highlight never appeared. Bumps to `1.4.0`.

### Root cause

`SidebarItem`'s `styleProps` object used Chakra prop shorthand:

```ts
const styleProps = {
  bg: active ? "primary.50" : "transparent",
  color: active ? "primary.700" : "default",
  px: "3", py: "2", gap: "2",
  borderRadius: "md", fontSize: "sm", fontWeight: "medium",
  ...
};
```

Under `asChild`, this object was passed through `React.cloneElement(..., { style: styleProps })`. Plain DOM `style={...}` only accepts real CSS — Chakra shorthand (`bg`, `px`, `borderRadius="md"`, `color="primary.700"`) isn't resolved at this layer. The browser silently dropped every shorthand and only kept `display`, `alignItems`, `position`, `textDecoration`. Result: active and inactive nav items rendered visually identical, and even inactive items lost their padding and gap.

DevTools probe on the deployed app confirmed the inline-style attribute on every nav `<a>` was just:
```
display: flex; align-items: center; position: relative; text-decoration: none;
```

### Fix

`itemStyle` now uses plain CSS referencing Chakra's emitted CSS variables (`var(--chakra-colors-primary-700)`, `var(--chakra-spacing-3)`, `var(--chakra-radii-sm)`, etc.). Those work in inline-style on any element, Box or cloned link. The non-asChild path uses the same object via `style={itemStyle}`, dropping the prior Chakra-prop spread for consistency.

### Visual change

Active state now matches the Claude Design handoff:
- Background: `bg-surface` (white)
- Inset 1px border in `var(--chakra-colors-border)` plus a subtle drop shadow
- 3px × 14px rounded indicator pill in `primary.700` at the trailing edge

(Previous behavior was a flat `primary.50` chip — but in practice it was invisible due to the inline-style bug.)

## Test plan

- [x] `npx vitest run src/components/sidebar` — 14/14 pass, including new regression test
- [x] `npm run lint` — no new errors
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] After merge: bump odon to 1.4.0, deploy, verify active item shows white bg + inset border + indicator pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)