### PR TITLE
fix(sidebar): use border (gray.200) for header/footer separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] — 2026-05-04
+
+### Fixed
+
+- **`Sidebar.Header` and `Sidebar.Footer` separators now use `border` instead of `border-muted`**, matching the design handoff. Both bands previously rendered a `gray.100` (`#f1f5f9`) border that was barely distinguishable from the `bg-canvas` (`gray.50`) sidebar surface — the right column edge already used `border` (`gray.200`), so the contrast inside the sidebar was inconsistent with the column edge.
+
 ## [1.4.0] — 2026-05-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -32,7 +32,7 @@ SidebarRoot.displayName = "Sidebar";
 
 // Header / Body / Footer
 const SidebarHeader = ({ children }: { children: React.ReactNode }) => (
-	<Box p="4" borderBottomWidth="1px" borderBottomColor="border-muted">
+	<Box p="4" borderBottomWidth="1px" borderBottomColor="border">
 		{children}
 	</Box>
 );
@@ -46,7 +46,7 @@ const SidebarBody = ({ children }: { children?: React.ReactNode }) => (
 SidebarBody.displayName = "Sidebar.Body";
 
 const SidebarFooter = ({ children }: { children: React.ReactNode }) => (
-	<Box p="3" borderTopWidth="1px" borderTopColor="border-muted">
+	<Box p="3" borderTopWidth="1px" borderTopColor="border">
 		{children}
 	</Box>
 );


### PR DESCRIPTION
## Summary

`Sidebar.Header` bottom and `Sidebar.Footer` top now use `border` (gray.200, `#e2e8f0`) instead of `border-muted` (gray.100, `#f1f5f9`), matching the Claude Design handoff and the right column edge.

The previous color was so close to the slate.50 sidebar surface that the separators were barely visible — the right column edge already used `border`, making the inside of the sidebar look "borderless" by comparison.

## Test plan

- [x] All 14 sidebar tests pass
- [x] Lint, typecheck, build clean
- [ ] Verify in odon after bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)