### PR TITLE
feat(templates): page patterns + @knkcs/anker/templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.0] — 2026-05-05
+
+### Added
+
+- **`@knkcs/anker/templates`** — new entrypoint that ships the canonical page-level layouts every knkCMS solution should use:
+  - `<AppShell>` — sidebar / main / rail composition with built-in slot store. Exposes `usePageActions(node)` and `usePageRail(node)` hooks that any descendant can call to register content into the page chrome. The slot store uses `useSyncExternalStore` so producers and consumers stay decoupled across React commit boundaries (no flicker on route changes).
+  - `<IndexPageTemplate>` — list pages: PageHeader + optional Tabs + Toolbar + flush body.
+  - `<DetailPageTemplate>` — single-entity pages: PageHeader + optional Tabs + padded body. `flush` prop available for full-bleed bodies.
+  - `<SettingsPageTemplate>` — tabbed settings pages: PageHeader + Tabs (required) + readability-constrained body (`maxBodyWidth="3xl"` by default).
+  - `<DashboardPageTemplate>` — widget-grid overview pages: PageHeader + 12-column responsive grid.
+  - `<AuthPageTemplate>` — pre-auth screens: thin wrapper around `<AuthCard>`, surfaced under templates so consumers have one entry point.
+  - `<MarketingPageTemplate>` — full-bleed landing-page chrome with hero + features + footer.
+  - `<ErrorPage>` — 404 / 500 / 403 / generic failures.
+  - `<LoadingPage>` — initial app-boot loading screen.
+  - `<MaintenancePage>` — service-down screens with optional ETA.
+- **`docs/page-patterns.md`** — comprehensive page-pattern specification (~1500 lines). Defines app-shell composition, sidebar IA, rail variants, PageHeader and Toolbar anatomy, modal patterns, form patterns, empty/loading/error states, the full template catalog (with composition diagrams, slot tables, escape hatches, authoring rules), and the slot-mechanism rationale. Source-of-truth contract for solution authors.
+- **README "Setup for consumers"** — comprehensive section covering install, provider tree, fonts (Inter Tight + JetBrains Mono), theme customization via `createAnkerTheme(preset)`, the `@`-import for `CLAUDE-ANKER.md`, opt-out paths for sidebar / dark mode / confirm modal / i18n, and a hello-world example wiring AppShell + IndexPageTemplate.
+- **`CLAUDE-ANKER.md` "Page templates" section** — lists the available templates and the rule "Use templates before composing primitives". Adds `@knkcs/anker/templates` to the Pointers list.
+- **`docs/design-system.md` cross-reference** — references section now points to `page-patterns.md` for layout/template patterns.
+
+### Build
+
+- `tsup.config.ts` and `package.json` `exports` field gain a `./templates` entry. The `check-chakra-imports` script now scans `src/templates` to enforce the same Chakra-import discipline used elsewhere.
+
 ## [1.8.1] — 2026-05-04
 
 ### Fixed

