### PR TITLE
fix(templates): AppShell column surfaces + drop bg-canvas in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.3] — 2026-05-05
+
+### Fixed
+
+- **`<AppShell>` main + rail columns now render on `bg-surface` (white) with 1px column dividers; page-template bodies no longer force `bg-canvas`. Restores the handoff visual design.** In 1.9.0–1.9.2 the main and rail columns inherited the grid's `bg-canvas` (gray), making them visually indistinguishable from the sidebar; the only structural separator was the PageHeader's bottom border, which left content in `<DetailHeader>` and the rail column appearing to overlap with no hard boundary. AppShell now sets `bg="bg-surface"` and a `borderLeftWidth="1px" borderColor="border"` divider on both the main column (`gridColumn="2"`) and the rail column (`gridColumn="3"`), matching odon's pre-anker hand-rolled `AppLayout`. The sidebar continues to inherit the grid's `bg-canvas` (gray) — the surface contrast is what produces the column separation.
+- **Page-template bodies no longer force `bg-canvas`.** `<IndexPageTemplate>`, `<DetailPageTemplate>`, `<SettingsPageTemplate>`, and `<DashboardPageTemplate>` previously set `bg="bg-canvas"` on their outer `<Flex>`, which overrode any surface treatment AppShell applied to its main column. The templates now inherit their parent's surface — `bg-surface` when rendered inside `<AppShell>`, or whatever the surrounding wrapper provides in stories / standalone tests. Visual-only change; no public API impact.
+
+### Documentation
+
+- **`docs/page-patterns.md` §2 — "Column surfaces" subsection added.** Documents the anker visual contract: sidebar = `bg-canvas`, main + rail = `bg-surface`, with a 1px `border` divider between each column. Consumers should not override.
+
 ## [1.9.2] — 2026-05-05
 
 ### Changed

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -119,6 +119,30 @@ function UsersPage() {
 }
 ```
 
+### Column surfaces
+
+Each column has a defined surface and a 1px divider separates them. This is
+the anker visual contract — consumers should not override.
+
+| Column   | Surface          | Token         | Left divider |
+|----------|------------------|---------------|--------------|
+| Sidebar  | gray (page frame) | `bg-canvas`   | —            |
+| Main     | white (content)   | `bg-surface`  | 1px `border` against sidebar |
+| Rail     | white (content)   | `bg-surface`  | 1px `border` against main |
+
+The sidebar inherits the grid's `bg-canvas`. The main column (`gridColumn="2"`)
+and the rail column (`gridColumn="3"`) sit on `bg-surface` with a
+`borderLeftWidth="1px" borderColor="border"` against the column to their left.
+This produces the structural separation that makes the `<PageHeader>` and
+`<DetailHeader>` content in the main column distinct from the rail content
+without relying on header borders alone.
+
+Page templates (`<IndexPageTemplate>`, `<DetailPageTemplate>`,
+`<SettingsPageTemplate>`, `<DashboardPageTemplate>`) inherit the main column's
+`bg-surface` — they no longer set their own background. This means a template
+rendered standalone (e.g. in a Storybook story without an `<AppShell>` parent)
+inherits whatever surface its wrapper provides.
+
 ### Rail precedence
 
 When both a `rail` prop *and* a descendant `usePageRail(content)` are

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knkcs/anker",
-      "version": "1.8.1",
+      "version": "1.9.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chakra-react-select": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/templates/app-shell.test.tsx
+++ b/src/templates/app-shell.test.tsx
@@ -3,10 +3,20 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
+import { createAnkerTheme } from "../theme/create-theme";
 import { AppShell, usePageRail } from "./app-shell";
 
 function renderWithChakra(ui: ReactElement) {
 	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+// Use the anker theme so semantic tokens (`bg-surface`, `border`, …) actually
+// resolve to `var(--chakra-colors-…)` references in computed styles. The
+// surrounding tests use `defaultSystem` because they only need layout / DOM
+// presence assertions; the column-surface tests below check token resolution.
+function renderWithAnkerTheme(ui: ReactElement) {
+	const system = createAnkerTheme();
+	return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
 }
 
 function RailRegistrar() {
@@ -77,5 +87,37 @@ describe("AppShell", () => {
 			"data-rail",
 			"true",
 		);
+	});
+
+	it("main column renders on the surface with a left divider", () => {
+		// Visual contract: the main column sits on `bg-surface` (white) with a
+		// 1px divider against the gray sidebar. Sidebar inherits the grid's
+		// `bg-canvas`. See docs/page-patterns.md §2 "Column surfaces".
+		renderWithAnkerTheme(
+			<AppShell sidebar={<div data-testid="sb" />}>
+				<div>main</div>
+			</AppShell>,
+		);
+		const main = screen.getByTestId("app-shell-main");
+		expect(main).toBeInTheDocument();
+		expect(main).toHaveStyle({ borderLeftWidth: "1px" });
+		const cs = window.getComputedStyle(main);
+		expect(cs.background).toContain("--chakra-colors-bg-surface");
+	});
+
+	it("rail column renders on the surface with a left divider", () => {
+		renderWithAnkerTheme(
+			<AppShell
+				sidebar={<div data-testid="sb" />}
+				rail={<div data-testid="rail">rail</div>}
+			>
+				<div>main</div>
+			</AppShell>,
+		);
+		const rail = screen.getByTestId("app-shell-rail");
+		expect(rail).toBeInTheDocument();
+		expect(rail).toHaveStyle({ borderLeftWidth: "1px" });
+		const cs = window.getComputedStyle(rail);
+		expect(cs.background).toContain("--chakra-colors-bg-surface");
 	});
 });

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -252,11 +252,27 @@ function AppShellInner({ sidebar, rail, children }: AppShellProps) {
 			<Box gridColumn="1" minW="0">
 				{sidebar}
 			</Box>
-			<Flex gridColumn="2" direction="column" minW="0" minH="100vh">
+			<Flex
+				data-testid="app-shell-main"
+				gridColumn="2"
+				direction="column"
+				minW="0"
+				minH="100vh"
+				bg="bg-surface"
+				borderLeftWidth="1px"
+				borderColor="border"
+			>
 				{children}
 			</Flex>
 			{showRailColumn ? (
-				<Box gridColumn="3" minW="0">
+				<Box
+					data-testid="app-shell-rail"
+					gridColumn="3"
+					minW="0"
+					bg="bg-surface"
+					borderLeftWidth="1px"
+					borderColor="border"
+				>
 					{renderedRail}
 				</Box>
 			) : null}

--- a/src/templates/dashboard-page-template.tsx
+++ b/src/templates/dashboard-page-template.tsx
@@ -62,7 +62,6 @@ export function DashboardPageTemplate({
 			direction="column"
 			flex="1"
 			minH="0"
-			bg="bg-canvas"
 		>
 			<PageHeader
 				breadcrumbs={breadcrumbs}

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -60,7 +60,6 @@ export function DetailPageTemplate({
 			direction="column"
 			flex="1"
 			minH="0"
-			bg="bg-canvas"
 		>
 			<PageHeader
 				breadcrumbs={breadcrumbs}

--- a/src/templates/index-page-template.tsx
+++ b/src/templates/index-page-template.tsx
@@ -81,7 +81,6 @@ export function IndexPageTemplate({
 			direction="column"
 			flex="1"
 			minH="0"
-			bg="bg-canvas"
 		>
 			<PageHeader
 				breadcrumbs={breadcrumbs}

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -63,7 +63,6 @@ export function SettingsPageTemplate({
 			direction="column"
 			flex="1"
 			minH="0"
-			bg="bg-canvas"
 		>
 			<PageHeader
 				breadcrumbs={breadcrumbs}


### PR DESCRIPTION
## Summary

- AppShell main + rail columns now render on `bg-surface` (white) with 1px column dividers (`borderLeftWidth="1px" borderColor="border"`). Sidebar continues to inherit the grid's `bg-canvas` (gray) — the surface contrast is what produces the column separation. Restores the handoff visual design (matches odon's pre-anker hand-rolled `AppLayout`).
- `<IndexPageTemplate>`, `<DetailPageTemplate>`, `<SettingsPageTemplate>`, `<DashboardPageTemplate>` no longer force `bg="bg-canvas"` on their outer Flex — they inherit the AppShell main column's surface. No public API change.
- `docs/page-patterns.md` §2: new "Column surfaces" subsection documenting the visual contract (sidebar = `bg-canvas`, main + rail = `bg-surface`, 1px `border` dividers).
- Version bumped to `1.9.3`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (pre-existing warnings unchanged)
- [x] `npm test` — 105/105 passing (added 2 new column-surface assertions)
- [x] `npm run build` clean
- [x] `npm run build:storybook` clean
- [ ] Visual smoke in odon after consuming `1.9.3` — confirm gray sidebar + white main + white rail + 1px column dividers