### PR TITLE
feat: Button default colorPalette=primary + DataTable select column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.0] — 2026-05-04
+
+### Changed
+
+- **`<Button>` and `<IconButton>` now default `colorPalette="primary"`.** Previously, `<Button variant="solid">` without an explicit `colorPalette` rendered gray.900 (near-black) — a subtle source of bugs across consumers. Pass `colorPalette="gray"` (or another palette) to opt out. Visual change: any button using `variant="solid"` without an explicit `colorPalette` will now render in the brand primary color instead of gray.
+
+### Fixed
+
+- **`<DataTable>` `__select` column is now 40px wide** instead of TanStack Table's 150px default. The checkbox-only column no longer steals space from data columns.
+
 ## [1.6.0] — 2026-05-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/atoms/button/button.test.tsx
+++ b/src/atoms/button/button.test.tsx
@@ -1,0 +1,23 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("Button", () => {
+	it("renders without explicit colorPalette", () => {
+		// Chakra v3 does not expose colorPalette in outerHTML — visual confirmation
+		// is required post-release. This test confirms the button renders and
+		// does not throw when no colorPalette is provided.
+		renderWithChakra(<Button>Click</Button>);
+		expect(screen.getByRole("button", { name: /click/i })).toBeInTheDocument();
+	});
+
+	it("renders with explicit colorPalette override", () => {
+		renderWithChakra(<Button colorPalette="red">Delete</Button>);
+		expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+	});
+});

--- a/src/atoms/button/button.tsx
+++ b/src/atoms/button/button.tsx
@@ -22,12 +22,14 @@ export type ButtonProps = Omit<ChakraButtonProps, "variant"> & {
 
 export const Button = ({
 	ref,
+	colorPalette = "primary",
 	...props
 }: ButtonProps & { ref?: React.Ref<HTMLButtonElement> }) => {
 	return (
 		<ChakraButton
 			size="md"
 			variant={"secondary" as ChakraButtonProps["variant"]}
+			colorPalette={colorPalette}
 			ref={ref}
 			{...(props as ChakraButtonProps)}
 		/>

--- a/src/atoms/button/icon-button.tsx
+++ b/src/atoms/button/icon-button.tsx
@@ -7,8 +7,17 @@ export type { IconButtonProps };
 
 export const IconButton = ({
 	ref,
+	colorPalette = "primary",
 	...props
 }: IconButtonProps & { ref?: React.Ref<HTMLButtonElement> }) => {
-	return <ChakraIconButton size="md" variant="ghost" ref={ref} {...props} />;
+	return (
+		<ChakraIconButton
+			size="md"
+			variant="ghost"
+			colorPalette={colorPalette}
+			ref={ref}
+			{...props}
+		/>
+	);
 };
 IconButton.displayName = "IconButton";

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -81,6 +81,9 @@ function DataTableInner<T extends Record<string, unknown>>(
 	const selectionColumn = useMemo<ColumnDef<T, unknown>>(
 		() => ({
 			id: "_select",
+			size: 40,
+			minSize: 40,
+			maxSize: 40,
 			header: ({ table }) => (
 				<Checkbox.Root
 					checked={
@@ -162,6 +165,7 @@ function DataTableInner<T extends Record<string, unknown>>(
 								{headerGroup.headers.map((header) => {
 									const canSort = header.column.getCanSort();
 									const sorted = header.column.getIsSorted();
+									const isSelectCol = header.column.id === "_select";
 
 									return (
 										<Table.ColumnHeader
@@ -192,6 +196,11 @@ function DataTableInner<T extends Record<string, unknown>>(
 																header.column.getToggleSortingHandler()?.(e);
 															}
 														}
+													: undefined
+											}
+											style={
+												isSelectCol
+													? { width: header.column.getSize() }
 													: undefined
 											}
 										>
@@ -252,7 +261,14 @@ function DataTableInner<T extends Record<string, unknown>>(
 									}
 								>
 									{row.getVisibleCells().map((cell) => (
-										<Table.Cell key={cell.id}>
+										<Table.Cell
+											key={cell.id}
+											style={
+												cell.column.id === "_select"
+													? { width: cell.column.getSize() }
+													: undefined
+											}
+										>
 											{flexRender(
 												cell.column.columnDef.cell,
 												cell.getContext(),


### PR DESCRIPTION
## Summary

- `<Button>` and `<IconButton>` default `colorPalette` to `primary`. Removes a recurring footgun where `variant="solid"` without an explicit colorPalette rendered gray.900. Consumers who want gray now pass `colorPalette="gray"` explicitly.
- `<DataTable>` `__select` column is now 40px wide (was using TanStack's 150px default).

Bumps to 1.7.0.

## Test plan

- All existing tests pass.
- Lint, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)