--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -65,10 +65,36 @@ The full human-facing spec lives at the anker GitHub Pages docs site (linked fro
 
 ---
 
+## Page templates
+
+anker ships canonical page-level templates under `@knkcs/anker/templates`. **Use templates before composing primitives manually.** They guarantee visual parity across knkCMS solutions — module federation will assemble multiple solutions into one browser frame, and inconsistent page chrome will look broken.
+
+Available templates:
+
+| Template | Use for |
+|---|---|
+| `<AppShell>` | Authenticated chrome (sidebar · main · rail). Provides `usePageActions(node)` and `usePageRail(node)` hooks. |
+| `<IndexPageTemplate>` | List pages — header + optional tabs + toolbar + DataTable |
+| `<DetailPageTemplate>` | Single-entity pages — header + optional tabs + body |
+| `<SettingsPageTemplate>` | Tabbed settings pages with form Cards |
+| `<DashboardPageTemplate>` | Widget-grid overview pages |
+| `<AuthPageTemplate>` | Login, register, MFA, verify — centered card, no shell |
+| `<MarketingPageTemplate>` | Unauthenticated landing pages |
+| `<ErrorPage>` | 404 / 500 / 403 |
+| `<LoadingPage>` | Initial app boot |
+| `<MaintenancePage>` | Service-down screens |
+
+**Rule:** if a template doesn't fit your page, file an issue — don't reinvent the layout.
+
+Full spec with composition diagrams, slot tables, and authoring rules: `docs/page-patterns.md` in the anker repo (linked from the GitHub Pages docs site).
+
+---
+
 ## Pointers
 
-- Full spec: anker GitHub Pages docs site (`/design-system`)
+- Full spec: anker GitHub Pages docs site (`/design-system`, `/page-patterns`)
 - Components: `node_modules/@knkcs/anker/dist/{primitives,components,atoms,forms,feedback}`
+- Templates: `import { AppShell, IndexPageTemplate, … } from "@knkcs/anker/templates"`
 - Theme entry: `import system from "@knkcs/anker/theme"`
 - Provider entry: `import { Provider } from "@knkcs/anker/primitives"`
 - Anker development rules (for working *on* anker, not consuming it): `node_modules/@knkcs/anker/CLAUDE.md` is **not** included in the package; see the anker GitHub repo

--- a/README.md
+++ b/README.md
@@ -10,29 +10,180 @@ The UI component library for the knk software group. Provides a shared design sy
 - Lucide React (icons)
 - Storybook (documentation)
 
-## Installation
+## Setup for consumers
+
+This is the canonical setup for any knkCMS solution adopting `@knkcs/anker`. Follow it in order — the rest of the README assumes you've done these steps.
+
+### 1. Install
 
 ```bash
 npm install @knkcs/anker
 ```
 
-## Usage
+Install the peer dependencies (your project may already have them):
+
+```bash
+npm install react react-dom @chakra-ui/react react-hook-form @hookform/resolvers zod react-router-dom react-i18next next-themes lucide-react
+```
+
+`next-themes` powers light/dark mode. `lucide-react` provides icons (anker uses lucide exclusively — never FontAwesome).
+
+### 2. Provider tree
+
+Mount providers at the root of the React tree:
 
 ```tsx
 import { Provider } from "@knkcs/anker/primitives";
+import { ConfirmModalProvider } from "@knkcs/anker/feedback";
+import { I18nextProvider } from "react-i18next";
+import i18n from "./i18n";
 
-function App() {
+export function Root({ children }) {
   return (
     <Provider>
-      <YourApp />
+      <I18nextProvider i18n={i18n}>
+        <ConfirmModalProvider>
+          {children}
+        </ConfirmModalProvider>
+      </I18nextProvider>
     </Provider>
   );
 }
 ```
 
-The `Provider` defaults to anker's theme system. To override with a custom system, pass it via the `system` prop.
+- `<Provider>` from `@knkcs/anker/primitives` mounts Chakra UI v3 with anker's theme system and wires up `next-themes` for light/dark mode.
+- `<ConfirmModalProvider>` from `@knkcs/anker/feedback` enables `useConfirmModal()` for destructive-action confirmations.
+- `<I18nextProvider>` is the consumer's choice — anker doesn't ship i18n. All anker user-facing strings are props with English defaults; consumers translate them at call sites.
 
-### Imports by layer
+### 3. Fonts
+
+anker's theme assumes **Inter Tight** (UI) and **JetBrains Mono** (code, IDs, API keys). Load both via Google Fonts in your HTML:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+  rel="stylesheet"
+>
+```
+
+The theme falls back to `system-ui` and `ui-monospace` if the fonts aren't loaded, but the visual character of anker depends on Inter Tight — install it.
+
+### 4. Theme
+
+anker exports a default theme system that needs no configuration:
+
+```tsx
+import system from "@knkcs/anker/theme";
+import { Provider } from "@knkcs/anker/primitives";
+
+<Provider system={system}>{children}</Provider>
+// or simply (uses the default automatically):
+<Provider>{children}</Provider>
+```
+
+To customize tokens (fonts, radii, brand colors), use `createAnkerTheme(preset)`:
+
+```tsx
+import { createAnkerTheme, type ThemePreset } from "@knkcs/anker/theme";
+import { Provider } from "@knkcs/anker/primitives";
+
+const editorial: ThemePreset = {
+  name: "editorial",
+  fonts: { heading: "Georgia, serif" },
+  radii: { sm: "0", md: "0", lg: "0", xl: "0", "2xl": "0" },
+};
+
+<Provider system={createAnkerTheme(editorial)}>{children}</Provider>
+```
+
+Presets override token layers (colors, semanticTokens, textStyles, fonts, radii, durations, easings) while preserving every component recipe and structural default. See `docs/design-system.md` for the full preset reference.
+
+### 5. CLAUDE-ANKER.md (Claude Code consumers)
+
+If your project uses Claude Code, `@`-import anker's design-system rules into your root `CLAUDE.md`:
+
+```
+@node_modules/@knkcs/anker/CLAUDE-ANKER.md
+```
+
+Claude will then follow anker's design principles, token rules, page templates, and component conventions when assisting with your code. The file is included in the npm tarball (no separate install).
+
+### 6. Disabling parts of the system
+
+You can opt out of anker subsystems if you don't need them:
+
+- **Opt out of the sidebar / app shell** — use `<AuthPageTemplate>`, `<MarketingPageTemplate>`, or `<ErrorPage>` from `@knkcs/anker/templates`. They render no sidebar at all.
+- **Opt out of the rail column** — pass `rail={null}` (or omit) to `<AppShell>`. The grid drops to two columns and the main column expands.
+- **Opt out of dark mode** — don't wire `next-themes`. anker's tokens are defined for both modes, but if you never toggle the mode, only light renders.
+- **Opt out of the confirm modal** — don't mount `<ConfirmModalProvider>`. This is only safe if your code never calls `useConfirmModal()` and you don't use any anker components that depend on it (currently none do — it's a consumer-only API).
+- **Opt out of i18n** — use anker components without wrapping them in `<I18nextProvider>`. They'll fall back to English defaults.
+
+### 7. Hello world
+
+Minimal consumer app — sidebar, page-header, table.
+
+```tsx
+import { Provider } from "@knkcs/anker/primitives";
+import { ConfirmModalProvider } from "@knkcs/anker/feedback";
+import {
+  AppShell,
+  IndexPageTemplate,
+} from "@knkcs/anker/templates";
+import { Sidebar, Toolbar } from "@knkcs/anker/components";
+import { Button } from "@knkcs/anker/atoms";
+import { Users, Plus } from "lucide-react";
+
+function App() {
+  return (
+    <Provider>
+      <ConfirmModalProvider>
+        <AppShell
+          sidebar={
+            <Sidebar storageKey="myapp-sidebar">
+              <Sidebar.Header>
+                <Sidebar.Logo wordmark="MyApp" />
+              </Sidebar.Header>
+              <Sidebar.Body>
+                <Sidebar.Section label="Identity">
+                  <Sidebar.Item icon={<Users size={16} />} active>
+                    Users
+                  </Sidebar.Item>
+                </Sidebar.Section>
+              </Sidebar.Body>
+            </Sidebar>
+          }
+        >
+          <IndexPageTemplate
+            title="Users"
+            subtitle="People with access to this workspace."
+            actions={
+              <Button colorPalette="primary" size="sm">
+                <Plus size={14} /> Add user
+              </Button>
+            }
+            toolbar={
+              <Toolbar>
+                <Toolbar.Search placeholder="Search…" value="" onChange={() => {}} />
+                <Toolbar.Right>
+                  <Toolbar.Count>0 users</Toolbar.Count>
+                </Toolbar.Right>
+              </Toolbar>
+            }
+          >
+            {/* DataTable goes here */}
+          </IndexPageTemplate>
+        </AppShell>
+      </ConfirmModalProvider>
+    </Provider>
+  );
+}
+```
+
+This is the canonical wiring. Every list page in every knkCMS solution looks like this — that's the contract.
+
+## Imports by layer
 
 ```tsx
 // Design tokens and Chakra system
@@ -52,17 +203,10 @@ import { InputField, ArrayField, FormField } from "@knkcs/anker/forms";
 
 // Feedback patterns (confirm modal)
 import { ConfirmModalProvider, useConfirmModal } from "@knkcs/anker/feedback";
+
+// Page-level templates (AppShell, IndexPageTemplate, …)
+import { AppShell, IndexPageTemplate, DetailPageTemplate } from "@knkcs/anker/templates";
 ```
-
-## Using with Claude Code
-
-If your consumer project uses Claude Code, add this line to your root `CLAUDE.md` to import anker's design-system rules automatically:
-
-```
-@node_modules/@knkcs/anker/CLAUDE-ANKER.md
-```
-
-Claude will then follow anker's design principles, token rules, and component conventions when assisting with your code.
 
 ## Brand Colors
 
@@ -95,19 +239,7 @@ The UI primary anchor (`primary.700` = `#134788`) is intentionally one step ligh
 
 ## Font
 
-The theme uses [Inter](https://rsms.me/inter/) as its primary typeface. Install the variable font in your app:
-
-```bash
-npm install @fontsource-variable/inter
-```
-
-Then import it in your app entry point:
-
-```tsx
-import "@fontsource-variable/inter";
-```
-
-If Inter is not installed, the theme gracefully falls back to the system font stack (`-apple-system, system-ui, sans-serif`).
+The theme uses **Inter Tight** (UI) and **JetBrains Mono** (code, IDs, API keys). See the "Setup for consumers → Fonts" section above for installation instructions. The theme falls back to `system-ui` and `ui-monospace` if the fonts aren't loaded, but Inter Tight is the visual character anker is designed around — install it.
 
 ## Accessibility
 
@@ -134,6 +266,12 @@ npm run typecheck    # tsc --noEmit
 ## Documentation
 
 Interactive component docs are available at [https://knkcs.github.io/anker/](https://knkcs.github.io/anker/)
+
+Reference documents in this repo:
+
+- [`docs/design-system.md`](docs/design-system.md) — visual language: tokens, typography, motion. Read first.
+- [`docs/page-patterns.md`](docs/page-patterns.md) — page-level contract: app shell, templates, slot mechanism, authoring rules.
+- [`CLAUDE-ANKER.md`](CLAUDE-ANKER.md) — design-system rules consumers `@`-import into their `CLAUDE.md`.
 
 ## License
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -287,6 +287,7 @@ Consumers can build a customized system via `createAnkerTheme(preset)`. The pres
 - knk Brand Guidelines (October 2021) — print/InDesign source
 - `docs/chakra-v3-reference.md` — v3 patterns this repo enforces
 - `docs/react-table-reference.md` — TanStack Table patterns
+- **`docs/page-patterns.md`** — see for layout/template patterns (AppShell, IndexPageTemplate, etc.). This document defines the visual language; `page-patterns.md` defines the page-level contract on top of it.
 - `CLAUDE.md` — anker development rules
 - `CLAUDE-ANKER.md` — design-system rules for AI-assisted consumers
 

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -1,0 +1,1311 @@
+# anker Page Patterns
+
+**Version:** 1.x
+**Status:** Active — source-of-truth contract for knkCMS solutions
+**Last updated:** May 2026
+
+---
+
+## 1. About this document
+
+This document is the page-level companion to `docs/design-system.md`. Where
+the design-system spec defines the visual language (tokens, typography,
+shadows, motion), this spec defines the **page-level contract**: how a knkCMS
+page is composed, where the chrome lives, what slots exist, and which template
+to reach for in any given situation.
+
+**Audience.** Developers building knkCMS solutions (Odon, Core, Template,
+Aufgabenmanagement, Media Asset System, …). The patterns here are normative
+— solutions that diverge will look out of place inside the platform shell,
+especially once module federation lands and multiple solutions render side
+by side in a single browser frame.
+
+**Status.** The 1.x conventions are stable. Templates are additive — new
+templates may be added as new page types are discovered, but existing
+templates will not change their slot contract within a 1.x line. Major
+contract changes ride a major version.
+
+**Relationship to other docs.**
+
+- [`docs/design-system.md`](./design-system.md) — token system, typography,
+  spacing, motion. Read first.
+- [`CLAUDE-ANKER.md`](../CLAUDE-ANKER.md) — design-system rules consumers
+  `@`-import into their `CLAUDE.md`. Includes a short "Page templates"
+  section that points back here.
+- [`docs/react-table-reference.md`](./react-table-reference.md) —
+  TanStack Table conventions used inside `<DataTable>`.
+- [`README.md`](../README.md) — consumer-facing entry point with the
+  "Setup for consumers" section.
+
+---
+
+## 2. App shell
+
+The **app shell** is the outermost authenticated chrome of every knkCMS
+solution. It is composed of three columns — sidebar, main, rail — assembled
+by the `<AppShell>` template:
+
+```
+┌────────────┬─────────────────────────────────────┬────────────┐
+│            │                                     │            │
+│  Sidebar   │            Main content             │ ContextRail│
+│   240px    │              (fluid)                │   320px    │
+│ ↔ 60px     │                                     │  ↔ 44px    │
+│ collapsed  │                                     │ collapsed  │
+│            │                                     │            │
+└────────────┴─────────────────────────────────────┴────────────┘
+```
+
+### Dimensions
+
+| Element       | Expanded width | Collapsed width | Collapse breakpoint |
+|---------------|----------------|-----------------|---------------------|
+| `<Sidebar>`   | 240px          | 60px (icon rail) | < 1440px viewport  |
+| `<ContextRail>` | 320px        | 44px (icon-only) | < 1440px viewport  |
+| Main column   | fluid (`1fr`) | —                | —                   |
+
+Both side columns persist their collapsed state to `localStorage` via the
+`storageKey` prop (e.g. `storageKey="odon-sidebar-collapsed"`). On first
+visit at viewport width < 1440px both columns start collapsed; otherwise
+they start expanded.
+
+### Responsive behavior
+
+The shell does **not** auto-rearrange below 768px (mobile is out of scope
+for the 1.x knkCMS surface — these are power-user web tools). On tablet
+viewports (768–1439px) both columns default to collapsed. On desktop
+(≥ 1440px) both default to expanded.
+
+### Slot mechanism
+
+`<AppShell>` installs a slot store on its descendants via React context.
+Two named slots are exposed:
+
+- **`actions`** — registered via `usePageActions(content)`. Surfaced by
+  the active page template inside its `<PageHeader>` `actions` slot.
+- **`rail`**    — registered via `usePageRail(content)`. Surfaced as the
+  body of the right rail column.
+
+The store uses `useSyncExternalStore` so that producers (deep child
+components rendered after the consumer) and consumers (AppShell, the page
+templates) stay decoupled across React commit boundaries. See
+[Section 12](#12-slot-mechanism) for full details and rationale.
+
+### Composition example
+
+```tsx
+import { AppShell } from "@knkcs/anker/templates";
+import { Sidebar, ContextRail } from "@knkcs/anker/components";
+
+export default function Layout({ children }) {
+  return (
+    <AppShell
+      sidebar={<MyAppSidebar />}
+      rail={<ContextRail storageKey="myapp-rail" />}
+    >
+      {children}
+    </AppShell>
+  );
+}
+```
+
+If the rail column is omitted entirely (`rail` not passed, or `null`),
+AppShell drops the third grid column and the main column expands to fill
+the freed space. This is the right shape for solutions that don't have a
+contextual side panel.
+
+---
+
+## 3. Sidebar IA
+
+The sidebar is the global navigation surface. It is the first thing users
+see on every page and the only navigation surface that is always visible
+in the chrome.
+
+### Section anatomy
+
+A sidebar is composed of:
+
+1. **`<Sidebar.Header>`** — fixed-height header band. Contains
+   `<Sidebar.Logo>` (wordmark + optional subtitle + collapse toggle).
+2. **`<Sidebar.Body>`** — scrolling section list. Contains zero or more
+   `<Sidebar.Section>`s, each of which contains zero or more
+   `<Sidebar.Item>`s.
+3. **`<Sidebar.Footer>`** — fixed-height footer band. Typically holds
+   `<Sidebar.UserMenu>`.
+
+### `<Sidebar.Section>` structure
+
+Each section has a single `label` prop (uppercased, muted overline) plus
+its children. Sections render their label only in the expanded state —
+when collapsed, the label is hidden and items become icon-only with
+hover tooltips.
+
+```tsx
+<Sidebar.Section label="Identity">
+  <Sidebar.Item icon={<Users size={16} />} active>Users</Sidebar.Item>
+  <Sidebar.Item icon={<Building2 size={16} />}>Organizations</Sidebar.Item>
+</Sidebar.Section>
+```
+
+### `<Sidebar.Item>` structure
+
+An item is a row with an optional leading icon, a label (its `children`),
+and an active-state style. Items integrate with React Router via the
+`asChild` prop:
+
+```tsx
+<Sidebar.Item asChild active={isActive} icon={<Users size={16} />}>
+  <NavLink to="/users">Users</NavLink>
+</Sidebar.Item>
+```
+
+The `active` state renders the row with a `bg-surface` background, a 1px
+inset border, a subtle drop shadow, and a 3px × 14px `primary.700` pill
+on the trailing edge. When the sidebar is collapsed, the active state
+keeps the background and border but drops the trailing pill (no room).
+
+### When sections appear vs. when they're empty
+
+- **Show a section** when it has at least one item visible to the current
+  user. Empty sections must not be rendered — a section header with no
+  items is visual noise.
+- **Show all sections** when none are user-context-dependent. If a
+  section's visibility depends on permissions, render the whole section
+  conditionally.
+
+### Footer
+
+The footer is reserved for `<Sidebar.UserMenu>` (account avatar +
+dropdown with personal-settings, theme toggle, sign-out). Solutions may
+add product-specific items above the user menu (e.g. a "Help" link) by
+nesting them inside `<Sidebar.Footer>` above `<Sidebar.UserMenu>`.
+
+The collapse-toggle lives **inside** `<Sidebar.Logo>`, not in the footer.
+This was a deliberate move in 1.8.1 — putting the toggle in the header
+keeps the footer pure user-action territory.
+
+### Sub-section pattern: "Personal / Organization / Identity / Admin"
+
+Larger solutions group their navigation into thematic sub-sections.
+Odon's Settings sidebar uses this pattern:
+
+```
+PERSONAL
+  Profile
+  Password
+  Sessions
+
+ORGANIZATION
+  Members
+  Settings
+
+IDENTITY
+  OAuth Clients
+  API Keys
+
+ADMIN
+  Users
+  Audit Log
+```
+
+Each sub-section is a separate `<Sidebar.Section>` with its own `label`.
+The order is: most-personal first, most-administrative last. This
+matches the user's likely path of investigation when looking for a
+setting.
+
+---
+
+## 4. ContextRail patterns
+
+The context rail is the **right column** of the app shell — a fixed-width
+secondary surface for at-a-glance information that supports the main
+content without being part of it.
+
+### When to render
+
+Render a rail when a page benefits from showing "what" or "how many" of
+the things shown in the main content, without making the user scroll.
+Indicators that a rail belongs:
+
+- A list page with > 50 items (rail shows aggregate stats / filters).
+- A detail page with related entities (rail shows links to siblings,
+  parent records, audit summary).
+- A page where bulk-selection is a primary action (rail substitutes for
+  the bulk-action bar — see below).
+
+### When to hide
+
+- The page is one screen of content (no scroll). The rail would be empty
+  air.
+- The page is a form or settings tab. Rails compete with form fields for
+  the user's attention; settings should be read top-to-bottom.
+- The page is a dashboard. Dashboards already aggregate — a rail is
+  redundant.
+- The page is unauthenticated (auth, marketing, error). These templates
+  don't have a shell.
+
+### The three rail variants
+
+#### 4.1 Overview / stats rail (default)
+
+Used on most index and detail pages. Renders a small set of
+`<ContextRail.Section>`s with aggregate stats, recent activity, or
+filter shortcuts.
+
+```tsx
+<ContextRail storageKey="users-rail">
+  <ContextRail.Header eyebrow="OVERVIEW" title="Users" />
+  <ContextRail.Section id="stats" label="Stats">
+    <DataList items={[
+      { label: "Total", value: "1,284" },
+      { label: "Active (30d)", value: "1,108" },
+    ]} />
+  </ContextRail.Section>
+</ContextRail>
+```
+
+#### 4.2 Detail-context rail
+
+Used on detail pages. Shows the entity's relationships and metadata
+(parent record, sibling records, audit-log shortcut).
+
+```tsx
+<ContextRail>
+  <ContextRail.Header eyebrow="USER" title="Jana Schmid" />
+  <ContextRail.Section id="meta" label="Metadata">
+    <DataList items={[
+      { label: "Created", value: <RelativeDateTime value={createdAt} /> },
+      { label: "Last sign-in", value: <RelativeDateTime value={lastSignIn} /> },
+    ]} />
+  </ContextRail.Section>
+  <ContextRail.Section id="related" label="Related">
+    <Link href="/users/jana/sessions">Active sessions →</Link>
+  </ContextRail.Section>
+</ContextRail>
+```
+
+#### 4.3 Bulk-selection rail
+
+When the user enters a bulk-selection mode (selects ≥ 1 row in a
+`<DataTable>` with `selectable`), the rail is substituted for a
+`<BulkActionBar>`-style summary: count + actions. The page swaps the
+rail content via `usePageRail(<BulkActionBar … />)` for the duration of
+the selection.
+
+This is the canonical knkCMS pattern. It replaces the floating
+bottom-of-screen action bar that is common in other UIs — pinning bulk
+actions to the rail keeps them in a predictable place and avoids
+covering the table.
+
+### Collapsed state
+
+When the rail is collapsed, only a thin 44px column with the
+expand-toggle remains. Section content is hidden. Tooltips on the
+toggle hint at what's hidden.
+
+---
+
+## 5. PageHeader anatomy
+
+`<PageHeader>` is the **per-page header band** rendered at the top of
+every authenticated content area. It is *not* part of the app shell —
+each page renders its own.
+
+### Anatomy
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Identity › Users › Jana Schmid                             │ ← breadcrumbs (optional)
+│                                                            │
+│ Jana Schmid                              [Edit] [Delete]   │ ← title + actions
+│ jana.schmid@knk.de                                         │ ← subtitle (optional)
+└────────────────────────────────────────────────────────────┘
+```
+
+### Slots
+
+| Slot          | Type           | Notes                                                    |
+|---------------|----------------|----------------------------------------------------------|
+| `eyebrow`     | `ReactNode`    | Optional uppercase overline above breadcrumbs            |
+| `breadcrumbs` | `Crumb[]`      | Optional. Each crumb is `{ label, to? }`. Last is current |
+| `title`       | `ReactNode`    | Required. Rendered as `<h1>` 24px semibold default       |
+| `subtitle`    | `ReactNode`    | Optional. 14px muted, mt="1"                             |
+| `actions`     | `ReactNode`    | Optional. Right-aligned button cluster                   |
+
+### Sizing rules
+
+The PageHeader is **always single-band** (one row of vertical space at
+`py="4" px="8"`). When subtitle or breadcrumbs are present, they
+compress into the same band — the row grows vertically but the band
+boundaries don't change.
+
+There is no "two-line" variant. If you need more than what the slots
+support (e.g. an inline status pill next to the title), render it inside
+the `actions` slot or wrap the title:
+
+```tsx
+<PageHeader
+  title={
+    <Flex align="center" gap="2">
+      <span>Jana Schmid</span>
+      <StatusBadge status="success">Active</StatusBadge>
+    </Flex>
+  }
+/>
+```
+
+### Breadcrumb max depth
+
+The recommended max is **4 segments** (workspace › section › list ›
+detail). Beyond that, fold intermediate crumbs into a single
+"… (parent)" item — but most knkCMS hierarchies don't go that deep.
+
+---
+
+## 6. Toolbar anatomy
+
+`<Toolbar>` is the per-page filter strip rendered between the
+`<PageHeader>` (or `<Tabs.List>` if present) and the page body, on list
+pages.
+
+### Anatomy
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ [Search…]  [filter] [filter]            42 items   [Sort] │
+└────────────────────────────────────────────────────────────┘
+   ──Search──  ───Filters───            ─Right─    ─Right─
+```
+
+### Slots
+
+| Subcomponent             | Position | Use                                             |
+|--------------------------|----------|-------------------------------------------------|
+| `<Toolbar.Search>`       | Left     | Free-text search                                |
+| `<Toolbar.Filters>`      | Left     | Container for `<Toolbar.FilterChip>`s, selects  |
+| `<Toolbar.FilterChip>`   | inside Filters | Single chip with active/inactive state    |
+| `<Toolbar.Right>`        | Right    | Container for count + secondary actions         |
+| `<Toolbar.Count>`        | inside Right | "{n} items" muted text                       |
+
+The `<Toolbar>` root is fixed-height (48px) and uses `bg-subtle` so it
+visually separates from the white page body.
+
+### BulkActionBar substitution
+
+When the user selects ≥ 1 row in the page's table, the toolbar should
+**not** persist below the bulk action bar. Solutions can either:
+
+1. Hide the toolbar and replace it with `<BulkActionBar>` in the same
+   slot (what odon does), or
+2. Keep the toolbar visible and float `<BulkActionBar>` at the bottom
+   of the rail / viewport.
+
+Option 1 is the canonical pattern. The page-level escape hatch:
+
+```tsx
+{selectedCount > 0
+  ? <BulkActionBar selectedCount={selectedCount} onClear={…}>…</BulkActionBar>
+  : <Toolbar>…</Toolbar>}
+```
+
+---
+
+## 7. Tab patterns
+
+Tabs are used as the primary navigation device **inside** a page (not as
+the global navigation — that's the sidebar's job).
+
+### Placement
+
+Tabs are rendered:
+
+- **Inside `IndexPageTemplate`**: under the PageHeader, above the
+  Toolbar.
+- **Inside `DetailPageTemplate`**: under the PageHeader, above the
+  page body.
+- **Inside `SettingsPageTemplate`**: under the PageHeader, above the
+  page body. Required (settings pages without tabs use
+  `DetailPageTemplate`).
+
+The `tabs` slot accepts a full `<Tabs.Root>` (with `<Tabs.List>` and
+`<Tabs.Content>`s). The template renders the root inside its layout —
+it does **not** wrap the tabs in any other container.
+
+### Value semantics
+
+Tab values should be URL-friendly slugs (`profile`, `password`, `mfa`)
+that map directly to a route segment. The recommended pattern is to
+mirror the active tab into the URL (`?tab=profile` or
+`/settings/profile`) so deep-links work and the browser back-button
+behaves naturally.
+
+### Content alignment: flush vs. padded
+
+Tab content can be either:
+
+- **Flush** — content extends edge-to-edge of the page body. Use for
+  index-page tabs whose body is a `<DataTable>` (the tables already
+  span full-width).
+- **Padded** — content is wrapped in `<Box px="8" py="6">`. Use for
+  settings-page tabs whose body is form Cards.
+
+The page templates do not apply padding inside the `tabs` slot. The tab
+content's own children determine the padding strategy.
+
+### `<Tabs.Root>` wrapping conventions
+
+The `<Tabs.List>` should always be wrapped in a `<Box px="8">` so the
+tab list aligns with the PageHeader's `px="8"` padding:
+
+```tsx
+<Tabs.Root defaultValue="active" variant="line">
+  <Box px="8">
+    <Tabs.List>
+      <Tabs.Trigger value="active">Active</Tabs.Trigger>
+      <Tabs.Trigger value="invited">Invited</Tabs.Trigger>
+    </Tabs.List>
+  </Box>
+  <Tabs.Content value="active">…</Tabs.Content>
+  <Tabs.Content value="invited">…</Tabs.Content>
+</Tabs.Root>
+```
+
+Use `variant="line"` for content tabs (anker default). Avoid
+`variant="enclosed"` — it competes visually with Cards inside the body.
+
+---
+
+## 8. Modal patterns
+
+Two modal types exist:
+
+- **Form modal** — `<Modal>` with body fields and a save/cancel footer.
+- **Confirm dialog** — `useConfirmModal()` for destructive actions.
+
+### Form modal (`<Modal>`)
+
+Use `<Modal>` for inline create/edit flows where opening a full-page
+form is overkill (e.g. "Add API key", "Invite member").
+
+```tsx
+<Modal
+  open={open}
+  onClose={() => setOpen(false)}
+  header="Invite member"
+  onSave={handleSave}
+  saveLabel="Send invite"
+  loading={pending}
+>
+  <FormField name="email" label="Email">
+    <TextInput />
+  </FormField>
+</Modal>
+```
+
+| Slot          | Role                                              |
+|---------------|---------------------------------------------------|
+| `header`      | Title (string or ReactNode)                       |
+| `children`    | Body — typically `<FormField>`s                   |
+| `footer`      | Footer override. Default: Cancel + Save buttons.   |
+| `onSave`      | Save handler. Required for default footer.         |
+| `saveLabel`, `cancelLabel`, `closeLabel` | Strings, English defaults. |
+
+Modals use `<Dialog.Root size="xl">` by default (~720px wide). Override
+via the `size` prop (`"sm"`, `"md"`, `"lg"`, `"xl"`, `"full"`).
+
+### Confirm dialog (`useConfirmModal`)
+
+Use for destructive actions (delete user, revoke key, sign out
+everywhere). The hook returns a `confirm({…})` function that resolves
+`true`/`false`.
+
+```tsx
+const { confirm } = useConfirmModal();
+
+async function onDelete() {
+  const ok = await confirm({
+    title: "Delete user?",
+    message: "This will revoke their access immediately.",
+    confirmLabel: "Delete",
+    colorPalette: "red",
+  });
+  if (ok) deleteUser(id);
+}
+```
+
+The default `colorPalette` is `"red"` — i.e. confirm dialogs default to
+the destructive treatment. Pass `colorPalette="primary"` to render a
+non-destructive confirmation (rarely needed — non-destructive
+confirmations should usually be skipped).
+
+### Save/cancel labels
+
+- **Save labels**: prefer the action verb, not "Save". E.g. "Send
+  invite", "Revoke key", "Suspend user". "Save" is acceptable for plain
+  edit-modals.
+- **Cancel labels**: always "Cancel" (not "Discard", "Close", "No").
+
+### Destructive treatment
+
+Destructive actions (delete, revoke, suspend) **must** use
+`colorPalette="red"` on the confirm/save button. This is the only
+place red is allowed in the UI.
+
+---
+
+## 9. Form patterns
+
+### Layout
+
+A form field row is composed by `<FormField>`:
+
+```
+Label                                                       (required *)
+┌──────────────────────────────────────────────────────────────┐
+│ Input                                                        │
+└──────────────────────────────────────────────────────────────┘
+Help text                                                       Error text
+```
+
+Use `<InputField>`, `<TextareaField>`, `<DatePickerField>`, etc. from
+`@knkcs/anker/forms` — they wrap React Hook Form's `Controller` and
+attach `aria-describedby` automatically.
+
+### Required vs. optional treatment
+
+- **Required**: append a small `*` after the label, no extra text.
+- **Optional**: append `(optional)` after the label in muted color.
+
+Don't mark some fields required-with-asterisk and others
+optional-with-text in the same form — pick one and stick with it. Forms
+with mostly-required fields use `(optional)` markers; forms with
+mostly-optional fields use `*` on the few that are required.
+
+### Save-button placement
+
+Two patterns:
+
+1. **Card-internal save** — settings tab cards have their save button
+   inside the card footer (`<Card footer={…}>`). Use when the form is
+   one of several independent sections on the page.
+2. **PageHeader actions save** — full-page edit forms have their save
+   button in the PageHeader's `actions` slot. Use when the form is the
+   entire page.
+
+Never both. A PageHeader save + a Card save on the same screen is a UX
+trap (which one persists?).
+
+### Inline edit vs. full-page edit
+
+- **Inline edit (modal)**: small forms, ≤ 6 fields, no nested data.
+  Use `<Modal>`.
+- **Full-page edit (DetailPageTemplate)**: large forms, nested data,
+  dependent fields. Use a separate page rendered by
+  `DetailPageTemplate` with the form Card-wrapped in the body.
+
+---
+
+## 10. Empty / loading / error states
+
+### DataTable empty state
+
+The `<DataTable emptyState={…}>` prop accepts a ReactNode rendered when
+`data.length === 0`. The canonical empty state uses `<EmptyState>`:
+
+```tsx
+<DataTable
+  data={users}
+  columns={columns}
+  emptyState={
+    <EmptyState
+      icon={<Users size={32} />}
+      header="No users yet"
+      description="Invite your first team member to get started."
+      actions={<Button colorPalette="primary">Invite member</Button>}
+    />
+  }
+/>
+```
+
+### Error Alert placement
+
+Inline errors on flush `bg-canvas` pages use `<Alert>` with explicit
+horizontal margin so they don't sit flush against the page edge:
+
+```tsx
+<Alert
+  status="error"
+  title="Failed to load users"
+  mx="8"
+  mt="4"
+>
+  Couldn't reach the server. Try again in a moment.
+</Alert>
+```
+
+For padded pages (settings, dashboard), the alert lives inside the
+already-padded body and doesn't need `mx`.
+
+### Spinner placement
+
+For full-page loading (between tab switches, initial data fetch), use a
+centered spinner inside a `bg-canvas` wrapper:
+
+```tsx
+<Flex align="center" justify="center" minH="40vh" bg="bg-canvas">
+  <Spinner size="lg" color="accent" />
+</Flex>
+```
+
+For initial-app-boot loading (before the AppShell has rendered), use
+the `<LoadingPage>` template.
+
+### 404 / 500 / 403 page layouts
+
+Always use the `<ErrorPage>` template for these. Don't compose
+404/500/403 ad-hoc — the template ensures visual parity across
+solutions and federated views.
+
+---
+
+## 11. Page templates
+
+This section defines every supported page template. Each template
+includes a composition diagram, when-to-use guidance, and escape
+hatches (the deviation rules — when it's acceptable to *not* use the
+template).
+
+The **one rule** every template enforces: **slots accept ReactNode,
+not config objects**. This is deliberate. Slots are escape hatches —
+if the template doesn't fit, you can pass arbitrary content into the
+slot. Config objects would force every variant to be expressible as
+data, and we don't have that crystal ball.
+
+### 11.1 IndexPageTemplate
+
+**When to use.** Any "browse a list" page: users, OAuth clients, audit
+events, API keys, webhooks. The page's main content is a `<DataTable>`
+or list, optionally filtered.
+
+**Composition.**
+
+```
+┌───────────────────────────────────────┐
+│ PageHeader  (breadcrumbs · title)     │
+├───────────────────────────────────────┤
+│ Tabs (optional)                       │
+├───────────────────────────────────────┤
+│ Toolbar  (search · filters · count)   │
+├───────────────────────────────────────┤
+│ children  (DataTable, flush)          │
+└───────────────────────────────────────┘
+```
+
+**Slots.**
+
+| Prop          | Type        | Default | Notes                                                |
+|---------------|-------------|---------|------------------------------------------------------|
+| `breadcrumbs` | `Crumb[]`   | —       | Forwarded to `<PageHeader>`                          |
+| `title`       | `ReactNode` | —       | Required                                             |
+| `subtitle`    | `ReactNode` | —       |                                                      |
+| `eyebrow`     | `ReactNode` | —       | Uppercase overline                                   |
+| `actions`     | `ReactNode` | reads `usePageActions` | Right-aligned in PageHeader               |
+| `tabs`        | `ReactNode` | —       | Optional `<Tabs.Root>` rendered under PageHeader     |
+| `toolbar`     | `ReactNode` | —       | Optional `<Toolbar>` rendered under tabs             |
+| `children`    | `ReactNode` | —       | Page body — DataTable, list, empty/error states      |
+
+**Escape hatches.**
+
+- The body is rendered flush (no padding). If you need a padded body
+  (e.g. a single Card instead of a DataTable), wrap children in
+  `<Box px="8" py="6">`.
+- The toolbar can be omitted entirely — pass `toolbar={null}` (or just
+  omit the prop). Don't fake a toolbar with a `<Box>`.
+
+### 11.2 DetailPageTemplate
+
+**When to use.** Any "single entity" page: a single user, a single
+OAuth client, a single audit event detail, a single webhook config.
+
+**Composition.**
+
+```
+┌───────────────────────────────────────┐
+│ PageHeader  (breadcrumbs · title)     │
+├───────────────────────────────────────┤
+│ Tabs (optional)                       │
+├───────────────────────────────────────┤
+│ children  (identity Card · panes …)   │
+│   px="8" pt="6" by default            │
+└───────────────────────────────────────┘
+```
+
+**Slots.**
+
+| Prop          | Type        | Default | Notes                                                |
+|---------------|-------------|---------|------------------------------------------------------|
+| `breadcrumbs`, `title`, `subtitle`, `eyebrow` | … | … | Same as IndexPageTemplate            |
+| `actions`     | `ReactNode` | reads `usePageActions` | —                                         |
+| `tabs`        | `ReactNode` | —       | Recommended for entities with multiple aspects       |
+| `children`    | `ReactNode` | —       | Body — typically an identity Card + tab content      |
+| `flush`       | `boolean`   | `false` | When `true`, removes the default `px="8" pt="6"`     |
+
+**Escape hatches.**
+
+- `flush={true}` removes the default body padding. Use for code-editor
+  pages or full-bleed media viewers.
+- The identity-Card-then-tabs pattern is a convention, not a
+  requirement. A detail page without tabs is fine — render the body
+  however the entity demands.
+
+### 11.3 SettingsPageTemplate
+
+**When to use.** Any "preferences / configuration" page composed of
+multiple tabbed sections: personal settings (Profile, Password, MFA),
+organization settings, IDP settings, admin → general.
+
+**Composition.**
+
+```
+┌───────────────────────────────────────┐
+│ PageHeader  (breadcrumbs · title)     │
+├───────────────────────────────────────┤
+│ Tabs (required)                       │
+├───────────────────────────────────────┤
+│ children  (Card-wrapped forms · …)    │
+│   max-width 720px (3xl), centered     │
+└───────────────────────────────────────┘
+```
+
+**Slots.**
+
+| Prop          | Type        | Default | Notes                                                |
+|---------------|-------------|---------|------------------------------------------------------|
+| `breadcrumbs`, `title`, `subtitle`, `eyebrow` | … | … |                                          |
+| `actions`     | `ReactNode` | reads `usePageActions` |                                            |
+| `tabs`        | `ReactNode` | —       | **Required**                                         |
+| `children`    | `ReactNode` | —       | Body — typically Card-wrapped forms or DataLists     |
+| `maxBodyWidth` | `string`   | `"3xl"` | `"full"` to disable the constraint                   |
+
+**Escape hatches.**
+
+- `maxBodyWidth="full"` disables the readability constraint. Use when a
+  settings tab needs a full-width DataTable (rare — that's an index
+  page in disguise).
+- A single-tab settings page is a sign you should be using
+  DetailPageTemplate instead. Use SettingsPageTemplate only when there
+  are ≥ 2 tabs.
+
+### 11.4 DashboardPageTemplate
+
+**When to use.** Overview pages composed of a grid of widgets — small
+stat tiles, mini-charts, recent-activity panes. Inspired by Linear's
+"All issues" overview and GitHub's repo insights — calm surfaces,
+dense info, clear hierarchy.
+
+**Composition.**
+
+```
+┌───────────────────────────────────────┐
+│ PageHeader (greeting · range picker)  │
+├───────────────────────────────────────┤
+│ ┌────┬────┬────┬────┐                 │
+│ │stat│stat│stat│stat│                 │
+│ ├────┴────┼────┴────┤                 │
+│ │ widget  │ widget  │                 │
+│ ├─────────┴─────────┤                 │
+│ │   wide widget     │                 │
+│ └───────────────────┘                 │
+└───────────────────────────────────────┘
+```
+
+**Slots.**
+
+| Prop          | Type        | Default | Notes                                                |
+|---------------|-------------|---------|------------------------------------------------------|
+| `breadcrumbs`, `title`, `subtitle`, `eyebrow` | … | … |                                          |
+| `actions`     | `ReactNode` | reads `usePageActions` | Range picker, refresh button              |
+| `children`    | `ReactNode` | —       | Widgets — set `gridColumn` on each child            |
+| `gap`         | `string`    | `"4"`   | Grid gap between widgets                             |
+
+**Escape hatches.**
+
+- The grid is 12 columns. Default per-child span is 12 (full-width).
+  Set `gridColumn="span 3"` for quarter-width tiles, `"span 6"` for
+  half, etc.
+- For non-grid dashboards (e.g. a single timeline), use
+  `DetailPageTemplate` instead — the dashboard chrome implies a grid.
+
+**Authoring rules (dashboards specifically).**
+
+- Stat tiles go on the top row. They answer "is the system healthy?".
+- Charts go in the middle. They answer "how is it trending?".
+- Lists / activity feeds go at the bottom. They answer "what just
+  happened?".
+- Don't mix densities — all top-row stats should be the same column
+  span. Refined minimalism applies more strictly to dashboards because
+  the screen is busy by definition.
+
+### 11.5 AuthPageTemplate
+
+**When to use.** Pre-authentication screens: login, register, MFA
+challenge, forgot/reset password. The user is not signed in, the app
+shell isn't loaded.
+
+**Composition.** Full-bleed centered card on a dot-grid canvas, with
+an optional topbar (logo + locale switcher) and optional footer slot.
+Internally a thin wrapper around the existing `<AuthCard>`.
+
+**Slots.** All the same as `<AuthCard>`:
+
+| Prop            | Type        | Notes                                       |
+|-----------------|-------------|---------------------------------------------|
+| `logo`          | `ReactNode` | Top-left of the topbar                      |
+| `topBarRight`   | `ReactNode` | Top-right (locale switcher, help link)      |
+| `hideTopBar`    | `boolean`   | Hide topbar entirely (rare)                 |
+| `hideBackground`| `boolean`   | Hide dot-grid (printable)                   |
+| `eyebrow`       | `ReactNode` | Small uppercase eyebrow above title         |
+| `title`         | `ReactNode` | Card title                                  |
+| `subtitle`      | `ReactNode` | Subtitle below title                        |
+| `size`          | `"md" \| "lg"` | Card width preset (440px / 480px)        |
+| `footer`        | `ReactNode` | Bottom-bordered footer inside the card      |
+| `children`      | `ReactNode` | Page body                                   |
+
+**Escape hatches.**
+
+- For OAuth consent screens, prefer `<AuthPageTemplate size="lg">`
+  with a denser layout — see 11.7.
+- For email-verification "we sent a link" screens, use the same
+  template with a single action button as `children`.
+
+### 11.6 Verify / Confirm page
+
+**When to use.** Email verification, account-deletion confirmation,
+"check your inbox" callouts. These pages have copy + a single CTA, no
+form.
+
+**Composition.** Use `AuthPageTemplate`:
+
+```tsx
+<AuthPageTemplate
+  logo={<Logo />}
+  eyebrow="VERIFY EMAIL"
+  title="Check your inbox"
+  subtitle="We sent a verification link to jana@knk.de."
+>
+  <Button colorPalette="primary" variant="outline" w="full">
+    Resend email
+  </Button>
+</AuthPageTemplate>
+```
+
+There is no separate `<VerifyPageTemplate>` — verify is just a special
+case of auth.
+
+### 11.7 OAuth consent page
+
+**When to use.** Relying-party authorization prompt — "App X wants
+access to your account".
+
+**Composition.** Use `AuthPageTemplate size="lg"` with denser body
+content (no large hero text, just an app-card + scope-list +
+allow/deny buttons).
+
+```tsx
+<AuthPageTemplate size="lg" title="Authorize MyApp">
+  <Persona name="MyApp" /* … */ />
+  <Box my="4">
+    <Text fontSize="sm" fontWeight="medium" mb="2">MyApp will be able to:</Text>
+    <List items={[…scopes]} />
+  </Box>
+  <Flex gap="3" justify="flex-end">
+    <Button variant="outline">Deny</Button>
+    <Button colorPalette="primary">Allow</Button>
+  </Flex>
+</AuthPageTemplate>
+```
+
+The denser `lg` width gives room for the scope list without forcing the
+user to scroll.
+
+### 11.8 Logout / signed-out page
+
+**When to use.** Post-logout landing — confirms sign-out and offers a
+sign-back-in CTA.
+
+**Composition.** `AuthPageTemplate`:
+
+```tsx
+<AuthPageTemplate
+  logo={<Logo />}
+  eyebrow="SIGNED OUT"
+  title="See you next time"
+  subtitle="You've been signed out of all devices."
+>
+  <Button colorPalette="primary" variant="solid" w="full" asChild>
+    <a href="/login">Sign in again</a>
+  </Button>
+</AuthPageTemplate>
+```
+
+### 11.9 MarketingPageTemplate
+
+**When to use.** Unauthenticated marketing surfaces — product
+landing, "about us", coming-soon teasers. Full-bleed, no app shell.
+
+**Composition.**
+
+```
+┌──────────────────────────────────────────┐
+│ topbar (logo · nav · CTA)                │
+├──────────────────────────────────────────┤
+│ hero (eyebrow · title · subtitle · CTAs) │
+├──────────────────────────────────────────┤
+│ children (feature sections, …)           │
+├──────────────────────────────────────────┤
+│ footer (copyright, links)                │
+└──────────────────────────────────────────┘
+```
+
+**Slots.**
+
+| Prop          | Type        | Notes                                                |
+|---------------|-------------|------------------------------------------------------|
+| `logo`        | `ReactNode` | Topbar left                                          |
+| `topBarRight` | `ReactNode` | Topbar right (nav + sign-in CTA)                     |
+| `hideTopBar`  | `boolean`   | Rare                                                 |
+| `heroEyebrow` | `ReactNode` | Uppercase overline above hero title                  |
+| `heroTitle`   | `ReactNode` | Hero headline (large display text)                   |
+| `heroSubtitle`| `ReactNode` | One-paragraph value statement                        |
+| `heroActions` | `ReactNode` | Hero CTAs (typically 1 solid + 1 ghost)              |
+| `heroVisual`  | `ReactNode` | Optional hero illustration on wide viewports         |
+| `children`    | `ReactNode` | Body — feature sections, testimonials, etc.          |
+| `footer`      | `ReactNode` | Footer band                                          |
+
+**Authoring rules (marketing specifically).**
+
+- Anker's principles still apply. Refined minimalism, calm surfaces,
+  brand colors as accents (not full backgrounds). Don't import a
+  Bootstrap-y "hero with gradient overlay" — it will look out of place
+  next to the rest of the platform.
+- One hero per page. No alternating-band designs unless absolutely
+  necessary.
+- Use `secondary.600` (brand orange) at most once on the page (e.g. on
+  the hero CTA, never on body links).
+
+### 11.10 ErrorPage
+
+**When to use.** 404, 500, 403, generic failures.
+Full-bleed, no app shell.
+
+**Composition.** Centered status code + title + description + actions.
+Optional logo top-left, optional illustration above the status code.
+
+**Slots.**
+
+| Prop          | Type        | Notes                                                |
+|---------------|-------------|------------------------------------------------------|
+| `logo`        | `ReactNode` | Top-left brand mark                                  |
+| `statusCode`  | `ReactNode` | Required. "404", "500", "OOPS"                       |
+| `title`       | `ReactNode` | Required. Short headline                             |
+| `description` | `ReactNode` | One-paragraph explanation                            |
+| `actions`     | `ReactNode` | Buttons — back home, retry, contact support          |
+| `illustration`| `ReactNode` | Rendered above the status code. Use sparingly.       |
+
+**Authoring rules.**
+
+- Keep description ≤ 2 sentences. The user is frustrated.
+- Always offer at least one action — "back to dashboard" is the
+  universal default.
+- Don't tell the user "an error has occurred" in the description.
+  Give them a useful next step instead.
+
+### 11.11 LoadingPage
+
+**When to use.** Initial app boot — before the authenticated app
+shell has hydrated. For in-page loading (tab switch, data refresh)
+use a centered `<Spinner>` inside the page body.
+
+**Slots.**
+
+| Prop      | Type        | Notes                                                |
+|-----------|-------------|------------------------------------------------------|
+| `logo`    | `ReactNode` | Optional. Rendered above the spinner.                |
+| `message` | `ReactNode` | Optional. "Loading your workspace…". Keep it short.  |
+
+**Authoring rules.**
+
+- Don't add progress bars unless you can actually report progress.
+  Indeterminate spinners > fake progress.
+- The message is optional and should be omitted if the load is fast
+  (< 500ms). The flash of "Loading…" is worse than the flash of
+  blank.
+
+### 11.12 MaintenancePage
+
+**When to use.** The service is down for upgrade or maintenance.
+Operators serve this from a static asset or fallback handler.
+
+**Slots.**
+
+| Prop          | Type        | Notes                                                |
+|---------------|-------------|------------------------------------------------------|
+| `logo`        | `ReactNode` | Top-left brand mark                                  |
+| `title`       | `ReactNode` | Default: "We'll be right back"                       |
+| `description` | `ReactNode` | Default: "We're upgrading the service. Please refresh in a few minutes." |
+| `eta`         | `ReactNode` | Optional ETA banner ("Estimated back online: 14:30 UTC") |
+| `statusLink`  | `ReactNode` | Link to status page                                  |
+
+**Authoring rules.**
+
+- Always provide an ETA if you have one. Users tolerate downtime
+  much better when they know how long.
+- Never suggest the user "try again later" without giving them a
+  link to a status page or way to check.
+
+---
+
+## 12. Slot mechanism
+
+`<AppShell>` exposes two write-side hooks for descendant components to
+register content into the shell:
+
+- `usePageActions(content: ReactNode)` — registers content into the
+  page-actions slot, surfaced inside the active page template's
+  `<PageHeader actions={…}>`.
+- `usePageRail(content: ReactNode)` — registers content into the rail
+  slot, surfaced as the body of the right rail column.
+
+### How it works
+
+`<AppShell>` creates a slot store on mount and provides it via React
+context. The store keeps the latest registered ReactNode for each
+named slot plus a set of subscriber callbacks. Producers register
+content in a `useEffect`; consumers read content via
+`useSyncExternalStore`. This decouples render-time across React commit
+boundaries.
+
+```tsx
+// Producer (a tab pane component, deep in the tree)
+function UsersListPane() {
+  usePageActions(
+    <Button colorPalette="primary" onClick={openInviteModal}>
+      Invite member
+    </Button>
+  );
+  return <DataTable …/>;
+}
+
+// Consumer (the page template, also deep in the tree)
+function IndexPageTemplate({ actions, …rest }) {
+  const registered = useRegisteredPageActions();
+  const resolvedActions = actions ?? registered;
+  return <PageHeader actions={resolvedActions} {…} />;
+}
+```
+
+### Why an external store (not plain context)
+
+A naive `useState`-based context would force the consumer to render in
+the same React commit as the producer. Because the producer is rendered
+*after* the consumer (the page header is at the top of the tree, the
+button-registering component is deep inside it), the consumer's first
+paint sees `null` and the second paint shows the registered content —
+causing a one-frame flicker on every route change.
+
+The fix (originally shipped in odon as PR #115) is to use an external
+store: the producer pushes the value via a `useEffect`, the store
+notifies subscribers, and the consumer re-reads on the next browser
+frame via `useSyncExternalStore`. React's concurrent renderer is happy,
+the producer and consumer don't need to be in the same commit, and the
+flicker disappears.
+
+This is the **canonical** way to wire cross-cutting page chrome in
+anker. Don't reach for state-management libraries (zustand, jotai) for
+this — the slot store is local to the AppShell instance and doesn't
+need a global namespace.
+
+### When to use slot hooks vs. prop-drilling
+
+Use slot hooks when:
+
+- The content is rendered by a deep descendant (a tab pane, a
+  selection-aware component) and needs to surface in the page chrome.
+- The content depends on per-pane state (e.g. selection count).
+
+Use prop-drilling (the `actions={…}` prop on the template) when:
+
+- The content is rendered by the page-level component itself and is
+  static across the page.
+- The content is conditional on URL params that the page already
+  knows about.
+
+The two approaches are not exclusive — pass `actions={…}` for the
+page-level default and let descendants override via `usePageActions`.
+The template merges them: prop wins over registered, registered wins
+over nothing.
+
+---
+
+## 13. Template components
+
+This section enumerates the `@knkcs/anker/templates` exports.
+
+### 13.1 `<AppShell>`
+
+| Prop      | Type        | Required | Notes                                          |
+|-----------|-------------|----------|------------------------------------------------|
+| `sidebar` | `ReactNode` | yes      | Typically `<Sidebar>` from `/components`       |
+| `rail`    | `ReactNode` | no       | Pass `null` / omit to drop the rail column     |
+| `children`| `ReactNode` | yes      | Page content                                   |
+
+Exposes hooks: `usePageActions(node)`, `usePageRail(node)`.
+
+### 13.2 `<IndexPageTemplate>`
+
+| Prop          | Type        | Required | Notes                                          |
+|---------------|-------------|----------|------------------------------------------------|
+| `title`       | `ReactNode` | yes      |                                                |
+| `breadcrumbs` | `Crumb[]`   | no       |                                                |
+| `subtitle`    | `ReactNode` | no       |                                                |
+| `eyebrow`     | `ReactNode` | no       |                                                |
+| `actions`     | `ReactNode` | no       | Falls back to `usePageActions` registration    |
+| `tabs`        | `ReactNode` | no       | `<Tabs.Root>`                                  |
+| `toolbar`     | `ReactNode` | no       | `<Toolbar>`                                    |
+| `children`    | `ReactNode` | yes      | Body, flush                                    |
+
+### 13.3 `<DetailPageTemplate>`
+
+| Prop          | Type        | Required | Notes                                          |
+|---------------|-------------|----------|------------------------------------------------|
+| `title`       | `ReactNode` | yes      |                                                |
+| `breadcrumbs`, `subtitle`, `eyebrow`, `actions` | … | no |                                |
+| `tabs`        | `ReactNode` | no       |                                                |
+| `flush`       | `boolean`   | no       | `true` removes default body padding            |
+| `children`    | `ReactNode` | yes      | Body, padded by default                        |
+
+### 13.4 `<SettingsPageTemplate>`
+
+| Prop           | Type        | Required | Notes                                          |
+|----------------|-------------|----------|------------------------------------------------|
+| `title`        | `ReactNode` | yes      |                                                |
+| `tabs`         | `ReactNode` | yes      | Required                                       |
+| `breadcrumbs`, `subtitle`, `eyebrow`, `actions` | … | no |                                |
+| `maxBodyWidth` | `string`    | no       | Default `"3xl"`. Pass `"full"` to disable.     |
+| `children`     | `ReactNode` | yes      | Body                                           |
+
+### 13.5 `<DashboardPageTemplate>`
+
+| Prop          | Type        | Required | Notes                                          |
+|---------------|-------------|----------|------------------------------------------------|
+| `title`       | `ReactNode` | yes      |                                                |
+| `breadcrumbs`, `subtitle`, `eyebrow`, `actions` | … | no |                                |
+| `gap`         | `string`    | no       | Default `"4"` (= 16px)                         |
+| `children`    | `ReactNode` | yes      | Widgets in 12-col grid                         |
+
+### 13.6 `<AuthPageTemplate>`
+
+Slots inherited from `<AuthCard>`. See 11.5.
+
+### 13.7 `<MarketingPageTemplate>`
+
+See 11.9 for the full slot table.
+
+### 13.8 `<ErrorPage>`
+
+| Prop          | Type        | Required | Notes                                          |
+|---------------|-------------|----------|------------------------------------------------|
+| `statusCode`  | `ReactNode` | yes      | "404", "500", …                                |
+| `title`       | `ReactNode` | yes      |                                                |
+| `description` | `ReactNode` | no       |                                                |
+| `actions`     | `ReactNode` | no       |                                                |
+| `illustration`| `ReactNode` | no       |                                                |
+| `logo`        | `ReactNode` | no       |                                                |
+
+### 13.9 `<LoadingPage>`
+
+| Prop      | Type        | Required | Notes                                          |
+|-----------|-------------|----------|------------------------------------------------|
+| `logo`    | `ReactNode` | no       |                                                |
+| `message` | `ReactNode` | no       |                                                |
+
+### 13.10 `<MaintenancePage>`
+
+| Prop          | Type        | Required | Notes                                          |
+|---------------|-------------|----------|------------------------------------------------|
+| `logo`        | `ReactNode` | no       |                                                |
+| `title`       | `ReactNode` | no       | Default: "We'll be right back"                 |
+| `description` | `ReactNode` | no       | Default: "We're upgrading the service…"        |
+| `eta`         | `ReactNode` | no       | Estimated time-of-restoration banner           |
+| `statusLink`  | `ReactNode` | no       | Link to status page                            |
+
+---
+
+## 14. Authoring rules
+
+These rules are the contract for solution authors.
+
+1. **Use templates before composing primitives manually.** Reach for
+   `<IndexPageTemplate>` before composing `<PageHeader>` + `<Toolbar>`
+   + `<DataTable>` by hand. Templates exist so the composition is
+   guaranteed correct.
+
+2. **Templates are the contract. If a template doesn't fit, file an
+   issue — don't reinvent the layout.** A new page type emerging in
+   solution X should become a new template in anker, not a one-off.
+   This is how visual parity stays guaranteed across solutions.
+
+3. **Slots accept ReactNode. Don't pass styled raw elements that fight
+   the template's spacing.** If you find yourself wrapping a slot's
+   content in `<Box mt="-4" px="0">…</Box>` to undo the template's
+   defaults, the template is wrong — file an issue.
+
+4. **Don't bypass the slot mechanism for cross-cutting chrome.**
+   Page-actions and rail content belong in the AppShell slot store,
+   not in a Redux store, not in a React context you set up yourself,
+   not in a portal.
+
+5. **One template per page.** Pages don't nest templates. If a tab
+   pane needs its own header, render it inside the parent template's
+   body — don't put a `<DetailPageTemplate>` inside a
+   `<DetailPageTemplate>`'s tabs.
+
+6. **Keep i18n at the consumer level.** Templates speak English by
+   default. Consumers wrap them with i18n strings (the same way they
+   wrap `<Modal saveLabel={t("…")}>`).
+
+7. **No domain-specific behavior in template props.** If a template
+   prop name reads like a feature flag (`enableMfaCheck`,
+   `oauthClientId`), it's wrong — domain logic belongs in consumer
+   code, not in anker.
+
+8. **Templates are pure layout.** They never import from a service
+   codebase, never call APIs, never read i18n catalogues. The only
+   imports allowed are anker primitives, anker components, and
+   `lucide-react`.
+
+9. **Visual changes ride a minor version.** Templates that change
+   visually within a 1.x line must follow the same rule as the rest of
+   anker — minor bump, deprecation note, migration guide.
+
+10. **Test parity in storybook.** Every template has at least one
+    canonical story and one variant story. If you find yourself
+    visually tweaking a template's CSS, add a story that captures the
+    change.
+
+---
+
+## 15. References
+
+- [`docs/design-system.md`](./design-system.md) — token system and
+  visual language. Read first.
+- [`CLAUDE-ANKER.md`](../CLAUDE-ANKER.md) — design-system rules
+  consumers `@`-import into their `CLAUDE.md`. Includes a "Page
+  templates" section that points back here.
+- [`docs/react-table-reference.md`](./react-table-reference.md) —
+  TanStack Table conventions used inside `<DataTable>`.
+- [`docs/chakra-v3-reference.md`](./chakra-v3-reference.md) — Chakra
+  v3 patterns this repo enforces.
+- [`README.md`](../README.md) — consumer-facing entry point with the
+  "Setup for consumers" section.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knkcs/anker",
-  "version": "0.0.6",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knkcs/anker",
-      "version": "0.0.6",
+      "version": "1.8.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chakra-react-select": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",
@@ -34,6 +34,10 @@
     "./feedback": {
       "import": "./dist/feedback/index.js",
       "types": "./dist/feedback/index.d.ts"
+    },
+    "./templates": {
+      "import": "./dist/templates/index.js",
+      "types": "./dist/templates/index.d.ts"
     }
   },
   "files": [

--- a/scripts/check-chakra-imports.ts
+++ b/scripts/check-chakra-imports.ts
@@ -72,7 +72,7 @@ const EXEMPT_FILE_PATTERNS = [
 	/src\/feedback\/confirm-modal\.tsx$/, // Wraps Dialog compound with Chakra Button
 ];
 
-const SCAN_DIRS = ["src/atoms", "src/components", "src/forms", "src/feedback", "src/stories"];
+const SCAN_DIRS = ["src/atoms", "src/components", "src/forms", "src/feedback", "src/stories", "src/templates"];
 const CHAKRA_IMPORT_RE = /import\s+\{([^}]+)\}\s+from\s+["']@chakra-ui\/react["']/g;
 const TYPE_IMPORT_RE = /import\s+type\s+\{[^}]+\}\s+from\s+["']@chakra-ui\/react["']/g;
 

--- a/src/templates/app-shell.stories.tsx
+++ b/src/templates/app-shell.stories.tsx
@@ -27,7 +27,9 @@ const SampleSidebar = () => (
 				<Sidebar.Item icon={<Users size={16} />} active>
 					Users
 				</Sidebar.Item>
-				<Sidebar.Item icon={<Building2 size={16} />}>Organizations</Sidebar.Item>
+				<Sidebar.Item icon={<Building2 size={16} />}>
+					Organizations
+				</Sidebar.Item>
 			</Sidebar.Section>
 		</Sidebar.Body>
 	</Sidebar>
@@ -66,8 +68,8 @@ const RegisteringChild = () => {
 				Demo page
 			</Heading>
 			<Text color="muted">
-				This child registers page-actions and rail content via the AppShell
-				slot store.
+				This child registers page-actions and rail content via the AppShell slot
+				store.
 			</Text>
 		</Box>
 	);
@@ -96,8 +98,8 @@ export const NoRail: Story = {
 					No rail variant
 				</Heading>
 				<Text color="muted">
-					When `rail` is omitted (or null), the right column is dropped from
-					the grid entirely.
+					When `rail` is omitted (or null), the right column is dropped from the
+					grid entirely.
 				</Text>
 			</Box>
 		</AppShell>

--- a/src/templates/app-shell.stories.tsx
+++ b/src/templates/app-shell.stories.tsx
@@ -1,0 +1,113 @@
+// src/templates/app-shell.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Building2, Plus, Users } from "lucide-react";
+import { Button } from "../atoms/button";
+import { ContextRail } from "../components/context-rail/context-rail";
+import { Sidebar } from "../components/sidebar/sidebar";
+import { Box } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+import { AppShell, usePageActions, usePageRail } from "./app-shell";
+
+const meta = {
+	title: "Templates/AppShell",
+	component: AppShell,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof AppShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleSidebar = () => (
+	<Sidebar>
+		<Sidebar.Header>
+			<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
+		</Sidebar.Header>
+		<Sidebar.Body>
+			<Sidebar.Section label="Identity">
+				<Sidebar.Item icon={<Users size={16} />} active>
+					Users
+				</Sidebar.Item>
+				<Sidebar.Item icon={<Building2 size={16} />}>Organizations</Sidebar.Item>
+			</Sidebar.Section>
+		</Sidebar.Body>
+	</Sidebar>
+);
+
+const SampleRail = () => (
+	<ContextRail>
+		<ContextRail.Header eyebrow="OVERVIEW" title="Users" />
+		<ContextRail.Section id="stats" label="Stats">
+			<Text fontSize="sm" color="muted">
+				42 total users
+			</Text>
+		</ContextRail.Section>
+	</ContextRail>
+);
+
+const RegisteringChild = () => {
+	usePageActions(
+		<Button colorPalette="primary" size="sm">
+			<Plus size={14} /> Add user
+		</Button>,
+	);
+	usePageRail(
+		<ContextRail>
+			<ContextRail.Header eyebrow="REGISTERED" title="Filtered view" />
+			<ContextRail.Section id="filters" label="Active filters">
+				<Text fontSize="sm" color="muted">
+					Department: Engineering
+				</Text>
+			</ContextRail.Section>
+		</ContextRail>,
+	);
+	return (
+		<Box px="8" py="6">
+			<Heading as="h1" size="lg" mb="2">
+				Demo page
+			</Heading>
+			<Text color="muted">
+				This child registers page-actions and rail content via the AppShell
+				slot store.
+			</Text>
+		</Box>
+	);
+};
+
+export const Default: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />} rail={<SampleRail />}>
+			<Box px="8" py="6">
+				<Heading as="h1" size="lg" mb="2">
+					Page content
+				</Heading>
+				<Text color="muted">
+					AppShell renders sidebar | main | rail in a 3-column grid.
+				</Text>
+			</Box>
+		</AppShell>
+	),
+};
+
+export const NoRail: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<Box px="8" py="6">
+				<Heading as="h1" size="lg" mb="2">
+					No rail variant
+				</Heading>
+				<Text color="muted">
+					When `rail` is omitted (or null), the right column is dropped from
+					the grid entirely.
+				</Text>
+			</Box>
+		</AppShell>
+	),
+};
+
+export const WithSlotRegistration: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />} rail={<SampleRail />}>
+			<RegisteringChild />
+		</AppShell>
+	),
+};

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -1,0 +1,258 @@
+// src/templates/app-shell.tsx
+//
+// AppShell — top-level layout for authenticated knkCMS pages.
+//
+// Composition: a 3-column CSS grid with a fixed-width sidebar, a fluid main
+// content column, and an optional fixed-width context rail.
+//
+//     ┌─────────┬───────────────────────────┬─────────┐
+//     │         │                           │         │
+//     │ sidebar │         children          │  rail   │
+//     │         │  (page header / content)  │         │
+//     │         │                           │         │
+//     └─────────┴───────────────────────────┴─────────┘
+//
+// Slot mechanism
+// --------------
+// AppShell installs an external slot store on its descendants via context.
+// Two named slots are exposed:
+//
+//   - "actions" — registered via `usePageActions(node)` — surfaced by page
+//     templates inside their <PageHeader actions=…> slot.
+//   - "rail"    — registered via `usePageRail(node)`    — surfaced by AppShell
+//     as the content of the right rail column.
+//
+// The store uses `useSyncExternalStore` so that producers (deep child
+// components rendered after the consumer) and consumers (AppShell, the page
+// templates) stay decoupled. A naive `useState`-based context would force the
+// consumer to render in the same React commit as the producer, which causes
+// the actions/rail to flicker on route changes (the Path-B fix originally
+// shipped in odon as PR #115). The external-store pattern lets the producer
+// register its content in a `useEffect`, the consumer re-reads on the next
+// browser frame, and React's concurrent renderer is happy.
+
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useSyncExternalStore,
+} from "react";
+import { Box, Flex, Grid } from "../primitives/layout";
+
+type SlotName = "actions" | "rail";
+
+interface SlotStore {
+	get(slot: SlotName): ReactNode;
+	set(slot: SlotName, node: ReactNode): void;
+	clear(slot: SlotName): void;
+	subscribe(slot: SlotName, listener: () => void): () => void;
+}
+
+function createSlotStore(): SlotStore {
+	const values: Record<SlotName, ReactNode> = {
+		actions: null,
+		rail: null,
+	};
+	const listeners: Record<SlotName, Set<() => void>> = {
+		actions: new Set(),
+		rail: new Set(),
+	};
+
+	function notify(slot: SlotName) {
+		for (const listener of listeners[slot]) listener();
+	}
+
+	return {
+		get(slot) {
+			return values[slot];
+		},
+		set(slot, node) {
+			if (values[slot] === node) return;
+			values[slot] = node;
+			notify(slot);
+		},
+		clear(slot) {
+			if (values[slot] === null) return;
+			values[slot] = null;
+			notify(slot);
+		},
+		subscribe(slot, listener) {
+			listeners[slot].add(listener);
+			return () => {
+				listeners[slot].delete(listener);
+			};
+		},
+	};
+}
+
+const SlotStoreContext = createContext<SlotStore | null>(null);
+
+/**
+ * Read-side hook used internally by AppShell and the page templates to
+ * subscribe to a named slot's currently-registered ReactNode. Returns `null`
+ * when no producer has registered content (or when called outside an AppShell).
+ */
+function useSlotValue(slot: SlotName): ReactNode {
+	const store = useContext(SlotStoreContext);
+	const subscribe = useCallback(
+		(listener: () => void) => {
+			if (!store) return () => undefined;
+			return store.subscribe(slot, listener);
+		},
+		[store, slot],
+	);
+	const getSnapshot = useCallback(() => {
+		if (!store) return null;
+		return store.get(slot);
+	}, [store, slot]);
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Register page-action content (typically buttons rendered to the right of
+ * the page title) from any descendant of `<AppShell>`. The content is
+ * surfaced by the active page template inside its `<PageHeader>` actions
+ * slot.
+ *
+ * Pass `null` (or omit) to clear the registration. The hook is a no-op when
+ * called outside an AppShell, which keeps it safe to use in stories and
+ * isolated component tests.
+ */
+export function usePageActions(content: ReactNode): void {
+	const store = useContext(SlotStoreContext);
+	// Stash the most recent content in a ref so the effect can run on every
+	// render without forcing a fresh effect-cleanup cycle for unstable nodes.
+	const latest = useRef<ReactNode>(content);
+	latest.current = content;
+	useEffect(() => {
+		if (!store) return;
+		store.set("actions", latest.current);
+		return () => {
+			store.clear("actions");
+		};
+	}, [store]);
+	// Re-register on every change of `content` (effect above only runs once
+	// per mount; this second effect re-pushes the latest value).
+	useEffect(() => {
+		if (!store) return;
+		store.set("actions", content);
+	}, [store, content]);
+}
+
+/**
+ * Register context-rail content from any descendant of `<AppShell>`. The
+ * content is rendered in the rail column (assuming the AppShell has a rail
+ * slot enabled).
+ *
+ * Pass `null` (or omit) to clear the registration. The hook is a no-op when
+ * called outside an AppShell.
+ */
+export function usePageRail(content: ReactNode): void {
+	const store = useContext(SlotStoreContext);
+	const latest = useRef<ReactNode>(content);
+	latest.current = content;
+	useEffect(() => {
+		if (!store) return;
+		store.set("rail", latest.current);
+		return () => {
+			store.clear("rail");
+		};
+	}, [store]);
+	useEffect(() => {
+		if (!store) return;
+		store.set("rail", content);
+	}, [store, content]);
+}
+
+/**
+ * Internal hook used by page templates to read the currently-registered
+ * page-actions ReactNode. Page templates fall back to a locally-passed
+ * `actions` prop when nothing is registered.
+ */
+export function useRegisteredPageActions(): ReactNode {
+	return useSlotValue("actions");
+}
+
+export interface AppShellProps {
+	/**
+	 * Sidebar element — the navigation column. Required. Typically an instance
+	 * of `<Sidebar>` from `@knkcs/anker/components`. AppShell does not own the
+	 * sidebar's collapsed-state — pass it through the Sidebar's own props.
+	 */
+	sidebar: ReactNode;
+	/**
+	 * Context rail element. Pass an instance of `<ContextRail>` to enable the
+	 * rail column. Pass `null` (or omit) to disable the column entirely (no
+	 * grid track is reserved). Pages can still register rail content via
+	 * `usePageRail` — when the rail column is disabled, registered content is
+	 * dropped silently.
+	 *
+	 * Tip: pass an _empty_ `<ContextRail>` if you want the column to exist
+	 * (so child pages can populate it via `usePageRail`) without rendering
+	 * any default content.
+	 */
+	rail?: ReactNode;
+	/** Page content. */
+	children: ReactNode;
+}
+
+/**
+ * AppShell is the top-level layout for authenticated knkCMS pages. It owns
+ * the slot context that powers `usePageActions` and `usePageRail`, and
+ * arranges sidebar / main / rail in a 3-column CSS grid.
+ *
+ * AppShell is layout-only — it does not render a PageHeader, and it does not
+ * inject any business chrome. Pages compose `<IndexPageTemplate>`,
+ * `<DetailPageTemplate>`, etc. inside `children`.
+ */
+export function AppShell({ sidebar, rail, children }: AppShellProps) {
+	const store = useMemo(() => createSlotStore(), []);
+	const railNode = useSlotValue("rail");
+
+	// The rail column is enabled when the consumer passed a `rail` element.
+	// We use the consumer-supplied element as a *container* for the
+	// dynamically-registered rail content: anything registered via
+	// `usePageRail` is appended into that container at render time. This
+	// keeps the framing chrome (collapse toggle, scrolling, borders) under
+	// the consumer's control while letting pages contribute body content.
+	//
+	// Implementation note: we render `rail` as-is and tee its `children`
+	// across (a) whatever the consumer passed and (b) whatever a page
+	// registered via `usePageRail`. The simplest, escape-hatch-friendly
+	// behavior is: if a page has registered rail content, render that;
+	// otherwise render the consumer's `rail` as-is. Consumers that want
+	// "default + page-specific" content can wire that themselves.
+	const showRailColumn = rail !== undefined && rail !== null;
+	const renderedRail = railNode ?? rail;
+
+	return (
+		<SlotStoreContext.Provider value={store}>
+			<Grid
+				data-testid="app-shell"
+				data-rail={showRailColumn ? "true" : "false"}
+				templateColumns={
+					showRailColumn ? "auto 1fr auto" : "auto 1fr"
+				}
+				minH="100vh"
+				bg="bg-canvas"
+			>
+				<Box gridColumn="1" minW="0">
+					{sidebar}
+				</Box>
+				<Flex gridColumn="2" direction="column" minW="0" minH="100vh">
+					{children}
+				</Flex>
+				{showRailColumn ? (
+					<Box gridColumn="3" minW="0">
+						{renderedRail}
+					</Box>
+				) : null}
+			</Grid>
+		</SlotStoreContext.Provider>
+	);
+}
+AppShell.displayName = "AppShell";

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -234,9 +234,7 @@ export function AppShell({ sidebar, rail, children }: AppShellProps) {
 			<Grid
 				data-testid="app-shell"
 				data-rail={showRailColumn ? "true" : "false"}
-				templateColumns={
-					showRailColumn ? "auto 1fr auto" : "auto 1fr"
-				}
+				templateColumns={showRailColumn ? "auto 1fr auto" : "auto 1fr"}
 				minH="100vh"
 				bg="bg-canvas"
 			>

--- a/src/templates/auth-page-template.stories.tsx
+++ b/src/templates/auth-page-template.stories.tsx
@@ -1,0 +1,67 @@
+// src/templates/auth-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../atoms/button";
+import { TextInput } from "../atoms/text-input";
+import { Heading, Text } from "../primitives/typography";
+import { AuthPageTemplate } from "./auth-page-template";
+
+const meta = {
+	title: "Templates/AuthPageTemplate",
+	component: AuthPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof AuthPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Logo = () => (
+	<Heading as="span" size="md" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+export const Login: Story = {
+	args: {
+		logo: <Logo />,
+		topBarRight: (
+			<>
+				<Text fontSize="xs" color="muted">
+					Help
+				</Text>
+				<Text fontSize="xs" color="muted">
+					EN
+				</Text>
+			</>
+		),
+		eyebrow: "SIGN IN",
+		title: "Welcome back",
+		subtitle: "Enter your email to continue.",
+		children: (
+			<>
+				<TextInput placeholder="you@example.com" mb="4" />
+				<Button colorPalette="primary" variant="solid" w="full">
+					Continue
+				</Button>
+			</>
+		),
+		footer: (
+			<Text fontSize="xs">
+				No account? <a href="#">Create one</a>
+			</Text>
+		),
+	},
+};
+
+export const VerifyEmail: Story = {
+	args: {
+		logo: <Logo />,
+		eyebrow: "VERIFY EMAIL",
+		title: "Check your inbox",
+		subtitle: "We sent a verification link to jana@knk.de.",
+		children: (
+			<Button colorPalette="primary" variant="outline" w="full">
+				Resend email
+			</Button>
+		),
+	},
+};

--- a/src/templates/auth-page-template.stories.tsx
+++ b/src/templates/auth-page-template.stories.tsx
@@ -46,7 +46,7 @@ export const Login: Story = {
 		),
 		footer: (
 			<Text fontSize="xs">
-				No account? <a href="#">Create one</a>
+				No account? <a href="/register">Create one</a>
 			</Text>
 		),
 	},

--- a/src/templates/auth-page-template.tsx
+++ b/src/templates/auth-page-template.tsx
@@ -1,0 +1,40 @@
+// src/templates/auth-page-template.tsx
+//
+// AuthPageTemplate — full-bleed centered card on a neutral canvas. No app
+// shell, no sidebar, no rail. Used for login, register, MFA challenge,
+// forgot/reset password, and email-verification screens.
+//
+// Internally this is a thin wrapper around `<AuthCard>` (in
+// `@knkcs/anker/components`) — surfaced under the templates module so
+// consumers can import their layout chrome from one entry point.
+//
+// We re-expose the wrapper rather than re-implementing it because AuthCard
+// is already battle-tested and stable; the templates module is the consumer
+// contract, AuthCard is the implementation.
+
+import type { ReactNode } from "react";
+import { AuthCard, type AuthCardProps } from "../components/auth-card";
+
+export interface AuthPageTemplateProps extends AuthCardProps {
+	/**
+	 * Page body — typically a form or a verification CTA. Inherits all
+	 * AuthCard slots (logo, topBarRight, eyebrow, title, subtitle, footer).
+	 */
+	children: ReactNode;
+}
+
+/**
+ * Auth-flow page layout. Use for any pre-authentication screen (login,
+ * register, MFA, forgot-password, reset-password) and for short
+ * confirmation flows (email-verify, account-deleted). For consent
+ * dialogs, prefer `<OAuthConsentPageTemplate>` (denser layout).
+ *
+ * The template supplies a centered card with a dot-grid background, an
+ * optional topbar with logo + locale switcher, and a footer slot. To hide
+ * the topbar (rare — embedded preview, printable receipts) pass
+ * `hideTopBar`. To hide the dot-grid (printable) pass `hideBackground`.
+ */
+export function AuthPageTemplate(props: AuthPageTemplateProps) {
+	return <AuthCard {...props} />;
+}
+AuthPageTemplate.displayName = "AuthPageTemplate";

--- a/src/templates/dashboard-page-template.stories.tsx
+++ b/src/templates/dashboard-page-template.stories.tsx
@@ -1,0 +1,75 @@
+// src/templates/dashboard-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Activity, Users } from "lucide-react";
+import { Sidebar } from "../components/sidebar/sidebar";
+import { Widget } from "../components/widget";
+import { Box, GridItem } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+import { AppShell } from "./app-shell";
+import { DashboardPageTemplate } from "./dashboard-page-template";
+
+const meta = {
+	title: "Templates/DashboardPageTemplate",
+	component: DashboardPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof DashboardPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleSidebar = () => (
+	<Sidebar>
+		<Sidebar.Header>
+			<Sidebar.Logo wordmark="Odon" />
+		</Sidebar.Header>
+		<Sidebar.Body>
+			<Sidebar.Section label="Workspace">
+				<Sidebar.Item active>Dashboard</Sidebar.Item>
+			</Sidebar.Section>
+		</Sidebar.Body>
+	</Sidebar>
+);
+
+export const Default: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<DashboardPageTemplate
+				title="Dashboard"
+				subtitle="Last 30 days · all workspaces"
+			>
+				<GridItem gridColumn="span 3">
+					<Widget heading="Active users" icon={<Users size={16} />}>
+						<Heading size="2xl">1,284</Heading>
+					</Widget>
+				</GridItem>
+				<GridItem gridColumn="span 3">
+					<Widget heading="Sign-ins (7d)" icon={<Activity size={16} />}>
+						<Heading size="2xl">8,210</Heading>
+					</Widget>
+				</GridItem>
+				<GridItem gridColumn="span 3">
+					<Widget heading="MFA enrolled" icon={<Users size={16} />}>
+						<Heading size="2xl">76%</Heading>
+					</Widget>
+				</GridItem>
+				<GridItem gridColumn="span 3">
+					<Widget heading="Failed logins" icon={<Activity size={16} />}>
+						<Heading size="2xl">12</Heading>
+					</Widget>
+				</GridItem>
+				<GridItem gridColumn="span 8">
+					<Widget heading="Sign-in activity" icon={<Activity size={16} />}>
+						<Box h="200px" bg="bg-subtle" borderRadius="md" />
+					</Widget>
+				</GridItem>
+				<GridItem gridColumn="span 4">
+					<Widget heading="Recent events" icon={<Activity size={16} />}>
+						<Text fontSize="sm" color="muted">
+							[ Timeline goes here ]
+						</Text>
+					</Widget>
+				</GridItem>
+			</DashboardPageTemplate>
+		</AppShell>
+	),
+};

--- a/src/templates/dashboard-page-template.tsx
+++ b/src/templates/dashboard-page-template.tsx
@@ -22,8 +22,8 @@
 // insights — calm surfaces, dense info, clear hierarchy.
 
 import type { ReactNode } from "react";
-import { Box, Flex, Grid } from "../primitives/layout";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Box, Flex, Grid } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
 
 export interface DashboardPageTemplateProps

--- a/src/templates/dashboard-page-template.tsx
+++ b/src/templates/dashboard-page-template.tsx
@@ -1,0 +1,86 @@
+// src/templates/dashboard-page-template.tsx
+//
+// DashboardPageTemplate — for at-a-glance overview pages composed of a grid
+// of widgets (Stat cards, mini-charts, recent-activity panes, etc.).
+//
+//   ┌─────────────────────────────────────────┐
+//   │ PageHeader (greeting · range picker)    │
+//   ├─────────────────────────────────────────┤
+//   │ ┌──────┬──────┬──────┬──────┐           │
+//   │ │ stat │ stat │ stat │ stat │           │
+//   │ ├──────┴──────┼──────┴──────┤           │
+//   │ │   widget    │   widget    │           │
+//   │ │             │             │           │
+//   │ ├─────────────┴─────────────┤           │
+//   │ │       wide widget         │           │
+//   │ └───────────────────────────┘           │
+//   └─────────────────────────────────────────┘
+//
+// The template provides the page chrome and a 12-column responsive grid.
+// Widgets opt into the column count via Chakra's `gridColumn` prop on each
+// child. Inspired by Linear's "All issues" overview and GitHub's repo
+// insights — calm surfaces, dense info, clear hierarchy.
+
+import type { ReactNode } from "react";
+import { Box, Flex, Grid } from "../primitives/layout";
+import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { useRegisteredPageActions } from "./app-shell";
+
+export interface DashboardPageTemplateProps
+	extends Pick<
+		PageHeaderProps,
+		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
+	> {
+	actions?: ReactNode;
+	/**
+	 * Dashboard widgets. Children are placed inside a 12-column responsive
+	 * CSS grid with `gap="4"`. Each child should set `gridColumn` (e.g.
+	 * `"span 3"` for a quarter-width tile, `"span 6"` for half, `"span 12"`
+	 * for full-width). The default per-child column span is `"span 12"`.
+	 */
+	children: ReactNode;
+	/**
+	 * Override the grid `gap` between widgets. @default "4" (= 16px)
+	 */
+	gap?: string;
+}
+
+export function DashboardPageTemplate({
+	breadcrumbs,
+	title,
+	subtitle,
+	eyebrow,
+	actions,
+	children,
+	gap = "4",
+}: DashboardPageTemplateProps) {
+	const registered = useRegisteredPageActions();
+	const resolvedActions = actions ?? registered;
+	return (
+		<Flex
+			data-testid="dashboard-page-template"
+			direction="column"
+			flex="1"
+			minH="0"
+			bg="bg-canvas"
+		>
+			<PageHeader
+				breadcrumbs={breadcrumbs}
+				title={title}
+				subtitle={subtitle}
+				eyebrow={eyebrow}
+				actions={resolvedActions}
+			/>
+			<Box flex="1" minH="0" px="8" py="6">
+				<Grid
+					data-testid="dashboard-grid"
+					templateColumns="repeat(12, minmax(0, 1fr))"
+					gap={gap}
+				>
+					{children}
+				</Grid>
+			</Box>
+		</Flex>
+	);
+}
+DashboardPageTemplate.displayName = "DashboardPageTemplate";

--- a/src/templates/detail-page-template.stories.tsx
+++ b/src/templates/detail-page-template.stories.tsx
@@ -1,9 +1,9 @@
 // src/templates/detail-page-template.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
-import { Sidebar } from "../components/sidebar/sidebar";
 import { Card } from "../components/card";
-import { Tabs } from "../primitives/tabs";
+import { Sidebar } from "../components/sidebar/sidebar";
 import { Box } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
 import { Text } from "../primitives/typography";
 import { AppShell } from "./app-shell";
 import { DetailPageTemplate } from "./detail-page-template";

--- a/src/templates/detail-page-template.stories.tsx
+++ b/src/templates/detail-page-template.stories.tsx
@@ -1,0 +1,64 @@
+// src/templates/detail-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Sidebar } from "../components/sidebar/sidebar";
+import { Card } from "../components/card";
+import { Tabs } from "../primitives/tabs";
+import { Box } from "../primitives/layout";
+import { Text } from "../primitives/typography";
+import { AppShell } from "./app-shell";
+import { DetailPageTemplate } from "./detail-page-template";
+
+const meta = {
+	title: "Templates/DetailPageTemplate",
+	component: DetailPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof DetailPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleSidebar = () => (
+	<Sidebar>
+		<Sidebar.Header>
+			<Sidebar.Logo wordmark="Odon" />
+		</Sidebar.Header>
+		<Sidebar.Body>
+			<Sidebar.Section label="Identity">
+				<Sidebar.Item active>Users</Sidebar.Item>
+			</Sidebar.Section>
+		</Sidebar.Body>
+	</Sidebar>
+);
+
+export const Default: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<DetailPageTemplate
+				breadcrumbs={[
+					{ label: "Identity", to: "#" },
+					{ label: "Users", to: "#" },
+					{ label: "Jana Schmid" },
+				]}
+				title="Jana Schmid"
+				subtitle="jana.schmid@knk.de"
+				tabs={
+					<Tabs.Root defaultValue="profile" variant="line">
+						<Box px="8">
+							<Tabs.List>
+								<Tabs.Trigger value="profile">Profile</Tabs.Trigger>
+								<Tabs.Trigger value="sessions">Sessions</Tabs.Trigger>
+								<Tabs.Trigger value="audit">Audit log</Tabs.Trigger>
+							</Tabs.List>
+						</Box>
+					</Tabs.Root>
+				}
+			>
+				<Card title="Identity">
+					<Text color="muted">
+						Identity card content (avatar, persona block, role).
+					</Text>
+				</Card>
+			</DetailPageTemplate>
+		</AppShell>
+	),
+};

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -1,0 +1,87 @@
+// src/templates/detail-page-template.tsx
+//
+// DetailPageTemplate — the canonical "single entity" page layout.
+//
+// Composition:
+//
+//   ┌─────────────────────────────────────────┐
+//   │ PageHeader  (breadcrumbs · title · …)   │
+//   ├─────────────────────────────────────────┤
+//   │ Tabs (optional — pinned beneath header) │
+//   ├─────────────────────────────────────────┤
+//   │ children (identity card · panes · …)    │
+//   └─────────────────────────────────────────┘
+//
+// Use for pages that show one entity: a single user, a single OAuth client,
+// a single audit-event detail. Detail pages often have an identity Card at
+// the top followed by tabbed sections — DetailPageTemplate is intentionally
+// thin so consumers can compose those freely under `children`.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { useRegisteredPageActions } from "./app-shell";
+
+export interface DetailPageTemplateProps
+	extends Pick<
+		PageHeaderProps,
+		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
+	> {
+	actions?: ReactNode;
+	/**
+	 * Tab strip rendered immediately under the PageHeader. Typically a
+	 * `<Tabs.Root>` containing a `<Tabs.List>` and one `<Tabs.Content>` per
+	 * pane. The template does not render `<Tabs.Content>` separately —
+	 * consumers control the tab body composition entirely.
+	 */
+	tabs?: ReactNode;
+	/**
+	 * Page body — the entity's identity card, tab bodies, edit forms, etc.
+	 * Rendered with horizontal padding (`px="8"`) and top padding (`pt="6"`)
+	 * so cards inside don't sit flush against the page edges. Override by
+	 * passing a `<Box px="0" pt="0">…</Box>` if you need a flush layout.
+	 */
+	children: ReactNode;
+	/**
+	 * When `true`, removes the default `px="8" pt="6"` padding around
+	 * `children`. Use for detail pages whose body is itself a full-bleed
+	 * surface (e.g. a code editor). @default false
+	 */
+	flush?: boolean;
+}
+
+export function DetailPageTemplate({
+	breadcrumbs,
+	title,
+	subtitle,
+	eyebrow,
+	actions,
+	tabs,
+	children,
+	flush = false,
+}: DetailPageTemplateProps) {
+	const registered = useRegisteredPageActions();
+	const resolvedActions = actions ?? registered;
+	return (
+		<Flex
+			data-testid="detail-page-template"
+			direction="column"
+			flex="1"
+			minH="0"
+			bg="bg-canvas"
+		>
+			<PageHeader
+				breadcrumbs={breadcrumbs}
+				title={title}
+				subtitle={subtitle}
+				eyebrow={eyebrow}
+				actions={resolvedActions}
+			/>
+			{tabs ? <Box>{tabs}</Box> : null}
+			<Box flex="1" minH="0" px={flush ? "0" : "8"} pt={flush ? "0" : "6"}>
+				{children}
+			</Box>
+		</Flex>
+	);
+}
+DetailPageTemplate.displayName = "DetailPageTemplate";

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -18,8 +18,8 @@
 // thin so consumers can compose those freely under `children`.
 
 import type { ReactNode } from "react";
