### PR TITLE
fix(templates): AppShell rail slot reads its own store (1.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.1] — 2026-05-05
+
+### Fixed
+
+- **`<AppShell>` rail slot now shows descendant-registered content.** In 1.9.0, `<AppShell>` consumed its own slot store via `useSlotValue("rail")` at the same level it provided that store, so `useContext` resolved to the parent context (null) and any content registered through `usePageRail(...)` was dropped on the floor. AppShell is now split into an outer Provider and an inner Renderer so the Renderer's `useContext` resolves to the live store. The page-actions slot was unaffected (page templates that read it are descendants of AppShell, so their context lookup already worked).
+- **Rail precedence is now defined and documented.** Content registered by a descendant via `usePageRail` wins over the static `rail` prop. The `rail` prop becomes a fallback for the column when no descendant has registered content. The rail column is reserved (third grid track added) when *either* a `rail` prop is supplied *or* a descendant has registered rail content; omit both to drop the column entirely. No breaking changes — solutions that only used the `rail` prop continue to work identically.
+
 ## [1.9.0] — 2026-05-05
 
 ### Added

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -94,24 +94,43 @@ templates) stay decoupled across React commit boundaries. See
 ### Composition example
 
 ```tsx
-import { AppShell } from "@knkcs/anker/templates";
+import { AppShell, usePageRail } from "@knkcs/anker/templates";
 import { Sidebar, ContextRail } from "@knkcs/anker/components";
 
 export default function Layout({ children }) {
   return (
-    <AppShell
-      sidebar={<MyAppSidebar />}
-      rail={<ContextRail storageKey="myapp-rail" />}
-    >
+    <AppShell sidebar={<MyAppSidebar />}>
       {children}
     </AppShell>
   );
 }
+
+// Inside any descendant of <AppShell>:
+function UsersPage() {
+  usePageRail(
+    <ContextRail>
+      <ContextRail.Header eyebrow="OVERVIEW" title="Users" />
+      <ContextRail.Section id="stats" label="Stats">
+        42 total users
+      </ContextRail.Section>
+    </ContextRail>,
+  );
+  return <IndexPageTemplate title="Users">…</IndexPageTemplate>;
+}
 ```
 
-If the rail column is omitted entirely (`rail` not passed, or `null`),
-AppShell drops the third grid column and the main column expands to fill
-the freed space. This is the right shape for solutions that don't have a
+### Rail precedence
+
+When both a `rail` prop *and* a descendant `usePageRail(content)` are
+present, **registered slot content wins** and the `rail` prop acts as a
+fallback. Rationale: a descendant explicitly registering content is
+signaling "show this here", which should trump the static prop.
+
+The rail column is reserved (the third grid track is added) when *either*
+a `rail` prop is supplied *or* a descendant has registered rail content
+via `usePageRail`. Omit both (or pass `rail={null}`) and AppShell drops
+the third grid column entirely — the main column expands to fill the
+freed space. This is the right shape for solutions that don't have a
 contextual side panel.
 
 ---
@@ -1157,10 +1176,14 @@ This section enumerates the `@knkcs/anker/templates` exports.
 | Prop      | Type        | Required | Notes                                          |
 |-----------|-------------|----------|------------------------------------------------|
 | `sidebar` | `ReactNode` | yes      | Typically `<Sidebar>` from `/components`       |
-| `rail`    | `ReactNode` | no       | Pass `null` / omit to drop the rail column     |
+| `rail`    | `ReactNode` | no       | Fallback for the rail column. `usePageRail` registration wins. |
 | `children`| `ReactNode` | yes      | Page content                                   |
 
 Exposes hooks: `usePageActions(node)`, `usePageRail(node)`.
+
+Rail precedence: descendant `usePageRail(content)` wins over the `rail`
+prop. The column is reserved when *either* a prop is supplied *or* a
+descendant registers content; omit both to drop the third grid track.
 
 ### 13.2 `<IndexPageTemplate>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/templates/app-shell.stories.tsx
+++ b/src/templates/app-shell.stories.tsx
@@ -113,3 +113,15 @@ export const WithSlotRegistration: Story = {
 		</AppShell>
 	),
 };
+
+// Demonstrates descendant-driven rail content with no `rail` prop on AppShell.
+// The rail column appears purely because the child called `usePageRail(...)`.
+// This is the common shape for solutions where each route owns its own rail
+// content and there's no app-wide default.
+export const DescendantDrivenRail: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />}>
+			<RegisteringChild />
+		</AppShell>
+	),
+};

