### PR TITLE
fix(templates): DetailPageTemplate flush by default; doc contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.2] — 2026-05-05
+
+### Changed
+
+- **`<DetailPageTemplate>` now renders its body flush by default; the `flush` prop has been removed.** Previously the body wrapper applied `px="8" pt="6"` by default and accepted a `flush` opt-out — asymmetric with `<IndexPageTemplate>` (always flush) and a source of double-padding when children were `<Card>` (which has its own `p="6"`). Detail pages now match the index template's body shape: full-bleed by default, consumers add internal padding inside `children` (e.g. `<Box px="8" pt="6">`) when they need it. **Breaking change** for the small number of consumers passing `flush` explicitly — drop the prop. Consumers that previously relied on the implicit padded body should wrap their `children` in `<Box px="8" pt="6">`.
+
+### Documentation
+
+- **`docs/page-patterns.md` — rail-header contract.** Section 4 (ContextRail) now documents the rail-header contract: rail content MUST start with `<ContextRail.Header>` so the rail's top has a structural element matching the PageHeader's height. Without it the PageHeader's bottom border doesn't visually align with anything in the rail column. Adds a "Common rail mistakes" callout.
+- **`docs/page-patterns.md` — body tabs vs. sidebar sub-sections.** Sections 3 (Sidebar IA) and 11.2 (DetailPageTemplate) now include a clear "When to use" callout: body tabs for multiple views of the same entity (one page header), sidebar sub-sections for distinct destinations (one page header per item). Don't mix the two in the same view.
+
 ## [1.9.1] — 2026-05-05
 
 ### Fixed

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -233,6 +233,28 @@ The order is: most-personal first, most-administrative last. This
 matches the user's likely path of investigation when looking for a
 setting.
 
+### Body tabs vs. sidebar sub-sections — when to choose which
+
+> **Body tabs vs sidebar sub-sections — when to choose which:**
+>
+> - Use **body tabs** (DetailPageTemplate `tabs` slot) when the page
+>   presents *multiple views of the same entity* — e.g. a user with
+>   Profile / Security / Sessions / API Keys tabs. The user is exploring
+>   one record; the URL stays at `/users/123/<tab>` and the page chrome
+>   stays the same.
+>
+> - Use **sidebar sub-sections** when the items are *distinct
+>   destinations* — e.g. an Admin section with Users / OAuth Clients /
+>   Webhooks / Audit Log as separate index pages. Each is a top-level
+>   navigation target with its own page header.
+>
+> **Rule of thumb:** if the page header (title, breadcrumb, identity
+> card) stays the same across the items, they're tabs. If each item has
+> its own page header, they're sub-section nav.
+>
+> Don't mix the two in the same view — both UIs competing for the user's
+> eye is more noise than signal. Pick one based on the rule above.
+
 ---
 
 ## 4. ContextRail patterns
@@ -322,6 +344,40 @@ covering the table.
 When the rail is collapsed, only a thin 44px column with the
 expand-toggle remains. Section content is hidden. Tooltips on the
 toggle hint at what's hidden.
+
+### Rail-header contract
+
+> **Rail-header contract (required for alignment):** rail content MUST
+> start with `<ContextRail.Header>` (eyebrow + title) so the rail's top
+> has a structural element matching the PageHeader's height in the page
+> column. Without it, the PageHeader's bottom border (which is inside
+> the page-content column) doesn't visually align with anything in the
+> rail column, and the rail appears to float above the page divider.
+>
+> Example:
+>
+> ```tsx
+> usePageRail(
+>   <ContextRail>
+>     <ContextRail.Header eyebrow="WORKSPACE" title="Overview" />
+>     <ContextRail.Section …>…</ContextRail.Section>
+>   </ContextRail>,
+> );
+> ```
+
+### Common rail mistakes
+
+1. **Missing `<ContextRail.Header>`.** The #1 cause of misalignment
+   between the PageHeader bottom border and the rail content. Always
+   start a rail with `<ContextRail.Header>` — see the rail-header
+   contract above.
+2. **Rendering a rail on a settings/form page.** Rails compete with
+   form fields for the user's attention; settings should be read
+   top-to-bottom. See "When to hide" above.
+3. **Stuffing primary actions in the rail.** Primary actions belong in
+   the PageHeader's `actions` slot (via `usePageActions` or the
+   `actions` prop). The rail is for at-a-glance information, not the
+   page's main verbs.
 
 ---
 