-import { Box, Flex } from "../primitives/layout";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Box, Flex } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
 
 export interface DetailPageTemplateProps

--- a/src/templates/error-page.stories.tsx
+++ b/src/templates/error-page.stories.tsx
@@ -1,0 +1,69 @@
+// src/templates/error-page.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../atoms/button";
+import { Heading } from "../primitives/typography";
+import { ErrorPage } from "./error-page";
+
+const meta = {
+	title: "Templates/ErrorPage",
+	component: ErrorPage,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ErrorPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Logo = () => (
+	<Heading as="span" size="md" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+export const NotFound: Story = {
+	args: {
+		logo: <Logo />,
+		statusCode: "404",
+		title: "Page not found",
+		description:
+			"The page you were looking for has moved, expired, or never existed.",
+		actions: (
+			<>
+				<Button colorPalette="primary" size="md">
+					Back to dashboard
+				</Button>
+				<Button variant="ghost" size="md">
+					Contact support
+				</Button>
+			</>
+		),
+	},
+};
+
+export const ServerError: Story = {
+	args: {
+		logo: <Logo />,
+		statusCode: "500",
+		title: "Something went wrong",
+		description:
+			"An unexpected error occurred on the server. We've been notified and are looking into it.",
+		actions: (
+			<Button colorPalette="primary" size="md">
+				Retry
+			</Button>
+		),
+	},
+};
+
+export const Forbidden: Story = {
+	args: {
+		statusCode: "403",
+		title: "Access denied",
+		description:
+			"You don't have permission to view this resource. Contact your workspace admin if you think this is wrong.",
+		actions: (
+			<Button colorPalette="primary" size="md">
+				Back home
+			</Button>
+		),
+	},
+};

--- a/src/templates/error-page.tsx
+++ b/src/templates/error-page.tsx
@@ -93,13 +93,7 @@ export function ErrorPage({
 					{title}
 				</Heading>
 				{description && (
-					<Text
-						fontSize="md"
-						color="muted"
-						lineHeight="1.6"
-						maxW="lg"
-						mb="8"
-					>
+					<Text fontSize="md" color="muted" lineHeight="1.6" maxW="lg" mb="8">
 						{description}
 					</Text>
 				)}

--- a/src/templates/error-page.tsx
+++ b/src/templates/error-page.tsx
@@ -1,0 +1,115 @@
+// src/templates/error-page.tsx
+//
+// ErrorPage — full-bleed error layout for 404 / 403 / 500 / generic
+// failures. Centered status code + message + suggested next step. No app
+// shell, no sidebar.
+//
+// We keep it deliberately spare — an enterprise B2B error screen does not
+// need a 404-illustration of an astronaut. The optional `illustration`
+// slot is there for the rare case where a product wants to reach for one
+// (e.g. a dedicated brand "OOPS" SVG).
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+
+export interface ErrorPageProps {
+	/**
+	 * Status code (404, 500, 403, …) shown as the page's largest piece of
+	 * type. Pass any string — non-numeric codes like "OOPS" work too.
+	 */
+	statusCode: ReactNode;
+	/** Short headline — e.g. "Page not found" or "Something went wrong". */
+	title: ReactNode;
+	/**
+	 * One-paragraph explanation. Keep it short — the user is already in a
+	 * frustrated state.
+	 */
+	description?: ReactNode;
+	/**
+	 * Action(s) — typically one solid button (back home / retry) plus an
+	 * optional secondary link.
+	 */
+	actions?: ReactNode;
+	/**
+	 * Optional illustration rendered above the status code. Use sparingly.
+	 */
+	illustration?: ReactNode;
+	/**
+	 * Logo or wordmark rendered top-left. Useful for branded error pages
+	 * served from the root domain.
+	 */
+	logo?: ReactNode;
+}
+
+export function ErrorPage({
+	statusCode,
+	title,
+	description,
+	actions,
+	illustration,
+	logo,
+}: ErrorPageProps) {
+	return (
+		<Flex
+			data-testid="error-page"
+			direction="column"
+			minH="100vh"
+			bg="bg-canvas"
+		>
+			{logo && (
+				<Box px="8" py="6">
+					{logo}
+				</Box>
+			)}
+			<Flex
+				flex="1"
+				direction="column"
+				align="center"
+				justify="center"
+				px="8"
+				pb="16"
+				textAlign="center"
+			>
+				{illustration && <Box mb="8">{illustration}</Box>}
+				<Text
+					fontSize="7xl"
+					fontWeight="semibold"
+					color="muted"
+					letterSpacing="-0.04em"
+					lineHeight="1"
+					mb="4"
+				>
+					{statusCode}
+				</Text>
+				<Heading
+					as="h1"
+					fontSize="2xl"
+					fontWeight="semibold"
+					color="default"
+					letterSpacing="-0.02em"
+					mb="3"
+				>
+					{title}
+				</Heading>
+				{description && (
+					<Text
+						fontSize="md"
+						color="muted"
+						lineHeight="1.6"
+						maxW="lg"
+						mb="8"
+					>
+						{description}
+					</Text>
+				)}
+				{actions && (
+					<Flex gap="3" align="center" justify="center">
+						{actions}
+					</Flex>
+				)}
+			</Flex>
+		</Flex>
+	);
+}
+ErrorPage.displayName = "ErrorPage";

--- a/src/templates/index-page-template.stories.tsx
+++ b/src/templates/index-page-template.stories.tsx
@@ -1,0 +1,122 @@
+// src/templates/index-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../atoms/button";
+import { Sidebar } from "../components/sidebar/sidebar";
+import { Toolbar } from "../components/toolbar";
+import { Tabs } from "../primitives/tabs";
+import { Box } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+import { AppShell } from "./app-shell";
+import { IndexPageTemplate } from "./index-page-template";
+
+const meta = {
+	title: "Templates/IndexPageTemplate",
+	component: IndexPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof IndexPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleSidebar = () => (
+	<Sidebar>
+		<Sidebar.Header>
+			<Sidebar.Logo wordmark="Odon" subtitle="Identity Provider" />
+		</Sidebar.Header>
+		<Sidebar.Body>
+			<Sidebar.Section label="Identity">
+				<Sidebar.Item active>Users</Sidebar.Item>
+			</Sidebar.Section>
+		</Sidebar.Body>
+	</Sidebar>
+);
+
+const FakeTable = () => (
+	<Box px="8" py="6" bg="bg-canvas">
+		<Box bg="bg-surface" borderRadius="md" borderWidth="1px" borderColor="border" p="6">
+			<Text color="muted">[ DataTable goes here ]</Text>
+		</Box>
+	</Box>
+);
+
+const SearchToolbar = () => {
+	const [q, setQ] = useState("");
+	return (
+		<Toolbar>
+			<Toolbar.Search placeholder="Search users…" value={q} onChange={setQ} />
+			<Toolbar.Right>
+				<Toolbar.Count>42 users</Toolbar.Count>
+			</Toolbar.Right>
+		</Toolbar>
+	);
+};
+
+export const Default: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<IndexPageTemplate
+				breadcrumbs={[{ label: "Identity", to: "#" }, { label: "Users" }]}
+				title="Users"
+				subtitle="People with access to this workspace."
+				actions={
+					<Button colorPalette="primary" size="sm">
+						<Plus size={14} /> Add user
+					</Button>
+				}
+				toolbar={<SearchToolbar />}
+			>
+				<FakeTable />
+			</IndexPageTemplate>
+		</AppShell>
+	),
+};
+
+export const WithTabs: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<IndexPageTemplate
+				breadcrumbs={[{ label: "Identity", to: "#" }, { label: "Users" }]}
+				title="Users"
+				actions={
+					<Button colorPalette="primary" size="sm">
+						<Plus size={14} /> Add user
+					</Button>
+				}
+				tabs={
+					<Tabs.Root defaultValue="active" variant="line">
+						<Box px="8">
+							<Tabs.List>
+								<Tabs.Trigger value="active">Active</Tabs.Trigger>
+								<Tabs.Trigger value="invited">Invited</Tabs.Trigger>
+								<Tabs.Trigger value="suspended">Suspended</Tabs.Trigger>
+							</Tabs.List>
+						</Box>
+					</Tabs.Root>
+				}
+				toolbar={<SearchToolbar />}
+			>
+				<FakeTable />
+			</IndexPageTemplate>
+		</AppShell>
+	),
+};
+
+export const NoToolbar: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<IndexPageTemplate title="Users (no toolbar)">
+				<Box px="8" py="6">
+					<Heading size="md" mb="2">
+						No toolbar
+					</Heading>
+					<Text color="muted">
+						Some index pages don't need a search/filter toolbar (small
+						lists, fixed-set indexes).
+					</Text>
+				</Box>
+			</IndexPageTemplate>
+		</AppShell>
+	),
+};

