### PR TITLE
feat: ContextRail.Section collapsibility + Header border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.0] — 2026-05-04
+
+### Added
+
+- `<ContextRail.Section>` is now collapsible. New `defaultOpen?: boolean` prop (default `true`) and `action?: ReactNode` slot rendered next to the title. Clicking the section header toggles open/closed; clicking inside the `action` slot does not toggle. Section root gains a 1px bottom border in `border-muted` to match the design handoff. Header is a real button with `aria-expanded`; the chevron icon rotates 90° when open.
+- `<ContextRail.Header>` gains a 1px bottom border in `border` to visually separate it from the first section.
+
 ## [1.5.0] — 2026-05-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/context-rail/context-rail.test.tsx
+++ b/src/components/context-rail/context-rail.test.tsx
@@ -184,7 +184,7 @@ describe("ContextRail", () => {
 					id="s1"
 					label="Details"
 					action={
-						<button data-testid="action" onClick={onAction}>
+						<button type="button" data-testid="action" onClick={onAction}>
 							Manage
 						</button>
 					}
@@ -206,7 +206,9 @@ describe("ContextRail", () => {
 				</ContextRail.Section>
 			</ContextRail>,
 		);
-		const root = container.querySelector('[data-section-id="s1"]') as HTMLElement;
+		const root = container.querySelector(
+			'[data-section-id="s1"]',
+		) as HTMLElement;
 		expect(root).toBeInTheDocument();
 		expect(root).toHaveStyle({ borderBottomWidth: "1px" });
 	});

--- a/src/components/context-rail/context-rail.test.tsx
+++ b/src/components/context-rail/context-rail.test.tsx
@@ -1,8 +1,8 @@
 // src/components/context-rail/context-rail.test.tsx
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextRail } from "./context-rail";
 
 function renderWithChakra(ui: React.ReactElement) {
@@ -150,5 +150,64 @@ describe("ContextRail", () => {
 		expect(
 			screen.getByRole("button", { name: "Open detail" }),
 		).toBeInTheDocument();
+	});
+
+	it("Section is open by default and toggles closed on header click", () => {
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Section id="s1" label="Details">
+					<span data-testid="body">visible</span>
+				</ContextRail.Section>
+			</ContextRail>,
+		);
+		expect(screen.getByTestId("body")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /Details/i }));
+		expect(screen.queryByTestId("body")).not.toBeInTheDocument();
+	});
+
+	it("Section respects defaultOpen={false}", () => {
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Section id="s1" label="Details" defaultOpen={false}>
+					<span data-testid="body">hidden</span>
+				</ContextRail.Section>
+			</ContextRail>,
+		);
+		expect(screen.queryByTestId("body")).not.toBeInTheDocument();
+	});
+
+	it("Section action slot does not toggle the section when clicked", () => {
+		const onAction = vi.fn();
+		renderWithChakra(
+			<ContextRail>
+				<ContextRail.Section
+					id="s1"
+					label="Details"
+					action={
+						<button data-testid="action" onClick={onAction}>
+							Manage
+						</button>
+					}
+				>
+					<span data-testid="body">body</span>
+				</ContextRail.Section>
+			</ContextRail>,
+		);
+		fireEvent.click(screen.getByTestId("action"));
+		expect(onAction).toHaveBeenCalledOnce();
+		expect(screen.getByTestId("body")).toBeInTheDocument();
+	});
+
+	it("Section root has bottom border", () => {
+		const { container } = renderWithChakra(
+			<ContextRail>
+				<ContextRail.Section id="s1" label="Details">
+					<span>body</span>
+				</ContextRail.Section>
+			</ContextRail>,
+		);
+		const root = container.querySelector('[data-section-id="s1"]') as HTMLElement;
+		expect(root).toBeInTheDocument();
+		expect(root).toHaveStyle({ borderBottomWidth: "1px" });
 	});
 });

--- a/src/components/context-rail/context-rail.test.tsx
+++ b/src/components/context-rail/context-rail.test.tsx
@@ -210,4 +210,15 @@ describe("ContextRail", () => {
 		expect(root).toBeInTheDocument();
 		expect(root).toHaveStyle({ borderBottomWidth: "1px" });
 	});
+
+	it("Header has a bottom border", () => {
+		const { container } = renderWithChakra(
+			<ContextRail>
+				<ContextRail.Header title="User" />
+			</ContextRail>,
+		);
+		const header = container.querySelector("h2")?.parentElement as HTMLElement;
+		expect(header).toBeInTheDocument();
+		expect(header).toHaveStyle({ borderBottomWidth: "1px" });
+	});
 });

