### PR TITLE
feat: collapsible <Sidebar> + useSidebarContext hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.8.0] — 2026-05-04
+
+### Added
+
+- `<Sidebar>` becomes collapsible. New props `storageKey?: string` and `defaultCollapsed?: boolean` mirror the `<ContextRail>` API. Toggle button in the top-right of the sidebar; viewport `< 1440px` collapses by default; localStorage persistence via `storageKey`. Collapsed width 64px (icon rail), expanded 240px.
+- Subcomponents adapt automatically: `<Sidebar.Logo>` shows first-letter only, `<Sidebar.Section>` hides its label, `<Sidebar.Item>` becomes icon-only with hover tooltip (new optional `label?: string` prop overrides the tooltip text), `<Sidebar.UserMenu>` shows avatar-only.
+- New `useSidebarContext()` hook (`{ collapsed, toggle }`) so consumer-rendered children inside `<Sidebar.Slot>` can render compact variants.
+
 ## [1.7.0] — 2026-05-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -106,7 +106,7 @@ export type {
 	SidebarUserMenuItemProps,
 	SidebarUserMenuProps,
 } from "./sidebar/sidebar";
-export { Sidebar } from "./sidebar/sidebar";
+export { Sidebar, useSidebarContext } from "./sidebar/sidebar";
 // SidebarSection
 export type { SidebarSectionProps } from "./sidebar-section";
 export { SidebarSection } from "./sidebar-section";

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -2,10 +2,19 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { Sidebar } from "./sidebar";
+import { Sidebar, useSidebarContext } from "./sidebar";
 
 function renderWithChakra(ui: React.ReactElement) {
 	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+// Helper: render with sidebar forced expanded (innerWidth > 1440)
+function renderExpanded(ui: React.ReactElement) {
+	Object.defineProperty(window, "innerWidth", {
+		configurable: true,
+		value: 1600,
+	});
+	return renderWithChakra(ui);
 }
 
 describe("Sidebar", () => {
@@ -19,7 +28,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders Sidebar.Logo wordmark and subtitle", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Header>
 					<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
@@ -32,7 +41,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders Sidebar.Logo without subtitle when omitted", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Header>
 					<Sidebar.Logo wordmark="Odon" />
@@ -59,7 +68,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders Sidebar.Section label and children", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -73,7 +82,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders Sidebar.Item with icon and children", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -89,7 +98,7 @@ describe("Sidebar", () => {
 	});
 
 	it("Sidebar.Item with asChild forwards to its child element", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -108,7 +117,7 @@ describe("Sidebar", () => {
 	});
 
 	it("Sidebar.Item asChild renders the icon inside the cloned element", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -132,7 +141,7 @@ describe("Sidebar", () => {
 		// borderRadius="md", color="primary.700") through `style={...}`, which
 		// the browser silently dropped — active items were visually identical to
 		// inactive ones. Styles must be CSS-var references to survive inline.
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -165,7 +174,7 @@ describe("Sidebar", () => {
 	});
 
 	it("Sidebar.Item active=true exposes data-active attribute", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -183,7 +192,7 @@ describe("Sidebar", () => {
 	});
 
 	it("Sidebar.Item without active prop has no data-active='true' attribute", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
@@ -197,7 +206,7 @@ describe("Sidebar", () => {
 	});
 
 	it("renders Sidebar.UserMenu with user name and email", () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body />
 				<Sidebar.Footer>
@@ -214,7 +223,7 @@ describe("Sidebar", () => {
 	});
 
 	it("opens the user menu on click and renders Sidebar.UserMenuItem children", async () => {
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body />
 				<Sidebar.Footer>
@@ -232,7 +241,7 @@ describe("Sidebar", () => {
 
 	it("Sidebar.UserMenuItem onClick fires", async () => {
 		const onClick = vi.fn();
-		renderWithChakra(
+		renderExpanded(
 			<Sidebar>
 				<Sidebar.Body />
 				<Sidebar.Footer>
@@ -247,5 +256,200 @@ describe("Sidebar", () => {
 		fireEvent.click(screen.getByTestId("sidebar-user-menu-trigger"));
 		fireEvent.click(await screen.findByText("Sign out"));
 		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	// ── New tests: collapse state, viewport heuristic, storage, toggle ──
+
+	it("Sidebar starts expanded by default at wide viewport", () => {
+		// jsdom default innerWidth is 1024, so without storage this would
+		// collapse via heuristic. Set viewport wider than the breakpoint.
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"false",
+		);
+	});
+
+	it("Sidebar honors defaultCollapsed prop when no stored value", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar defaultCollapsed>
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+	});
+
+	it("Sidebar collapses by default below the 1440px breakpoint", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1280,
+		});
+		renderWithChakra(
+			<Sidebar>
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+	});
+
+	it("Sidebar reads stored value from localStorage when storageKey is set", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		window.localStorage.setItem("test.sidebar.collapsed", "true");
+		renderWithChakra(
+			<Sidebar storageKey="test.sidebar.collapsed">
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+		window.localStorage.removeItem("test.sidebar.collapsed");
+	});
+
+	it("Sidebar toggle button flips state and writes to localStorage", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar storageKey="test.sidebar.toggle">
+				<Sidebar.Body>body</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"false",
+		);
+		fireEvent.click(screen.getByTestId("sidebar-toggle"));
+		expect(screen.getByTestId("sidebar")).toHaveAttribute(
+			"data-collapsed",
+			"true",
+		);
+		expect(window.localStorage.getItem("test.sidebar.toggle")).toBe("true");
+		window.localStorage.removeItem("test.sidebar.toggle");
+	});
+
+	it("useSidebarContext throws when used outside Sidebar", () => {
+		// Suppress the React error boundary log:
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		function Probe() {
+			useSidebarContext();
+			return null;
+		}
+		expect(() => render(<Probe />)).toThrow(/useSidebarContext/);
+		spy.mockRestore();
+	});
+
+	// ── Task 3: Logo compact mode ──
+
+	it("Sidebar.Logo shows compact form when collapsed", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar defaultCollapsed>
+				<Sidebar.Header>
+					<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
+				</Sidebar.Header>
+				<Sidebar.Body />
+			</Sidebar>,
+		);
+		// First letter rendered, full wordmark and subtitle absent
+		expect(screen.getByText("O")).toBeInTheDocument();
+		expect(screen.queryByText("Odon")).not.toBeInTheDocument();
+		expect(screen.queryByText("Identity Provider")).not.toBeInTheDocument();
+	});
+
+	// ── Task 4: Section label hidden when collapsed ──
+
+	it("Sidebar.Section hides its label when collapsed", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar defaultCollapsed>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<span data-testid="item">A</span>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		expect(screen.queryByText("Identity")).not.toBeInTheDocument();
+		expect(screen.getByTestId("item")).toBeInTheDocument();
+	});
+
+	// ── Task 5: Item icon-only with tooltip when collapsed ──
+
+	it("Sidebar.Item shows icon-only with tooltip when collapsed", async () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar defaultCollapsed>
+				<Sidebar.Body>
+					<Sidebar.Section label="Identity">
+						<Sidebar.Item icon={<span data-testid="icon">i</span>} label="Users">
+							Users
+						</Sidebar.Item>
+					</Sidebar.Section>
+				</Sidebar.Body>
+			</Sidebar>,
+		);
+		// Icon present
+		expect(screen.getByTestId("icon")).toBeInTheDocument();
+		// Visible label hidden in collapsed mode (text "Users" not rendered as item content)
+		// Note: getByText would match the tooltip content if portal-rendered;
+		// assert via the rendered item box not containing "Users" text:
+		const item = screen.getByTestId("sidebar-item");
+		expect(item.textContent).not.toContain("Users");
+	});
+
+	// ── Task 6: UserMenu avatar-only when collapsed ──
+
+	it("Sidebar.UserMenu shows avatar only when collapsed", () => {
+		Object.defineProperty(window, "innerWidth", {
+			configurable: true,
+			value: 1600,
+		});
+		renderWithChakra(
+			<Sidebar defaultCollapsed>
+				<Sidebar.Body />
+				<Sidebar.Footer>
+					<Sidebar.UserMenu user={{ name: "Jana Schmid", email: "jana@knk.de" }}>
+						<Sidebar.UserMenuItem>Sign out</Sidebar.UserMenuItem>
+					</Sidebar.UserMenu>
+				</Sidebar.Footer>
+			</Sidebar>,
+		);
+		// Initials present, name and email NOT rendered in trigger
+		expect(screen.getByText("JS")).toBeInTheDocument();
+		expect(screen.queryByText("Jana Schmid")).not.toBeInTheDocument();
+		expect(screen.queryByText("jana@knk.de")).not.toBeInTheDocument();
 	});
 });

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -414,7 +414,10 @@ describe("Sidebar", () => {
 			<Sidebar defaultCollapsed>
 				<Sidebar.Body>
 					<Sidebar.Section label="Identity">
-						<Sidebar.Item icon={<span data-testid="icon">i</span>} label="Users">
+						<Sidebar.Item
+							icon={<span data-testid="icon">i</span>}
+							label="Users"
+						>
 							Users
 						</Sidebar.Item>
 					</Sidebar.Section>
@@ -441,7 +444,9 @@ describe("Sidebar", () => {
 			<Sidebar defaultCollapsed>
 				<Sidebar.Body />
 				<Sidebar.Footer>
-					<Sidebar.UserMenu user={{ name: "Jana Schmid", email: "jana@knk.de" }}>
+					<Sidebar.UserMenu
+						user={{ name: "Jana Schmid", email: "jana@knk.de" }}
+					>
 						<Sidebar.UserMenuItem>Sign out</Sidebar.UserMenuItem>
 					</Sidebar.UserMenu>
 				</Sidebar.Footer>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 // src/components/sidebar/sidebar.tsx
-import React from "react";
-import { Button } from "../../atoms/button";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { Button, IconButton } from "../../atoms/button";
 import { Box, Flex } from "../../primitives/layout";
 import {
 	MenuContent,
@@ -8,26 +9,107 @@ import {
 	MenuRoot,
 	MenuTrigger,
 } from "../../primitives/menu";
+import { Tooltip } from "../../primitives/tooltip";
 import { Heading, Text } from "../../primitives/typography";
+
+const COLLAPSED_WIDTH = "64px";
+const EXPANDED_WIDTH = "240px";
+const COLLAPSE_BREAKPOINT = 1440;
+
+interface SidebarContextValue {
+	collapsed: boolean;
+	toggle: () => void;
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+export function useSidebarContext(): SidebarContextValue {
+	const ctx = React.useContext(SidebarContext);
+	if (!ctx) {
+		throw new Error("useSidebarContext must be used inside <Sidebar>");
+	}
+	return ctx;
+}
+
+function getInitialCollapsed(
+	storageKey: string | undefined,
+	defaultCollapsed: boolean | undefined,
+): boolean {
+	if (typeof window === "undefined") return defaultCollapsed ?? false;
+	if (storageKey) {
+		const stored = window.localStorage.getItem(storageKey);
+		if (stored === "true") return true;
+		if (stored === "false") return false;
+	}
+	if (defaultCollapsed !== undefined) return defaultCollapsed;
+	return window.innerWidth < COLLAPSE_BREAKPOINT;
+}
 
 // Root
 export interface SidebarProps {
+	storageKey?: string;
+	defaultCollapsed?: boolean;
 	children: React.ReactNode;
 }
 
-const SidebarRoot = ({ children }: SidebarProps) => (
-	<Flex
-		data-testid="sidebar"
-		direction="column"
-		w="240px"
-		minH="100vh"
-		bg="bg-canvas"
-		borderRightWidth="1px"
-		borderRightColor="border"
-	>
-		{children}
-	</Flex>
-);
+const SidebarRoot = ({
+	storageKey,
+	defaultCollapsed,
+	children,
+}: SidebarProps) => {
+	const [collapsed, setCollapsed] = useState(() =>
+		getInitialCollapsed(storageKey, defaultCollapsed),
+	);
+
+	useEffect(() => {
+		if (storageKey) {
+			window.localStorage.setItem(storageKey, String(collapsed));
+		}
+	}, [collapsed, storageKey]);
+
+	const ctx = useMemo<SidebarContextValue>(
+		() => ({
+			collapsed,
+			toggle: () => setCollapsed((c) => !c),
+		}),
+		[collapsed],
+	);
+
+	return (
+		<SidebarContext.Provider value={ctx}>
+			<Flex
+				data-testid="sidebar"
+				data-collapsed={collapsed ? "true" : "false"}
+				direction="column"
+				w={collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}
+				minH="100vh"
+				bg="bg-canvas"
+				borderRightWidth="1px"
+				borderRightColor="border"
+				transition="width 250ms ease-out"
+				overflow="hidden"
+				position="relative"
+			>
+				<Flex justify="flex-end" px="2" pt="2">
+					<IconButton
+						data-testid="sidebar-toggle"
+						aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+						variant="ghost"
+						size="sm"
+						onClick={() => setCollapsed((c) => !c)}
+					>
+						{collapsed ? (
+							<PanelLeftOpen size={16} />
+						) : (
+							<PanelLeftClose size={16} />
+						)}
+					</IconButton>
+				</Flex>
+				{children}
+			</Flex>
+		</SidebarContext.Provider>
+	);
+};
 SidebarRoot.displayName = "Sidebar";
 
 // Header / Body / Footer
@@ -58,31 +140,49 @@ export interface SidebarLogoProps {
 	subtitle?: string;
 }
 
-const SidebarLogo = ({ wordmark, subtitle }: SidebarLogoProps) => (
-	<Box mb={subtitle ? "3" : "0"}>
-		<Heading
-			as="span"
-			fontSize="lg"
-			fontWeight="bold"
-			color="primary.700"
-			letterSpacing="tight"
-		>
-			{wordmark}
-		</Heading>
-		{subtitle && (
-			<Text
-				fontSize="2xs"
-				fontWeight="semibold"
-				letterSpacing="wider"
-				textTransform="uppercase"
-				color="muted"
-				mt="0.5"
+const SidebarLogo = ({ wordmark, subtitle }: SidebarLogoProps) => {
+	const { collapsed } = useSidebarContext();
+	if (collapsed) {
+		return (
+			<Box>
+				<Heading
+					as="span"
+					fontSize="lg"
+					fontWeight="bold"
+					color="primary.700"
+					letterSpacing="tight"
+				>
+					{wordmark.charAt(0)}
+				</Heading>
+			</Box>
+		);
+	}
+	return (
+		<Box mb={subtitle ? "3" : "0"}>
+			<Heading
+				as="span"
+				fontSize="lg"
+				fontWeight="bold"
+				color="primary.700"
+				letterSpacing="tight"
 			>
-				{subtitle}
-			</Text>
-		)}
-	</Box>
-);
+				{wordmark}
+			</Heading>
+			{subtitle && (
+				<Text
+					fontSize="2xs"
+					fontWeight="semibold"
+					letterSpacing="wider"
+					textTransform="uppercase"
+					color="muted"
+					mt="0.5"
+				>
+					{subtitle}
+				</Text>
+			)}
+		</Box>
+	);
+};
 SidebarLogo.displayName = "Sidebar.Logo";
 
 // Slot
@@ -97,24 +197,29 @@ export interface SidebarSectionProps {
 	children: React.ReactNode;
 }
 
-const SidebarSection = ({ label, children }: SidebarSectionProps) => (
-	<Box mb="4" px="3">
-		<Text
-			fontSize="2xs"
-			fontWeight="semibold"
-			letterSpacing="wider"
-			textTransform="uppercase"
-			color="muted"
-			px="2"
-			mb="1"
-		>
-			{label}
-		</Text>
-		<Flex direction="column" gap="0.5">
-			{children}
-		</Flex>
-	</Box>
-);
+const SidebarSection = ({ label, children }: SidebarSectionProps) => {
+	const { collapsed } = useSidebarContext();
+	return (
+		<Box mb="4" px="3">
+			{!collapsed && (
+				<Text
+					fontSize="2xs"
+					fontWeight="semibold"
+					letterSpacing="wider"
+					textTransform="uppercase"
+					color="muted"
+					px="2"
+					mb="1"
+				>
+					{label}
+				</Text>
+			)}
+			<Flex direction="column" gap="0.5">
+				{children}
+			</Flex>
+		</Box>
+	);
+};
 SidebarSection.displayName = "Sidebar.Section";
 
 // Item — nav link with active state
@@ -123,9 +228,18 @@ export interface SidebarItemProps {
 	children: React.ReactNode;
 	asChild?: boolean;
 	active?: boolean;
+	label?: string; // NEW — overrides children for tooltip text when collapsed
 }
 
-const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
+const SidebarItem = ({
+	icon,
+	children,
+	asChild,
+	active,
+	label,
+}: SidebarItemProps) => {
+	const { collapsed } = useSidebarContext();
+
 	// Styles must be plain CSS so they survive `style={...}` inline styling on
 	// the cloned asChild element (e.g. <NavLink>). Chakra prop shorthand like
 	// `bg="primary.50"` or `borderRadius="md"` is silently dropped by the
@@ -134,6 +248,7 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 	const itemStyle: React.CSSProperties = {
 		display: "flex",
 		alignItems: "center",
+		justifyContent: collapsed ? "center" : "flex-start",
 		gap: "var(--chakra-spacing-2)",
 		paddingInline: "var(--chakra-spacing-3)",
 		paddingBlock: "var(--chakra-spacing-2)",
@@ -161,7 +276,8 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 
 	// Right-tab indicator on active items, matching the design handoff
 	// (3px × 14px primary.700 pill at the trailing edge of the row).
-	const activeTab = active ? (
+	// Hidden when collapsed (no room).
+	const activeTab = active && !collapsed ? (
 		<span
 			aria-hidden="true"
 			style={{
@@ -175,6 +291,18 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 		/>
 	) : null;
 
+	const tooltipLabel =
+		label || (typeof children === "string" ? children : "");
+
+	const wrapTooltip = (node: React.ReactElement) =>
+		collapsed && tooltipLabel ? (
+			<Tooltip content={tooltipLabel} positioning={{ placement: "right" }}>
+				{node}
+			</Tooltip>
+		) : (
+			node
+		);
+
 	if (asChild) {
 		const child = React.Children.only(children) as React.ReactElement<
 			React.HTMLAttributes<HTMLElement> & {
@@ -184,7 +312,7 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 				children?: React.ReactNode;
 			}
 		>;
-		return React.cloneElement(
+		const cloned = React.cloneElement(
 			child,
 			{
 				"data-active": active ? "true" : "false",
@@ -194,21 +322,22 @@ const SidebarItem = ({ icon, children, asChild, active }: SidebarItemProps) => {
 				},
 			},
 			iconEl,
-			child.props.children,
+			collapsed ? null : child.props.children,
 			activeTab,
 		);
+		return wrapTooltip(cloned);
 	}
 
-	return (
+	return wrapTooltip(
 		<Box
 			data-testid="sidebar-item"
 			data-active={active ? "true" : "false"}
 			style={itemStyle}
 		>
 			{iconEl}
-			{children}
+			{!collapsed && children}
 			{activeTab}
-		</Box>
+		</Box>,
 	);
 };
 SidebarItem.displayName = "Sidebar.Item";
@@ -220,6 +349,7 @@ export interface SidebarUserMenuProps {
 }
 
 const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
+	const { collapsed } = useSidebarContext();
 	const initials = (user.name ?? user.email ?? "")
 		.split(/\s+/)
 		.slice(0, 2)
@@ -234,10 +364,10 @@ const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
 					variant="ghost"
 					size="md"
 					w="full"
-					justifyContent="flex-start"
+					justifyContent={collapsed ? "center" : "flex-start"}
 					px="2"
 				>
-					<Flex align="center" gap="2" w="full">
+					<Flex align="center" gap="2" w={collapsed ? "auto" : "full"}>
 						<Flex
 							align="center"
 							justify="center"
@@ -252,21 +382,23 @@ const SidebarUserMenu = ({ user, children }: SidebarUserMenuProps) => {
 						>
 							{initials || "?"}
 						</Flex>
-						<Box textAlign="start" flex="1" minW="0">
-							<Text
-								fontSize="sm"
-								fontWeight="medium"
-								color="default"
-								lineClamp={1}
-							>
-								{user.name ?? user.email}
-							</Text>
-							{user.email && user.name && (
-								<Text fontSize="xs" color="muted" lineClamp={1}>
-									{user.email}
+						{!collapsed && (
+							<Box textAlign="start" flex="1" minW="0">
+								<Text
+									fontSize="sm"
+									fontWeight="medium"
+									color="default"
+									lineClamp={1}
+								>
+									{user.name ?? user.email}
 								</Text>
-							)}
-						</Box>
+								{user.email && user.name && (
+									<Text fontSize="xs" color="muted" lineClamp={1}>
+										{user.email}
+									</Text>
+								)}
+							</Box>
+						)}
 					</Flex>
 				</Button>
 			</MenuTrigger>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 // src/components/sidebar/sidebar.tsx
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Button, IconButton } from "../../atoms/button";
 import { Box, Flex } from "../../primitives/layout";
 import {
@@ -277,22 +278,22 @@ const SidebarItem = ({
 	// Right-tab indicator on active items, matching the design handoff
 	// (3px × 14px primary.700 pill at the trailing edge of the row).
 	// Hidden when collapsed (no room).
-	const activeTab = active && !collapsed ? (
-		<span
-			aria-hidden="true"
-			style={{
-				width: 3,
-				height: 14,
-				background: "var(--chakra-colors-primary-700)",
-				borderRadius: 999,
-				flexShrink: 0,
-				marginInlineStart: "auto",
-			}}
-		/>
-	) : null;
+	const activeTab =
+		active && !collapsed ? (
+			<span
+				aria-hidden="true"
+				style={{
+					width: 3,
+					height: 14,
+					background: "var(--chakra-colors-primary-700)",
+					borderRadius: 999,
+					flexShrink: 0,
+					marginInlineStart: "auto",
+				}}
+			/>
+		) : null;
 
-	const tooltipLabel =
-		label || (typeof children === "string" ? children : "");
+	const tooltipLabel = label || (typeof children === "string" ? children : "");
 
 	const wrapTooltip = (node: React.ReactElement) =>
 		collapsed && tooltipLabel ? (


### PR DESCRIPTION
Adds a 64px icon-rail collapsed mode to <Sidebar>, mirroring <ContextRail>'s API (storageKey, viewport-aware default, persistence). Subcomponents adapt: Logo → first letter, Section → label hidden, Item → icon-only with tooltip, UserMenu → avatar-only. New useSidebarContext hook for consumer-owned children. Bumps to 1.8.0.