--- a/src/templates/index-page-template.stories.tsx
+++ b/src/templates/index-page-template.stories.tsx
@@ -5,8 +5,8 @@ import { useState } from "react";
 import { Button } from "../atoms/button";
 import { Sidebar } from "../components/sidebar/sidebar";
 import { Toolbar } from "../components/toolbar";
-import { Tabs } from "../primitives/tabs";
 import { Box } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
 import { Heading, Text } from "../primitives/typography";
 import { AppShell } from "./app-shell";
 import { IndexPageTemplate } from "./index-page-template";
@@ -35,7 +35,13 @@ const SampleSidebar = () => (
 
 const FakeTable = () => (
 	<Box px="8" py="6" bg="bg-canvas">
-		<Box bg="bg-surface" borderRadius="md" borderWidth="1px" borderColor="border" p="6">
+		<Box
+			bg="bg-surface"
+			borderRadius="md"
+			borderWidth="1px"
+			borderColor="border"
+			p="6"
+		>
 			<Text color="muted">[ DataTable goes here ]</Text>
 		</Box>
 	</Box>
@@ -112,8 +118,8 @@ export const NoToolbar: Story = {
 						No toolbar
 					</Heading>
 					<Text color="muted">
-						Some index pages don't need a search/filter toolbar (small
-						lists, fixed-set indexes).
+						Some index pages don't need a search/filter toolbar (small lists,
+						fixed-set indexes).
 					</Text>
 				</Box>
 			</IndexPageTemplate>

--- a/src/templates/index-page-template.tsx
+++ b/src/templates/index-page-template.tsx
@@ -1,0 +1,101 @@
+// src/templates/index-page-template.tsx
+//
+// IndexPageTemplate — the canonical "list of items" page layout.
+//
+// Composition (top to bottom):
+//
+//   ┌─────────────────────────────────────────┐
+//   │ PageHeader  (breadcrumbs · title · …)   │
+//   ├─────────────────────────────────────────┤
+//   │ Tabs (optional — under header)          │
+//   ├─────────────────────────────────────────┤
+//   │ Toolbar (search · filters · count)      │
+//   ├─────────────────────────────────────────┤
+//   │ children (DataTable, list, empty state) │
+//   └─────────────────────────────────────────┘
+//
+// Use this template for any "browse a list" page: users index, OAuth-clients
+// index, audit-log, etc. The template flushes its content (no horizontal
+// padding) so a full-bleed DataTable sits cleanly under the toolbar. Pages
+// that need padded content should wrap children in a `<Box px="8" py="6">`.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { useRegisteredPageActions } from "./app-shell";
+
+export interface IndexPageTemplateProps
+	extends Pick<
+		PageHeaderProps,
+		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
+	> {
+	/**
+	 * Optional explicit page-action content (rendered inside the PageHeader's
+	 * actions slot). When omitted, the template falls back to whatever a
+	 * descendant has registered via `usePageActions`.
+	 */
+	actions?: ReactNode;
+	/**
+	 * Optional tab strip rendered between the PageHeader and the toolbar.
+	 * Pass an instance of `<Tabs.Root>` (with its own `<Tabs.List>` and
+	 * `<Tabs.Content>`s). When omitted, no tab strip is rendered.
+	 */
+	tabs?: ReactNode;
+	/**
+	 * Toolbar element rendered between the tabs (if any) and the page body.
+	 * Typically an instance of `<Toolbar>` from `@knkcs/anker/components`.
+	 * Pass `null` to omit the toolbar entirely (rare).
+	 */
+	toolbar?: ReactNode;
+	/**
+	 * Page body — DataTable, list, empty state, or error/loading content.
+	 * Rendered flush against the canvas. Add internal padding inside
+	 * `children` if you need it.
+	 */
+	children: ReactNode;
+}
+
+/**
+ * Canonical list-page layout. Renders PageHeader → optional Tabs → optional
+ * Toolbar → children, full-bleed against the canvas.
+ *
+ * Page actions are sourced from (in priority order): `actions` prop →
+ * registered slot via `usePageActions`. This lets a tab-pane component deep
+ * inside `children` register its own actions without prop-drilling.
+ */
+export function IndexPageTemplate({
+	breadcrumbs,
+	title,
+	subtitle,
+	eyebrow,
+	actions,
+	tabs,
+	toolbar,
+	children,
+}: IndexPageTemplateProps) {
+	const registered = useRegisteredPageActions();
+	const resolvedActions = actions ?? registered;
+	return (
+		<Flex
+			data-testid="index-page-template"
+			direction="column"
+			flex="1"
+			minH="0"
+			bg="bg-canvas"
+		>
+			<PageHeader
+				breadcrumbs={breadcrumbs}
+				title={title}
+				subtitle={subtitle}
+				eyebrow={eyebrow}
+				actions={resolvedActions}
+			/>
+			{tabs ? <Box>{tabs}</Box> : null}
+			{toolbar ? <Box>{toolbar}</Box> : null}
+			<Box flex="1" minH="0">
+				{children}
+			</Box>
+		</Flex>
+	);
+}
+IndexPageTemplate.displayName = "IndexPageTemplate";

--- a/src/templates/index-page-template.tsx
+++ b/src/templates/index-page-template.tsx
@@ -20,8 +20,8 @@
 // that need padded content should wrap children in a `<Box px="8" py="6">`.
 
 import type { ReactNode } from "react";
-import { Box, Flex } from "../primitives/layout";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Box, Flex } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
 
 export interface IndexPageTemplateProps

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -12,27 +12,24 @@
 // AppShell + slot hooks
 export type { AppShellProps } from "./app-shell";
 export { AppShell, usePageActions, usePageRail } from "./app-shell";