--- a/src/templates/app-shell.test.tsx
+++ b/src/templates/app-shell.test.tsx
@@ -1,0 +1,81 @@
+// src/templates/app-shell.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { AppShell, usePageRail } from "./app-shell";
+
+function renderWithChakra(ui: ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+function RailRegistrar() {
+	usePageRail(<div data-testid="rail-content">registered rail</div>);
+	return <div data-testid="page-body">body</div>;
+}
+
+describe("AppShell", () => {
+	it("renders the sidebar", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div data-testid="sb">sidebar</div>}>
+				<div>main</div>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("sb")).toBeInTheDocument();
+	});
+
+	it("drops the rail column when no rail prop is supplied and no descendant registers content", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div data-testid="sb" />}>
+				<div>main</div>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("app-shell")).toHaveAttribute(
+			"data-rail",
+			"false",
+		);
+	});
+
+	it("renders the rail prop when no descendant registers content", () => {
+		renderWithChakra(
+			<AppShell
+				sidebar={<div data-testid="sb" />}
+				rail={<div data-testid="prop-rail">from prop</div>}
+			>
+				<div>main</div>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("prop-rail")).toBeInTheDocument();
+	});
+
+	it("renders rail content registered by a descendant via usePageRail", () => {
+		// Regression for #119: AppShell consumed its own slot store at the same
+		// level it provided it, so the rail column never picked up content
+		// registered by descendants. Splitting the consumer out of the provider
+		// fixes this.
+		renderWithChakra(
+			<AppShell
+				sidebar={<div data-testid="sb" />}
+				rail={<div data-testid="prop-rail">from prop</div>}
+			>
+				<RailRegistrar />
+			</AppShell>,
+		);
+		expect(screen.getByTestId("rail-content")).toBeInTheDocument();
+		// Registered content wins over the prop fallback.
+		expect(screen.queryByTestId("prop-rail")).not.toBeInTheDocument();
+	});
+
+	it("registered rail content shows even when no rail prop was passed", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div data-testid="sb" />}>
+				<RailRegistrar />
+			</AppShell>,
+		);
+		expect(screen.getByTestId("rail-content")).toBeInTheDocument();
+		expect(screen.getByTestId("app-shell")).toHaveAttribute(
+			"data-rail",
+			"true",
+		);
+	});
+});

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -185,15 +185,13 @@ export interface AppShellProps {
 	 */
 	sidebar: ReactNode;
 	/**
-	 * Context rail element. Pass an instance of `<ContextRail>` to enable the
-	 * rail column. Pass `null` (or omit) to disable the column entirely (no
-	 * grid track is reserved). Pages can still register rail content via
-	 * `usePageRail` — when the rail column is disabled, registered content is
-	 * dropped silently.
+	 * Context rail element. Acts as a *fallback* for the rail column: it
+	 * renders when no descendant has registered rail content via
+	 * `usePageRail`. Registered content always wins over the prop.
 	 *
-	 * Tip: pass an _empty_ `<ContextRail>` if you want the column to exist
-	 * (so child pages can populate it via `usePageRail`) without rendering
-	 * any default content.
+	 * The rail column is enabled — and a grid track is reserved — when *either*
+	 * a `rail` prop is supplied *or* a descendant has registered rail content.
+	 * Omit both (or pass `null`) to drop the rail column entirely.
 	 */
 	rail?: ReactNode;
 	/** Page content. */
@@ -208,49 +206,61 @@ export interface AppShellProps {
  * AppShell is layout-only — it does not render a PageHeader, and it does not
  * inject any business chrome. Pages compose `<IndexPageTemplate>`,
  * `<DetailPageTemplate>`, etc. inside `children`.
+ *
+ * Rail precedence: content registered by a descendant via `usePageRail` wins
+ * over the static `rail` prop. The prop is the fallback when no descendant
+ * has registered content. Rationale: a descendant explicitly registering
+ * content is signaling "show this here", which should trump the static prop.
  */
 export function AppShell({ sidebar, rail, children }: AppShellProps) {
+	// AppShell is split into an outer Provider and an inner Renderer so the
+	// renderer's `useContext(SlotStoreContext)` resolves to *our* store rather
+	// than the parent context. (A naive single component that both provides
+	// and consumes the context at the same level reads the parent context —
+	// the Provider only takes effect for descendants.)
 	const store = useMemo(() => createSlotStore(), []);
-	const railNode = useSlotValue("rail");
-
-	// The rail column is enabled when the consumer passed a `rail` element.
-	// We use the consumer-supplied element as a *container* for the
-	// dynamically-registered rail content: anything registered via
-	// `usePageRail` is appended into that container at render time. This
-	// keeps the framing chrome (collapse toggle, scrolling, borders) under
-	// the consumer's control while letting pages contribute body content.
-	//
-	// Implementation note: we render `rail` as-is and tee its `children`
-	// across (a) whatever the consumer passed and (b) whatever a page
-	// registered via `usePageRail`. The simplest, escape-hatch-friendly
-	// behavior is: if a page has registered rail content, render that;
-	// otherwise render the consumer's `rail` as-is. Consumers that want
-	// "default + page-specific" content can wire that themselves.
-	const showRailColumn = rail !== undefined && rail !== null;
-	const renderedRail = railNode ?? rail;
-
 	return (
 		<SlotStoreContext.Provider value={store}>
-			<Grid
-				data-testid="app-shell"
-				data-rail={showRailColumn ? "true" : "false"}
-				templateColumns={showRailColumn ? "auto 1fr auto" : "auto 1fr"}
-				minH="100vh"
-				bg="bg-canvas"
-			>
-				<Box gridColumn="1" minW="0">
-					{sidebar}
-				</Box>
-				<Flex gridColumn="2" direction="column" minW="0" minH="100vh">
-					{children}
-				</Flex>
-				{showRailColumn ? (
-					<Box gridColumn="3" minW="0">
-						{renderedRail}
-					</Box>
-				) : null}
-			</Grid>
+			<AppShellInner sidebar={sidebar} rail={rail}>
+				{children}
+			</AppShellInner>
 		</SlotStoreContext.Provider>
 	);
 }
 AppShell.displayName = "AppShell";
+
+function AppShellInner({ sidebar, rail, children }: AppShellProps) {
+	const railNode = useSlotValue("rail");
+
+	// Precedence: registered rail content wins, fall back to the `rail` prop.
+	// The rail column is enabled when *either* the consumer passed a `rail`
+	// element *or* a descendant registered content via `usePageRail`.
+	const renderedRail = railNode ?? rail;
+	const showRailColumn =
+		renderedRail !== undefined &&
+		renderedRail !== null &&
+		renderedRail !== false;
+
+	return (
+		<Grid
+			data-testid="app-shell"
+			data-rail={showRailColumn ? "true" : "false"}
+			templateColumns={showRailColumn ? "auto 1fr auto" : "auto 1fr"}
+			minH="100vh"
+			bg="bg-canvas"
+		>
+			<Box gridColumn="1" minW="0">
+				{sidebar}
+			</Box>
+			<Flex gridColumn="2" direction="column" minW="0" minH="100vh">
+				{children}
+			</Flex>
+			{showRailColumn ? (
+				<Box gridColumn="3" minW="0">
+					{renderedRail}
+				</Box>
+			) : null}
+		</Grid>
+	);
+}
+AppShellInner.displayName = "AppShellInner";


### PR DESCRIPTION
## Summary

- Fixes the `<AppShell>` rail slot: in 1.9.0, AppShell consumed `useSlotValue("rail")` at the same level it provided the store, so `useContext` resolved to the parent context (null) and descendant `usePageRail(...)` registrations were dropped on the floor. The page-actions slot was unaffected because page templates are descendants. AppShell is now split into an outer Provider and an inner Renderer so the Renderer's context lookup resolves to the live store.
- Defines rail precedence: a descendant `usePageRail(content)` wins, the `rail` prop is the fallback. The column is reserved when *either* a `rail` prop is supplied *or* a descendant has registered content. No breaking changes — the public API is identical.
- Bumps to `1.9.1`.

odon's first 1.9.0 adoption (PR #119 in odon) had to work around this with prop-driven rail plumbing; once 1.9.1 ships odon can drop the workaround.

## Changes

- `src/templates/app-shell.tsx` — split `AppShell` into Provider + `AppShellInner`. Updated JSDoc on the `rail` prop and component to document precedence.
- `src/templates/app-shell.test.tsx` — new vitest file. Covers sidebar render, no-rail column, prop-driven rail, descendant-driven rail (the regression), and registered-wins-over-prop. The regression tests fail on `main` and pass with the fix.
- `src/templates/app-shell.stories.tsx` — added `DescendantDrivenRail` story (no `rail` prop, child calls `usePageRail`).
- `docs/page-patterns.md` — composition example now uses `usePageRail`; added a "Rail precedence" subsection; updated the section 13.1 prop table.
- `CHANGELOG.md` — `1.9.1` entry.
- `package.json` — version bump.

## Test plan

- [x] `npm run lint` clean (Biome + chakra-imports check).
- [x] `npm run typecheck` clean.
- [x] `npm test` — 17 files, 193 tests passing (5 new tests for AppShell).
- [x] `npm run build` clean.
- [x] `npm run build:storybook` clean.
- [ ] Reviewer: open the `Templates/AppShell` story and confirm `DescendantDrivenRail` shows the registered rail (no `rail` prop on AppShell).

## Publish

Do **not** enable auto-merge — user will merge. After merge, push `v1.9.1` tag separately to fire the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)