@@ -747,6 +803,26 @@ or list, optionally filtered.
 **When to use.** Any "single entity" page: a single user, a single
 OAuth client, a single audit event detail, a single webhook config.
 
+> **Body tabs vs sidebar sub-sections — when to choose which:**
+>
+> - Use **body tabs** (DetailPageTemplate `tabs` slot) when the page
+>   presents *multiple views of the same entity* — e.g. a user with
+>   Profile / Security / Sessions / API Keys tabs. The user is exploring
+>   one record; the URL stays at `/users/123/<tab>` and the page chrome
+>   stays the same.
+>
+> - Use **sidebar sub-sections** when the items are *distinct
+>   destinations* — e.g. an Admin section with Users / OAuth Clients /
+>   Webhooks / Audit Log as separate index pages. Each is a top-level
+>   navigation target with its own page header.
+>
+> **Rule of thumb:** if the page header (title, breadcrumb, identity
+> card) stays the same across the items, they're tabs. If each item has
+> its own page header, they're sub-section nav.
+>
+> Don't mix the two in the same view — both UIs competing for the user's
+> eye is more noise than signal. Pick one based on the rule above.
+
 **Composition.**
 
 ```
@@ -756,7 +832,8 @@ OAuth client, a single audit event detail, a single webhook config.
 │ Tabs (optional)                       │
 ├───────────────────────────────────────┤
 │ children  (identity Card · panes …)   │
-│   px="8" pt="6" by default            │
+│   flush — add internal padding in     │
+│   children if you need it             │
 └───────────────────────────────────────┘
 ```
 
@@ -767,13 +844,13 @@ OAuth client, a single audit event detail, a single webhook config.
 | `breadcrumbs`, `title`, `subtitle`, `eyebrow` | … | … | Same as IndexPageTemplate            |
 | `actions`     | `ReactNode` | reads `usePageActions` | —                                         |
 | `tabs`        | `ReactNode` | —       | Recommended for entities with multiple aspects       |
-| `children`    | `ReactNode` | —       | Body — typically an identity Card + tab content      |
-| `flush`       | `boolean`   | `false` | When `true`, removes the default `px="8" pt="6"`     |
+| `children`    | `ReactNode` | —       | Body, flush. Add internal padding in `children`.     |
 
 **Escape hatches.**
 
-- `flush={true}` removes the default body padding. Use for code-editor
-  pages or full-bleed media viewers.
+- The body is rendered flush (no padding). If you need a padded body
+  (e.g. cards that shouldn't sit against the page edges), wrap children
+  in `<Box px="8" pt="6">`. This matches `IndexPageTemplate`.
 - The identity-Card-then-tabs pattern is a convention, not a
   requirement. A detail page without tabs is fine — render the body
   however the entity demands.
@@ -1205,8 +1282,7 @@ descendant registers content; omit both to drop the third grid track.
 | `title`       | `ReactNode` | yes      |                                                |
 | `breadcrumbs`, `subtitle`, `eyebrow`, `actions` | … | no |                                |
 | `tabs`        | `ReactNode` | no       |                                                |
-| `flush`       | `boolean`   | no       | `true` removes default body padding            |
-| `children`    | `ReactNode` | yes      | Body, padded by default                        |
+| `children`    | `ReactNode` | yes      | Body, flush                                    |
 
 ### 13.4 `<SettingsPageTemplate>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/templates/detail-page-template.stories.tsx
+++ b/src/templates/detail-page-template.stories.tsx
@@ -53,11 +53,18 @@ export const Default: Story = {
 					</Tabs.Root>
 				}
 			>
-				<Card title="Identity">
-					<Text color="muted">
-						Identity card content (avatar, persona block, role).
-					</Text>
-				</Card>
+				{/*
+				 * The body is rendered flush against the canvas. Add internal
+				 * padding inside `children` if cards/tables need breathing room
+				 * — here we wrap in a `<Box px="8" pt="6">`.
+				 */}
+				<Box px="8" pt="6">
+					<Card title="Identity">
+						<Text color="muted">
+							Identity card content (avatar, persona block, role).
+						</Text>
+					</Card>
+				</Box>
 			</DetailPageTemplate>
 		</AppShell>
 	),