-
-// Authenticated page templates
-export type { IndexPageTemplateProps } from "./index-page-template";
-export { IndexPageTemplate } from "./index-page-template";
-export type { DetailPageTemplateProps } from "./detail-page-template";
-export { DetailPageTemplate } from "./detail-page-template";
-export type { SettingsPageTemplateProps } from "./settings-page-template";
-export { SettingsPageTemplate } from "./settings-page-template";
-export type { DashboardPageTemplateProps } from "./dashboard-page-template";
-export { DashboardPageTemplate } from "./dashboard-page-template";
-
 // Unauthenticated / chromeless templates
 export type { AuthPageTemplateProps } from "./auth-page-template";
 export { AuthPageTemplate } from "./auth-page-template";
-export type { MarketingPageTemplateProps } from "./marketing-page-template";
-export { MarketingPageTemplate } from "./marketing-page-template";
-
+export type { DashboardPageTemplateProps } from "./dashboard-page-template";
+export { DashboardPageTemplate } from "./dashboard-page-template";
+export type { DetailPageTemplateProps } from "./detail-page-template";
+export { DetailPageTemplate } from "./detail-page-template";
 // Status / system pages
 export type { ErrorPageProps } from "./error-page";
 export { ErrorPage } from "./error-page";
+// Authenticated page templates
+export type { IndexPageTemplateProps } from "./index-page-template";
+export { IndexPageTemplate } from "./index-page-template";
 export type { LoadingPageProps } from "./loading-page";
 export { LoadingPage } from "./loading-page";
 export type { MaintenancePageProps } from "./maintenance-page";
 export { MaintenancePage } from "./maintenance-page";
