### PR TITLE
fix(sidebar): collapse toggle inline with Logo (no separate row)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.8.1] — 2026-05-04
+
+### Fixed
+
+- `<Sidebar>` collapse toggle now sits inline with `<Sidebar.Logo>` instead of in a separate row above it. Expanded: logo left, toggle right (same row). Collapsed: logo "O" top, toggle below (stacked). Cleaner header chrome.
+
 ## [1.8.0] — 2026-05-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -335,6 +335,9 @@ describe("Sidebar", () => {
 		});
 		renderWithChakra(
 			<Sidebar storageKey="test.sidebar.toggle">
+				<Sidebar.Header>
+					<Sidebar.Logo wordmark="Odon" />
+				</Sidebar.Header>
 				<Sidebar.Body>body</Sidebar.Body>
 			</Sidebar>,
 		);

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -91,21 +91,6 @@ const SidebarRoot = ({
 				overflow="hidden"
 				position="relative"
 			>
-				<Flex justify="flex-end" px="2" pt="2">
-					<IconButton
-						data-testid="sidebar-toggle"
-						aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-						variant="ghost"
-						size="sm"
-						onClick={() => setCollapsed((c) => !c)}
-					>
-						{collapsed ? (
-							<PanelLeftOpen size={16} />
-						) : (
-							<PanelLeftClose size={16} />
-						)}
-					</IconButton>
-				</Flex>
 				{children}
 			</Flex>
 		</SidebarContext.Provider>
@@ -142,10 +127,23 @@ export interface SidebarLogoProps {
 }
 
 const SidebarLogo = ({ wordmark, subtitle }: SidebarLogoProps) => {
-	const { collapsed } = useSidebarContext();
+	const { collapsed, toggle } = useSidebarContext();
+
+	const toggleButton = (
+		<IconButton
+			data-testid="sidebar-toggle"
+			aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+			variant="ghost"
+			size="sm"
+			onClick={toggle}
+		>
+			{collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
+		</IconButton>
+	);
+
 	if (collapsed) {
 		return (
-			<Box>
+			<Flex direction="column" align="center" gap="2">
 				<Heading
 					as="span"
 					fontSize="lg"
@@ -155,33 +153,44 @@ const SidebarLogo = ({ wordmark, subtitle }: SidebarLogoProps) => {
 				>
 					{wordmark.charAt(0)}
 				</Heading>
-			</Box>
+				{toggleButton}
+			</Flex>
 		);
 	}
+
 	return (
-		<Box mb={subtitle ? "3" : "0"}>
-			<Heading
-				as="span"
-				fontSize="lg"
-				fontWeight="bold"
-				color="primary.700"
-				letterSpacing="tight"
-			>
-				{wordmark}
-			</Heading>
-			{subtitle && (
-				<Text
-					fontSize="2xs"
-					fontWeight="semibold"
-					letterSpacing="wider"
-					textTransform="uppercase"
-					color="muted"
-					mt="0.5"
+		<Flex
+			direction="row"
+			align="center"
+			justify="space-between"
+			gap="2"
+			w="full"
+		>
+			<Box mb={subtitle ? "0" : "0"}>
+				<Heading
+					as="span"
+					fontSize="lg"
+					fontWeight="bold"
+					color="primary.700"
+					letterSpacing="tight"
 				>
-					{subtitle}
-				</Text>
-			)}
-		</Box>
+					{wordmark}
+				</Heading>
+				{subtitle && (
+					<Text
+						fontSize="2xs"
+						fontWeight="semibold"
+						letterSpacing="wider"
+						textTransform="uppercase"
+						color="muted"
+						mt="0.5"
+					>
+						{subtitle}
+					</Text>
+				)}
+			</Box>
+			{toggleButton}
+		</Flex>
 	);
 };
 SidebarLogo.displayName = "Sidebar.Logo";


### PR DESCRIPTION
Moves the sidebar collapse toggle from a standalone row into `<Sidebar.Logo>`. Expanded: logo + toggle on one row. Collapsed: logo letter + toggle stacked vertically. Bumps to 1.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)