--- a/src/components/context-rail/context-rail.tsx
+++ b/src/components/context-rail/context-rail.tsx
@@ -96,7 +96,7 @@ const ContextRailHeader = ({
 	title,
 	onClose: _onClose,
 }: ContextRailHeaderProps) => (
-	<Box mb="4">
+	<Box mb="4" pb="3" borderBottomWidth="1px" borderBottomColor="border">
 		{eyebrow && (
 			<Text
 				fontSize="2xs"

--- a/src/components/context-rail/context-rail.tsx
+++ b/src/components/context-rail/context-rail.tsx
@@ -150,7 +150,7 @@ const ContextRailSection = ({
 			<Flex w="full" align="center" gap="2">
 				<Flex
 					as="button"
-					type="button"
+					{...({ type: "button" } as object)}
 					onClick={() => setOpen((o) => !o)}
 					aria-expanded={open}
 					flex="1"

--- a/src/components/context-rail/context-rail.tsx
+++ b/src/components/context-rail/context-rail.tsx
@@ -1,5 +1,5 @@
 // src/components/context-rail/context-rail.tsx
-import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { ChevronRight, PanelRightClose, PanelRightOpen } from "lucide-react";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { IconButton } from "../../atoms/button";
@@ -127,6 +127,8 @@ export interface ContextRailSectionProps {
 	id: string;
 	icon?: React.ReactNode;
 	label: string;
+	defaultOpen?: boolean;
+	action?: React.ReactNode;
 	children: React.ReactNode;
 }
 
@@ -134,22 +136,66 @@ const ContextRailSection = ({
 	id,
 	icon,
 	label,
+	defaultOpen = true,
+	action,
 	children,
-}: ContextRailSectionProps) => (
-	<Box mb="4" data-section-id={id}>
-		<Flex align="center" gap="2" mb="2">
-			{icon && (
-				<Box display="inline-flex" alignItems="center" color="muted">
-					{icon}
-				</Box>
-			)}
-			<Heading as="h3" fontSize="sm" fontWeight="semibold" color="default">
-				{label}
-			</Heading>
-		</Flex>
-		<Box>{children}</Box>
-	</Box>
-);
+}: ContextRailSectionProps) => {
+	const [open, setOpen] = useState(defaultOpen);
+	return (
+		<Box
+			data-section-id={id}
+			borderBottomWidth="1px"
+			borderBottomColor="border-muted"
+		>
+			<Flex w="full" align="center" gap="2">
+				<Flex
+					as="button"
+					type="button"
+					onClick={() => setOpen((o) => !o)}
+					aria-expanded={open}
+					flex="1"
+					align="center"
+					gap="2"
+					px="0"
+					py="3"
+					bg="transparent"
+					border="none"
+					cursor="pointer"
+					textAlign="left"
+					_hover={{ bg: "bg-subtle" }}
+				>
+					<Box
+						display="inline-flex"
+						alignItems="center"
+						color="muted"
+						transform={open ? "rotate(90deg)" : "none"}
+						transition="transform 120ms ease-out"
+					>
+						<ChevronRight size={12} aria-hidden />
+					</Box>
+					{icon && (
+						<Box display="inline-flex" alignItems="center" color="muted">
+							{icon}
+						</Box>
+					)}
+					<Heading
+						as="h3"
+						fontSize="2xs"
+						fontWeight="semibold"
+						letterSpacing="wider"
+						textTransform="uppercase"
+						color="muted"
+						flex="1"
+					>
+						{label}
+					</Heading>
+				</Flex>
+				{action && <Box py="3">{action}</Box>}
+			</Flex>
+			{open && <Box pb="3">{children}</Box>}
+		</Box>
+	);
+};
 ContextRailSection.displayName = "ContextRail.Section";
 
 // Footer


### PR DESCRIPTION
## Summary

- `<ContextRail.Section>` becomes collapsible with optional `action` slot and bottom border.
- `<ContextRail.Header>` gains a bottom border to visually separate from the first section.
- Bumps to 1.6.0.

Matches the Claude Design handoff (`RailSection` with chevron + `RailHeader` with border).

## Test plan

- `npx vitest run` — 14 sidebar/context-rail tests pass.
- `npm run lint` / `typecheck` / `build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)