+export type { MarketingPageTemplateProps } from "./marketing-page-template";
+export { MarketingPageTemplate } from "./marketing-page-template";
+export type { SettingsPageTemplateProps } from "./settings-page-template";
+export { SettingsPageTemplate } from "./settings-page-template";

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,38 @@
+// src/templates/index.ts
+//
+// @knkcs/anker/templates — page-level layout templates.
+//
+// Templates are the contract: they encode anker's page-pattern decisions
+// (header chrome, toolbar placement, rail behavior, content padding) so
+// every knkCMS solution renders the same way. If a template doesn't fit
+// your page, file an issue — don't reinvent the layout.
+//
+// See `docs/page-patterns.md` for the full specification.
+
+// AppShell + slot hooks
+export type { AppShellProps } from "./app-shell";
+export { AppShell, usePageActions, usePageRail } from "./app-shell";
+
+// Authenticated page templates
+export type { IndexPageTemplateProps } from "./index-page-template";
+export { IndexPageTemplate } from "./index-page-template";
+export type { DetailPageTemplateProps } from "./detail-page-template";
+export { DetailPageTemplate } from "./detail-page-template";
+export type { SettingsPageTemplateProps } from "./settings-page-template";
+export { SettingsPageTemplate } from "./settings-page-template";
+export type { DashboardPageTemplateProps } from "./dashboard-page-template";
+export { DashboardPageTemplate } from "./dashboard-page-template";
+
+// Unauthenticated / chromeless templates
+export type { AuthPageTemplateProps } from "./auth-page-template";
+export { AuthPageTemplate } from "./auth-page-template";
+export type { MarketingPageTemplateProps } from "./marketing-page-template";
+export { MarketingPageTemplate } from "./marketing-page-template";
+
+// Status / system pages
+export type { ErrorPageProps } from "./error-page";
+export { ErrorPage } from "./error-page";
+export type { LoadingPageProps } from "./loading-page";
+export { LoadingPage } from "./loading-page";
+export type { MaintenancePageProps } from "./maintenance-page";
+export { MaintenancePage } from "./maintenance-page";