--- a/src/templates/detail-page-template.test.tsx
+++ b/src/templates/detail-page-template.test.tsx
@@ -1,0 +1,69 @@
+// src/templates/detail-page-template.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { AppShell } from "./app-shell";
+import { DetailPageTemplate } from "./detail-page-template";
+
+function renderWithChakra(ui: ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("DetailPageTemplate", () => {
+	it("renders the title", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate title="Jana Schmid">
+					<div>body</div>
+				</DetailPageTemplate>
+			</AppShell>,
+		);
+		expect(
+			screen.getByRole("heading", { name: "Jana Schmid" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the body children", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate title="Jana Schmid">
+					<div data-testid="body">body</div>
+				</DetailPageTemplate>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("body")).toBeInTheDocument();
+	});
+
+	it("renders the body flush (no horizontal padding) by default", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate title="Jana Schmid">
+					<div data-testid="body">body</div>
+				</DetailPageTemplate>
+			</AppShell>,
+		);
+		// The body wrapper is the parent of the children — it must not carry
+		// inline padding styles. The previous implementation passed
+		// `px="8" pt="6"` to the wrapper Box; the flush default does not.
+		// We assert the absence of any inline padding so the body sits flush
+		// against the canvas (matching IndexPageTemplate).
+		const body = screen.getByTestId("body");
+		const wrapper = body.parentElement as HTMLElement;
+		expect(wrapper.getAttribute("style") ?? "").not.toMatch(/padding/);
+	});
+
+	it("renders the tabs slot when provided", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate
+					title="Jana Schmid"
+					tabs={<div data-testid="tabs">tabs</div>}
+				>
+					<div>body</div>
+				</DetailPageTemplate>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("tabs")).toBeInTheDocument();
+	});
+});

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -37,17 +37,10 @@ export interface DetailPageTemplateProps
 	tabs?: ReactNode;
 	/**
 	 * Page body — the entity's identity card, tab bodies, edit forms, etc.
-	 * Rendered with horizontal padding (`px="8"`) and top padding (`pt="6"`)
-	 * so cards inside don't sit flush against the page edges. Override by
-	 * passing a `<Box px="0" pt="0">…</Box>` if you need a flush layout.
+	 * Rendered flush against the canvas. Add internal padding inside
+	 * `children` if you need it.
 	 */
 	children: ReactNode;
-	/**
-	 * When `true`, removes the default `px="8" pt="6"` padding around
-	 * `children`. Use for detail pages whose body is itself a full-bleed
-	 * surface (e.g. a code editor). @default false
-	 */
-	flush?: boolean;
 }
 
 export function DetailPageTemplate({
@@ -58,7 +51,6 @@ export function DetailPageTemplate({
 	actions,
 	tabs,
 	children,
-	flush = false,
 }: DetailPageTemplateProps) {
 	const registered = useRegisteredPageActions();
 	const resolvedActions = actions ?? registered;
@@ -78,7 +70,7 @@ export function DetailPageTemplate({
 				actions={resolvedActions}
 			/>
 			{tabs ? <Box>{tabs}</Box> : null}
-			<Box flex="1" minH="0" px={flush ? "0" : "8"} pt={flush ? "0" : "6"}>
+			<Box flex="1" minH="0">
 				{children}
 			</Box>
 		</Flex>


### PR DESCRIPTION
## Summary

- **Breaking** — `<DetailPageTemplate>` now renders its body flush by default; the `flush` prop has been removed. Matches `<IndexPageTemplate>`'s shape and fixes double-padding when children are `<Card>` (which has its own `p="6"`). Consumers that previously relied on the implicit padded body should wrap `children` in `<Box px="8" pt="6">`.
- **Docs** — `docs/page-patterns.md` gains a rail-header contract callout (rail content MUST start with `<ContextRail.Header>` so the PageHeader's bottom border visually aligns) plus a "Common rail mistakes" list.
- **Docs** — `docs/page-patterns.md` clarifies body tabs vs. sidebar sub-sections in sections 3 and 11.2: body tabs for multiple views of the same entity, sidebar sub-sections for distinct destinations. Don't mix the two.
- Version `1.9.1` → `1.9.2`.

Surfaced by odon's first real consumer of `@knkcs/anker/templates`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — all 197 tests pass (added 4 new tests for DetailPageTemplate)
- [x] `npm run build` clean
- [x] `npm run build:storybook` clean
- [ ] Tag `v1.9.2` after merge (user will do this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)