--- a/src/templates/loading-page.stories.tsx
+++ b/src/templates/loading-page.stories.tsx
@@ -1,0 +1,30 @@
+// src/templates/loading-page.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Heading } from "../primitives/typography";
+import { LoadingPage } from "./loading-page";
+
+const meta = {
+	title: "Templates/LoadingPage",
+	component: LoadingPage,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof LoadingPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Logo = () => (
+	<Heading as="span" size="lg" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+export const Default: Story = {
+	args: {
+		logo: <Logo />,
+		message: "Loading your workspace…",
+	},
+};
+
+export const Bare: Story = {
+	args: {},
+};

--- a/src/templates/loading-page.tsx
+++ b/src/templates/loading-page.tsx
@@ -1,0 +1,46 @@
+// src/templates/loading-page.tsx
+//
+// LoadingPage — full-bleed initial-boot loading screen. Used while the
+// authenticated app shell is being hydrated (auth check, theme loading,
+// initial data fetch). For in-page loading states (e.g. tab switch),
+// prefer a centered <Spinner /> inside the page body — this template is
+// only for the very first frame of the app.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Spinner } from "../primitives/spinner";
+import { Text } from "../primitives/typography";
+
+export interface LoadingPageProps {
+	/** Optional logo rendered above the spinner. */
+	logo?: ReactNode;
+	/**
+	 * Optional message rendered below the spinner. Keep it short
+	 * (e.g. "Loading your workspace…").
+	 */
+	message?: ReactNode;
+}
+
+export function LoadingPage({ logo, message }: LoadingPageProps) {
+	return (
+		<Flex
+			data-testid="loading-page"
+			direction="column"
+			align="center"
+			justify="center"
+			minH="100vh"
+			bg="bg-canvas"
+			gap="6"
+			textAlign="center"
+		>
+			{logo && <Box>{logo}</Box>}
+			<Spinner size="lg" color="accent" />
+			{message && (
+				<Text fontSize="sm" color="muted">
+					{message}
+				</Text>
+			)}
+		</Flex>
+	);
+}
+LoadingPage.displayName = "LoadingPage";

--- a/src/templates/maintenance-page.stories.tsx
+++ b/src/templates/maintenance-page.stories.tsx
@@ -1,0 +1,31 @@
+// src/templates/maintenance-page.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Heading, Link } from "../primitives/typography";
+import { MaintenancePage } from "./maintenance-page";
+
+const meta = {
+	title: "Templates/MaintenancePage",
+	component: MaintenancePage,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof MaintenancePage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Logo = () => (
+	<Heading as="span" size="md" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+export const Default: Story = {
+	args: {
+		logo: <Logo />,
+		eta: "Estimated back online: 14:30 UTC",
+		statusLink: <Link href="#">View status page →</Link>,
+	},
+};
+
+export const Minimal: Story = {
+	args: {},
+};

--- a/src/templates/maintenance-page.tsx
+++ b/src/templates/maintenance-page.tsx
@@ -1,0 +1,97 @@
+// src/templates/maintenance-page.tsx
+//
+// MaintenancePage — full-bleed maintenance/down-for-upgrade screen. No app
+// shell. Surfaces a clear message, an optional ETA, and an optional link
+// to a status page. Operators serve this from a static asset or a
+// fallback handler when the app is offline.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+
+export interface MaintenancePageProps {
+	/** Logo rendered top-left. */
+	logo?: ReactNode;
+	/** Headline — e.g. "We'll be right back". */
+	title?: ReactNode;
+	/**
+	 * One-paragraph message explaining what's happening and what users
+	 * should do (typically "wait, we'll be back shortly").
+	 */
+	description?: ReactNode;
+	/**
+	 * Estimated-time-of-restoration banner. Pass a string like
+	 * "Estimated back online: 14:30 UTC". Rendered below the description.
+	 */
+	eta?: ReactNode;
+	/**
+	 * Optional link to a status page or twitter status. Pass a fully-
+	 * styled `<Link>` or an `<a>` element.
+	 */
+	statusLink?: ReactNode;
+}
+
+export function MaintenancePage({
+	logo,
+	title = "We'll be right back",
+	description = "We're upgrading the service. Please refresh in a few minutes.",
+	eta,
+	statusLink,
+}: MaintenancePageProps) {
+	return (
+		<Flex
+			data-testid="maintenance-page"
+			direction="column"
+			minH="100vh"
+			bg="bg-canvas"
+		>
+			{logo && (
+				<Box px="8" py="6">
+					{logo}
+				</Box>
+			)}
+			<Flex
+				flex="1"
+				direction="column"
+				align="center"
+				justify="center"
+				px="8"
+				pb="16"
+				textAlign="center"
+			>
+				<Heading
+					as="h1"
+					fontSize="3xl"
+					fontWeight="semibold"
+					color="default"
+					letterSpacing="-0.02em"
+					mb="4"
+				>
+					{title}
+				</Heading>
+				{description && (
+					<Text fontSize="md" color="muted" lineHeight="1.6" maxW="lg" mb="6">
+						{description}
+					</Text>
+				)}
+				{eta && (
+					<Box
+						px="4"
+						py="2"
+						borderWidth="1px"
+						borderColor="border"
+						borderRadius="md"
+						bg="bg-surface"
+						mb="6"
+					>
+						<Text fontSize="sm" fontWeight="medium" color="emphasized">
+							{eta}
+						</Text>
+					</Box>
+				)}
+				{statusLink && <Box>{statusLink}</Box>}
+			</Flex>
+		</Flex>
+	);
+}
+MaintenancePage.displayName = "MaintenancePage";

--- a/src/templates/marketing-page-template.stories.tsx
+++ b/src/templates/marketing-page-template.stories.tsx
@@ -1,0 +1,105 @@
+// src/templates/marketing-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../atoms/button";
+import { Box, Flex, Grid, GridItem } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+import { MarketingPageTemplate } from "./marketing-page-template";
+
+const meta = {
+	title: "Templates/MarketingPageTemplate",
+	component: MarketingPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof MarketingPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Logo = () => (
+	<Heading as="span" size="md" color="primary.700" fontWeight="bold">
+		knk
+	</Heading>
+);
+
+export const Default: Story = {
+	render: () => (
+		<MarketingPageTemplate
+			logo={<Logo />}
+			topBarRight={
+				<>
+					<Text>Product</Text>
+					<Text>Customers</Text>
+					<Text>Pricing</Text>
+					<Button size="sm" colorPalette="primary">
+						Sign in
+					</Button>
+				</>
+			}
+			heroEyebrow="IDENTITY · ACCESS · GOVERNANCE"
+			heroTitle="One sign-in for every knk product."
+			heroSubtitle="Odon is the identity backbone for the knkCMS platform — SSO, MFA, social login, and audit-ready logs in one self-hosted service."
+			heroActions={
+				<>
+					<Button colorPalette="primary" size="md">
+						Get started
+					</Button>
+					<Button variant="ghost" size="md">
+						Read the docs →
+					</Button>
+				</>
+			}
+			footer={
+				<Flex justify="space-between" align="center">
+					<Text fontSize="sm" color="muted">
+						© 2026 knk Gruppe
+					</Text>
+					<Flex gap="6" fontSize="sm" color="muted">
+						<Text>Privacy</Text>
+						<Text>Terms</Text>
+						<Text>Status</Text>
+					</Flex>
+				</Flex>
+			}
+		>
+			<Box>
+				<Heading
+					as="h2"
+					fontSize="3xl"
+					fontWeight="semibold"
+					color="default"
+					mb="8"
+					textAlign="center"
+					letterSpacing="-0.02em"
+				>
+					What's inside
+				</Heading>
+				<Grid templateColumns={{ base: "1fr", md: "repeat(3, 1fr)" }} gap="6">
+					<GridItem>
+						<Heading size="md" mb="2">
+							Single sign-on
+						</Heading>
+						<Text color="muted" fontSize="sm">
+							OIDC + OAuth2 with rotation, JWKS, and refresh-token reuse
+							detection.
+						</Text>
+					</GridItem>
+					<GridItem>
+						<Heading size="md" mb="2">
+							Multi-factor auth
+						</Heading>
+						<Text color="muted" fontSize="sm">
+							TOTP, WebAuthn, and email OTP — enforced per-org or per-user.
+						</Text>
+					</GridItem>
+					<GridItem>
+						<Heading size="md" mb="2">
+							Audit trail
+						</Heading>
+						<Text color="muted" fontSize="sm">
+							Every authentication event recorded, queryable, exportable.
+						</Text>
+					</GridItem>
+				</Grid>
+			</Box>
+		</MarketingPageTemplate>
+	),
+};

--- a/src/templates/marketing-page-template.tsx
+++ b/src/templates/marketing-page-template.tsx
@@ -1,0 +1,170 @@
+// src/templates/marketing-page-template.tsx
+//
+// MarketingPageTemplate — full-bleed landing-page chrome. No app shell, no
+// sidebar, no rail. Used for product landing pages, "about us", coming-
+// soon teasers, and other unauthenticated marketing surfaces.
+//
+// Composition (top to bottom):
+//
+//   ┌──────────────────────────────────────────┐
+//   │ topbar (logo · nav · CTA)                │
+//   ├──────────────────────────────────────────┤
+//   │ hero (eyebrow · title · subtitle · CTAs) │
+//   ├──────────────────────────────────────────┤
+//   │ children (feature sections, testimonials) │
+//   ├──────────────────────────────────────────┤
+//   │ footer (copyright, links)                │
+//   └──────────────────────────────────────────┘
+//
+// The template aims for the same refined-minimalism aesthetic as the rest
+// of anker — calm surfaces, generous spacing on the hero only, brand
+// colors used as accents rather than full backgrounds. No carousels, no
+// animated parallax, no auto-rotating testimonials.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Heading, Text } from "../primitives/typography";
+
+export interface MarketingPageTemplateProps {
+	/** Logo or wordmark, far-left of the topbar. */
+	logo?: ReactNode;
+	/** Navigation links and/or sign-in CTA, far-right of the topbar. */
+	topBarRight?: ReactNode;
+	/** Hide the topbar (rare). */
+	hideTopBar?: boolean;
+	/** Eyebrow above the hero title (uppercase, muted). */
+	heroEyebrow?: ReactNode;
+	/** Hero title — large display text. */
+	heroTitle?: ReactNode;
+	/** Hero subtitle — one-paragraph value statement. */
+	heroSubtitle?: ReactNode;
+	/** Hero CTAs — typically one solid button + one ghost link. */
+	heroActions?: ReactNode;
+	/** Optional visual rendered to the right of the hero copy on wide viewports. */
+	heroVisual?: ReactNode;
+	/**
+	 * Feature sections, testimonials, etc. Rendered with `maxW="6xl"` and
+	 * `marginInline="auto"` so content tracks a consistent reading column.
+	 */
+	children?: ReactNode;
+	/** Footer content — copyright, secondary nav, contact. */
+	footer?: ReactNode;
+}
+
+export function MarketingPageTemplate({
+	logo,
+	topBarRight,
+	hideTopBar,
+	heroEyebrow,
+	heroTitle,
+	heroSubtitle,
+	heroActions,
+	heroVisual,
+	children,
+	footer,
+}: MarketingPageTemplateProps) {
+	return (
+		<Box data-testid="marketing-page-template" minH="100vh" bg="bg-canvas">
+			{!hideTopBar && (
+				<Flex
+					align="center"
+					justify="space-between"
+					px="8"
+					py="4"
+					bg="bg-surface"
+					borderBottomWidth="1px"
+					borderBottomColor="border"
+				>
+					<Box>{logo}</Box>
+					<Flex gap="6" align="center" fontSize="sm" color="emphasized">
+						{topBarRight}
+					</Flex>
+				</Flex>
+			)}
+
+			{(heroEyebrow || heroTitle || heroSubtitle || heroActions) && (
+				<Box px="8" py="20" bg="bg-canvas">
+					<Flex
+						maxW="6xl"
+						marginInline="auto"
+						align="center"
+						gap="12"
+						direction={{ base: "column", md: "row" }}
+					>
+						<Box flex="1" minW="0">
+							{heroEyebrow && (
+								<Text
+									fontSize="2xs"
+									fontWeight="semibold"
+									letterSpacing="wider"
+									textTransform="uppercase"
+									color="muted"
+									mb="3"
+								>
+									{heroEyebrow}
+								</Text>
+							)}
+							{heroTitle && (
+								<Heading
+									as="h1"
+									fontSize={{ base: "4xl", md: "6xl" }}
+									fontWeight="semibold"
+									color="default"
+									letterSpacing="-0.02em"
+									lineHeight="1.05"
+									mb="5"
+								>
+									{heroTitle}
+								</Heading>
+							)}
+							{heroSubtitle && (
+								<Text
+									fontSize="lg"
+									color="muted"
+									lineHeight="1.6"
+									maxW="2xl"
+									mb="8"
+								>
+									{heroSubtitle}
+								</Text>
+							)}
+							{heroActions && (
+								<Flex gap="3" align="center">
+									{heroActions}
+								</Flex>
+							)}
+						</Box>
+						{heroVisual && (
+							<Box flex="1" minW="0" display={{ base: "none", md: "block" }}>
+								{heroVisual}
+							</Box>
+						)}
+					</Flex>
+				</Box>
+			)}
+
+			{children && (
+				<Box px="8" py="16">
+					<Box maxW="6xl" marginInline="auto">
+						{children}
+					</Box>
+				</Box>
+			)}
+
+			{footer && (
+				<Box
+					px="8"
+					py="8"
+					bg="bg-subtle"
+					borderTopWidth="1px"
+					borderTopColor="border"
+				>
+					<Box maxW="6xl" marginInline="auto">
+						{footer}
+					</Box>
+				</Box>
+			)}
+		</Box>
+	);
+}
+MarketingPageTemplate.displayName = "MarketingPageTemplate";

--- a/src/templates/settings-page-template.stories.tsx
+++ b/src/templates/settings-page-template.stories.tsx
@@ -1,0 +1,58 @@
+// src/templates/settings-page-template.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Sidebar } from "../components/sidebar/sidebar";
+import { Card } from "../components/card";
+import { Tabs } from "../primitives/tabs";
+import { Box } from "../primitives/layout";
+import { Text } from "../primitives/typography";
+import { AppShell } from "./app-shell";
+import { SettingsPageTemplate } from "./settings-page-template";
+
+const meta = {
+	title: "Templates/SettingsPageTemplate",
+	component: SettingsPageTemplate,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof SettingsPageTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleSidebar = () => (
+	<Sidebar>
+		<Sidebar.Header>
+			<Sidebar.Logo wordmark="Odon" />
+		</Sidebar.Header>
+		<Sidebar.Body>
+			<Sidebar.Section label="Personal">
+				<Sidebar.Item active>Settings</Sidebar.Item>
+			</Sidebar.Section>
+		</Sidebar.Body>
+	</Sidebar>
+);
+
+export const Default: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<SettingsPageTemplate
+				breadcrumbs={[{ label: "Personal" }, { label: "Settings" }]}
+				title="Personal settings"
+				subtitle="Manage your profile, password, and security preferences."
+				tabs={
+					<Tabs.Root defaultValue="profile" variant="line">
+						<Box px="8">
+							<Tabs.List>
+								<Tabs.Trigger value="profile">Profile</Tabs.Trigger>
+								<Tabs.Trigger value="password">Password</Tabs.Trigger>
+								<Tabs.Trigger value="mfa">Two-factor auth</Tabs.Trigger>
+							</Tabs.List>
+						</Box>
+					</Tabs.Root>
+				}
+			>
+				<Card title="Profile">
+					<Text color="muted">[ form fields go here ]</Text>
+				</Card>
+			</SettingsPageTemplate>
+		</AppShell>
+	),
+};

--- a/src/templates/settings-page-template.stories.tsx
+++ b/src/templates/settings-page-template.stories.tsx
@@ -1,9 +1,9 @@
 // src/templates/settings-page-template.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
-import { Sidebar } from "../components/sidebar/sidebar";
 import { Card } from "../components/card";
-import { Tabs } from "../primitives/tabs";
+import { Sidebar } from "../components/sidebar/sidebar";
 import { Box } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
 import { Text } from "../primitives/typography";
 import { AppShell } from "./app-shell";
 import { SettingsPageTemplate } from "./settings-page-template";

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -1,0 +1,84 @@
+// src/templates/settings-page-template.tsx
+//
+// SettingsPageTemplate — for any "preferences / configuration" page that
+// uses a tabbed split between mixed form / list content. Visually identical
+// to DetailPageTemplate today, but exposed as a separate template so its
+// authoring rules (tabs are required, body is padded, max-width on forms)
+// can evolve independently.
+//
+//   ┌─────────────────────────────────────────┐
+//   │ PageHeader  (breadcrumbs · title · …)   │
+//   ├─────────────────────────────────────────┤
+//   │ Tabs (required for settings)            │
+//   ├─────────────────────────────────────────┤
+//   │ children (form cards · lists · …)       │
+//   └─────────────────────────────────────────┘
+//
+// Use this template for: personal-settings (profile, password, MFA tabs),
+// organization settings, identity-provider settings, admin → general.
+
+import type { ReactNode } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { useRegisteredPageActions } from "./app-shell";
+
+export interface SettingsPageTemplateProps
+	extends Pick<
+		PageHeaderProps,
+		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
+	> {
+	actions?: ReactNode;
+	/**
+	 * Tab strip. Settings pages should always have at least two tabs — if
+	 * you only have one section, use DetailPageTemplate instead.
+	 */
+	tabs: ReactNode;
+	/** Page body — typically Card-wrapped forms or DataLists. */
+	children: ReactNode;
+	/**
+	 * Constrain the body width for readability. Settings forms read better
+	 * at ~720px even on wide viewports. Pass a Chakra width token (`"3xl"`,
+	 * `"4xl"`) or any CSS length. @default "3xl" (= 768px)
+	 *
+	 * Pass `"full"` to disable the constraint entirely.
+	 */
+	maxBodyWidth?: string;
+}
+
+export function SettingsPageTemplate({
+	breadcrumbs,
+	title,
+	subtitle,
+	eyebrow,
+	actions,
+	tabs,
+	children,
+	maxBodyWidth = "3xl",
+}: SettingsPageTemplateProps) {
+	const registered = useRegisteredPageActions();
+	const resolvedActions = actions ?? registered;
+	return (
+		<Flex
+			data-testid="settings-page-template"
+			direction="column"
+			flex="1"
+			minH="0"
+			bg="bg-canvas"
+		>
+			<PageHeader
+				breadcrumbs={breadcrumbs}
+				title={title}
+				subtitle={subtitle}
+				eyebrow={eyebrow}
+				actions={resolvedActions}
+			/>
+			<Box>{tabs}</Box>
+			<Box flex="1" minH="0" px="8" pt="6">
+				<Box maxW={maxBodyWidth} marginInline={maxBodyWidth === "full" ? "0" : "auto"}>
+					{children}
+				</Box>
+			</Box>
+		</Flex>
+	);
+}
+SettingsPageTemplate.displayName = "SettingsPageTemplate";

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -18,8 +18,8 @@
 // organization settings, identity-provider settings, admin → general.
 
 import type { ReactNode } from "react";
-import { Box, Flex } from "../primitives/layout";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Box, Flex } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
 
 export interface SettingsPageTemplateProps
@@ -74,7 +74,10 @@ export function SettingsPageTemplate({
 			/>
 			<Box>{tabs}</Box>
 			<Box flex="1" minH="0" px="8" pt="6">
-				<Box maxW={maxBodyWidth} marginInline={maxBodyWidth === "full" ? "0" : "auto"}>
+				<Box
+					maxW={maxBodyWidth}
+					marginInline={maxBodyWidth === "full" ? "0" : "auto"}
+				>
 					{children}
 				</Box>
 			</Box>

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "atoms/index": "src/atoms/index.ts",
     "forms/index": "src/forms/index.ts",
     "feedback/index": "src/feedback/index.ts",
+    "templates/index": "src/templates/index.ts",
   },
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- Introduces a new `@knkcs/anker/templates` entrypoint with ten canonical page-level templates (`AppShell`, `IndexPageTemplate`, `DetailPageTemplate`, `SettingsPageTemplate`, `DashboardPageTemplate`, `AuthPageTemplate`, `MarketingPageTemplate`, `ErrorPage`, `LoadingPage`, `MaintenancePage`).
- Adds `docs/page-patterns.md` (~1300 lines) as the source-of-truth contract for every knkCMS solution: app-shell composition, sidebar IA, rail variants, header/toolbar/tab/modal/form/empty-state patterns, full template catalog with composition diagrams + slot tables + escape hatches, slot-mechanism rationale, and authoring rules.
- Authored from first principles using existing anker primitives — no code lifted from odon. The slot-context inside `AppShell` (powering `usePageActions` / `usePageRail`) is implemented fresh with the `useSyncExternalStore` external-store pattern that PR #115 in odon proved correct.

## Out of scope (deferred, deliberately)

- A test suite for the templates themselves. Storybook visual smoke is in place; full DOM tests can land in a follow-up.
- React-Router-style sub-route helpers. Templates are pure layout and don't know about routing — consumers wire that.

## What ships

| Deliverable | Notes |
|---|---|
| `src/templates/*.tsx` (10 templates + barrel) | Slot-driven, no business logic, internally compose existing anker primitives |
| `src/templates/*.stories.tsx` | One canonical story per template + selected variants |
| `docs/page-patterns.md` (1311 lines) | Comprehensive spec — composition diagrams, slot tables, authoring rules |
| `README.md` "Setup for consumers" | Provider tree, fonts, theme presets, opt-out paths, hello-world |
| `CLAUDE-ANKER.md` "Page templates" section | Lists templates, the "use templates before primitives" rule, import path |
| `docs/design-system.md` cross-reference | Points to page-patterns.md for layout patterns |
| `CHANGELOG.md` 1.9.0 entry | Additive — no breaking changes |
| `tsup.config.ts` + `package.json` exports | New `./templates` entrypoint |
| `scripts/check-chakra-imports.ts` | Now also scans `src/templates` |

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 94 / 94 pass (unchanged)
- `npx biome check src` — 0 errors (18 pre-existing warnings, none new)
- `npx tsx scripts/check-chakra-imports.ts` — clean
- `npx tsup` — clean, `dist/templates/index.{js,d.ts}` produced
- `npx storybook build` — clean, all template stories render

## Test plan

- [ ] `npm run dev` (storybook) — verify Templates/* stories render
- [ ] In a consumer (odon, core), bump anker to 1.9.0 and adopt `<AppShell>` + `<IndexPageTemplate>` on one page; confirm visual parity
- [ ] Visual diff vs. existing odon ad-hoc shell — note any divergences for follow-up odon corrections (this PR establishes anker as the contract; odon will follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)