### PR TITLE
fix(context-rail): harden Root contract + de-dup styling + drop dead onClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.4] — 2026-05-05
+
+Doc clarification on `<ContextRail>` Root wrapper requirement; dev-mode warning when Header/Section is rendered outside Root; de-duped styling between AppShell rail column and ContextRail Root; removed dead `onClose` prop on Header.
+
+### Documentation
+
+- **`docs/page-patterns.md` §4 — Rail Root contract.** Adds an explicit "Rail Root contract (required)" subsection documenting that rail content MUST be wrapped in `<ContextRail>` (the Root) to get the column width, collapse toggle, inner padding, and persistence. Using `<ContextRail.Header>` / `<ContextRail.Section>` inside a fragment renders without errors but silently strips all of those features — a trap the first consumer (odon) fell into. The "Common rail mistakes" callout now leads with this as mistake #1.
+
+### Changed
+
+- **`<ContextRail>` Root no longer sets `bg="bg-surface"` / `borderLeftWidth="1px"` / `borderLeftColor="border"`.** That column-level styling now lives exclusively on `<AppShell>`'s rail column (added in 1.9.3), which is the source of truth and applies even when the rail content is something other than `<ContextRail>`. Eliminates the double-style. Visual contract unchanged for consumers using `<ContextRail>` inside `<AppShell>` — the surface and divider come from the column. Storybook stories now wrap `<ContextRail>` in an equivalent column wrapper so the visual still matches in isolation.
+- **Dev-mode warning when `<ContextRail.Header>` / `<ContextRail.Section>` is rendered outside `<ContextRail>`.** A small private `RailRootContext` is provided by the Root; children consume it on mount and, in `process.env.NODE_ENV !== 'production'`, log a single `console.warn` per mount with a clear message pointing at `docs/page-patterns.md`. No throw, no behavior change in production. Pure DX nudge so future consumers don't repeat odon's silent-failure bug.
+
+### Removed
+
+- **`<ContextRail.Header>` `onClose?: () => void` prop.** Dead since the component was added — the implementation only destructured it as `_onClose` and never wired it up. The Root already provides a collapse toggle; a separate "close" button on the Header would be redundant. **Technically a breaking change to the type, but no consumer ever passed the prop** — removing rather than wiring it up keeps the API surface honest.
+
 ## [1.9.3] — 2026-05-05
 
 ### Fixed

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -369,6 +369,42 @@ When the rail is collapsed, only a thin 44px column with the
 expand-toggle remains. Section content is hidden. Tooltips on the
 toggle hint at what's hidden.
 
+### Rail Root contract (required)
+
+> **Rail Root contract (required):** rail content MUST be wrapped in
+> `<ContextRail>` (the Root). The Root provides the column width
+> (360px expanded / 44px collapsed), the collapse toggle button, inner
+> padding, and persistence (`storageKey` prop). Using
+> `<ContextRail.Header>` or `<ContextRail.Section>` inside a fragment
+> renders without errors — but you'll be missing all of those features.
+>
+> **Correct:**
+>
+> ```tsx
+> usePageRail(
+>   <ContextRail storageKey="rail-users-overview">
+>     <ContextRail.Header eyebrow="WORKSPACE" title="Overview" />
+>     <ContextRail.Section …>…</ContextRail.Section>
+>   </ContextRail>
+> );
+> ```
+>
+> **Incorrect (silent failure mode):**
+>
+> ```tsx
+> usePageRail(
+>   <>
+>     <ContextRail.Header eyebrow="WORKSPACE" title="Overview" />
+>     <ContextRail.Section …>…</ContextRail.Section>
+>   </>
+> );
+> // ❌ no width, no collapse, no padding
+> ```
+>
+> In development, anker logs a `console.warn` once per mount when
+> `<ContextRail.Header>` or `<ContextRail.Section>` is rendered outside
+> a `<ContextRail>` Root. The warning is silenced in production.
+
 ### Rail-header contract
 
 > **Rail-header contract (required for alignment):** rail content MUST
@@ -391,14 +427,19 @@ toggle hint at what's hidden.
 
 ### Common rail mistakes
 
-1. **Missing `<ContextRail.Header>`.** The #1 cause of misalignment
+1. **Missing `<ContextRail>` Root wrapper.** Rendering
+   `<ContextRail.Header>` / `<ContextRail.Section>` inside a fragment
+   silently strips the column width, collapse toggle, padding, and
+   persistence. See the Rail Root contract above. anker emits a
+   dev-mode `console.warn` when this happens.
+2. **Missing `<ContextRail.Header>`.** The #1 cause of misalignment
    between the PageHeader bottom border and the rail content. Always
    start a rail with `<ContextRail.Header>` — see the rail-header
    contract above.
-2. **Rendering a rail on a settings/form page.** Rails compete with
+3. **Rendering a rail on a settings/form page.** Rails compete with
    form fields for the user's attention; settings should be read
    top-to-bottom. See "When to hide" above.
-3. **Stuffing primary actions in the rail.** Primary actions belong in
+4. **Stuffing primary actions in the rail.** Primary actions belong in
    the PageHeader's `actions` slot (via `usePageActions` or the
    `actions` prop). The rail is for at-a-glance information, not the
    page's main verbs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/context-rail/context-rail.stories.tsx
+++ b/src/components/context-rail/context-rail.stories.tsx
@@ -1,7 +1,24 @@
 // src/components/context-rail/context-rail.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
 import { History, Info, Monitor, ShieldCheck, Zap } from "lucide-react";
+import { Box, Flex } from "../../primitives/layout";
 import { ContextRail } from "./context-rail";
+
+/**
+ * In real consumers `<ContextRail>` is rendered inside `<AppShell>`'s
+ * rail column, which provides the surface background and the left
+ * divider against the main column. In isolation (storybook) we wrap
+ * the rail in an equivalent column so the visual matches what
+ * consumers will see in production.
+ */
+const RailColumn = ({ children }: { children: React.ReactNode }) => (
+	<Flex bg="bg-canvas" minH="100vh">
+		<Box flex="1" />
+		<Box bg="bg-surface" borderLeftWidth="1px" borderColor="border">
+			{children}
+		</Box>
+	</Flex>
+);
 
 const meta = {
 	title: "Components/ContextRail",
@@ -14,57 +31,59 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	render: () => (
-		<ContextRail>
-			<ContextRail.Header eyebrow="User" title="Jana Schmid" />
-			<ContextRail.Section
-				id="details"
-				icon={<Info size={14} />}
-				label="Details"
-			>
-				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
-					Role: Admin · 2FA: On · ID: usr_abc123
-				</p>
-			</ContextRail.Section>
-			<ContextRail.Section
-				id="security"
-				icon={<ShieldCheck size={14} />}
-				label="Security"
-			>
-				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
-					Last sign-in: 2 hours ago
-				</p>
-			</ContextRail.Section>
-			<ContextRail.Section
-				id="sessions"
-				icon={<Monitor size={14} />}
-				label="Active Sessions"
-			>
-				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
-					3 devices
-				</p>
-			</ContextRail.Section>
-			<ContextRail.Section
-				id="activity"
-				icon={<History size={14} />}
-				label="Recent Activity"
-			>
-				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
-					Updated profile · 1 day ago
-				</p>
-			</ContextRail.Section>
-			<ContextRail.Section
-				id="actions"
-				icon={<Zap size={14} />}
-				label="Quick Actions"
-			>
-				<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
-					Reset password · Suspend
-				</p>
-			</ContextRail.Section>
-			<ContextRail.Footer>
-				<button type="button">Open detail →</button>
-			</ContextRail.Footer>
-		</ContextRail>
+		<RailColumn>
+			<ContextRail>
+				<ContextRail.Header eyebrow="User" title="Jana Schmid" />
+				<ContextRail.Section
+					id="details"
+					icon={<Info size={14} />}
+					label="Details"
+				>
+					<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+						Role: Admin · 2FA: On · ID: usr_abc123
+					</p>
+				</ContextRail.Section>
+				<ContextRail.Section
+					id="security"
+					icon={<ShieldCheck size={14} />}
+					label="Security"
+				>
+					<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+						Last sign-in: 2 hours ago
+					</p>
+				</ContextRail.Section>
+				<ContextRail.Section
+					id="sessions"
+					icon={<Monitor size={14} />}
+					label="Active Sessions"
+				>
+					<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+						3 devices
+					</p>
+				</ContextRail.Section>
+				<ContextRail.Section
+					id="activity"
+					icon={<History size={14} />}
+					label="Recent Activity"
+				>
+					<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+						Updated profile · 1 day ago
+					</p>
+				</ContextRail.Section>
+				<ContextRail.Section
+					id="actions"
+					icon={<Zap size={14} />}
+					label="Quick Actions"
+				>
+					<p style={{ fontSize: 13, color: "var(--chakra-colors-muted)" }}>
+						Reset password · Suspend
+					</p>
+				</ContextRail.Section>
+				<ContextRail.Footer>
+					<button type="button">Open detail →</button>
+				</ContextRail.Footer>
+			</ContextRail>
+		</RailColumn>
 	),
 };
 
@@ -74,9 +93,11 @@ export const CollapsedByDefault: Story = {
 			localStorage.setItem("storybook.rail.collapsed", "true");
 		}
 		return (
-			<ContextRail storageKey="storybook.rail.collapsed">
-				<ContextRail.Header eyebrow="User" title="Jana Schmid" />
-			</ContextRail>
+			<RailColumn>
+				<ContextRail storageKey="storybook.rail.collapsed">
+					<ContextRail.Header eyebrow="User" title="Jana Schmid" />
+				</ContextRail>
+			</RailColumn>
 		);
 	},
 };

--- a/src/components/context-rail/context-rail.test.tsx
+++ b/src/components/context-rail/context-rail.test.tsx
@@ -223,4 +223,57 @@ describe("ContextRail", () => {
 		expect(header).toBeInTheDocument();
 		expect(header).toHaveStyle({ borderBottomWidth: "1px" });
 	});
+
+	describe("dev-mode warnings", () => {
+		let warnSpy: ReturnType<typeof vi.spyOn>;
+		let originalNodeEnv: string | undefined;
+
+		beforeEach(() => {
+			originalNodeEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = "development";
+			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			warnSpy.mockRestore();
+			process.env.NODE_ENV = originalNodeEnv;
+		});
+
+		it("warns once when ContextRail.Header is rendered outside <ContextRail>", () => {
+			renderWithChakra(<ContextRail.Header title="User" />);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy.mock.calls[0]?.[0]).toContain("ContextRail.Header");
+			expect(warnSpy.mock.calls[0]?.[0]).toContain(
+				"was rendered outside <ContextRail>",
+			);
+		});
+
+		it("warns when ContextRail.Section is rendered outside <ContextRail>", () => {
+			renderWithChakra(
+				<ContextRail.Section id="x" label="Details">
+					<span>body</span>
+				</ContextRail.Section>,
+			);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy.mock.calls[0]?.[0]).toContain("ContextRail.Section");
+		});
+
+		it("does NOT warn when children are wrapped in <ContextRail>", () => {
+			renderWithChakra(
+				<ContextRail>
+					<ContextRail.Header title="User" />
+					<ContextRail.Section id="x" label="Details">
+						<span>body</span>
+					</ContextRail.Section>
+				</ContextRail>,
+			);
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it("does NOT warn in production env", () => {
+			process.env.NODE_ENV = "production";
+			renderWithChakra(<ContextRail.Header title="User" />);
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/components/context-rail/context-rail.tsx
+++ b/src/components/context-rail/context-rail.tsx
@@ -1,7 +1,7 @@
 // src/components/context-rail/context-rail.tsx
 import { ChevronRight, PanelRightClose, PanelRightOpen } from "lucide-react";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { IconButton } from "../../atoms/button";
 import { Box, Flex } from "../../primitives/layout";
 import { Heading, Text } from "../../primitives/typography";
@@ -9,6 +9,42 @@ import { Heading, Text } from "../../primitives/typography";
 const COLLAPSED_WIDTH = "44px";
 const EXPANDED_WIDTH = "360px";
 const COLLAPSE_BREAKPOINT = 1440;
+
+/**
+ * Internal context that signals "I am a `<ContextRail>` Root". Used by
+ * `<ContextRail.Header>` and `<ContextRail.Section>` to detect when they
+ * are rendered outside the Root and emit a dev-mode warning.
+ *
+ * The value is intentionally minimal — presence is the signal.
+ */
+const RailRootContext = createContext<boolean>(false);
+
+/**
+ * Dev-mode helper: warn once per component-mount when a rail child is
+ * rendered without a `<ContextRail>` Root ancestor. No-op in production.
+ */
+function isDevMode(): boolean {
+	// `process` is a Node global; bundlers (Vite, tsup) replace
+	// `process.env.NODE_ENV` at build time, so this works in both Node
+	// (vitest, SSR) and browser bundles. We avoid `@types/node` by
+	// reaching through `globalThis`.
+	const proc = (globalThis as { process?: { env?: { NODE_ENV?: string } } })
+		.process;
+	return proc?.env?.NODE_ENV !== "production";
+}
+
+function useWarnIfOutsideRailRoot(componentName: string) {
+	const insideRoot = useContext(RailRootContext);
+	const warnedRef = useRef(false);
+	useEffect(() => {
+		if (!insideRoot && !warnedRef.current && isDevMode()) {
+			warnedRef.current = true;
+			console.warn(
+				`${componentName} was rendered outside <ContextRail>. Wrap rail content in <ContextRail> to get column width, collapse toggle, inner padding, and persistence. See docs/page-patterns.md.`,
+			);
+		}
+	}, [insideRoot, componentName]);
+}
 
 function getInitialCollapsed(storageKey?: string): boolean {
 	if (typeof window === "undefined") return false;
@@ -37,49 +73,48 @@ const ContextRailRoot = ({ storageKey, children }: ContextRailProps) => {
 	}, [collapsed, storageKey]);
 
 	return (
-		<Box
-			data-testid="context-rail"
-			data-collapsed={collapsed ? "true" : "false"}
-			w={collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}
-			minH="100vh"
-			bg="bg-surface"
-			borderLeftWidth="1px"
-			borderLeftColor="border"
-			transition="width 250ms ease-out"
-			overflow="hidden"
-			position="relative"
-		>
-			{collapsed ? (
-				<Flex direction="column" align="center" pt="3" gap="3">
-					<IconButton
-						data-testid="context-rail-toggle"
-						aria-label="Expand context rail"
-						variant="ghost"
-						size="sm"
-						onClick={() => setCollapsed(false)}
-					>
-						<PanelRightOpen size={16} />
-					</IconButton>
-				</Flex>
-			) : (
-				<Flex direction="column" h="full">
-					<Flex justify="flex-end" px="3" pt="3">
+		<RailRootContext.Provider value={true}>
+			<Box
+				data-testid="context-rail"
+				data-collapsed={collapsed ? "true" : "false"}
+				w={collapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH}
+				minH="100vh"
+				transition="width 250ms ease-out"
+				overflow="hidden"
+				position="relative"
+			>
+				{collapsed ? (
+					<Flex direction="column" align="center" pt="3" gap="3">
 						<IconButton
 							data-testid="context-rail-toggle"
-							aria-label="Collapse context rail"
+							aria-label="Expand context rail"
 							variant="ghost"
 							size="sm"
-							onClick={() => setCollapsed(true)}
+							onClick={() => setCollapsed(false)}
 						>
-							<PanelRightClose size={16} />
+							<PanelRightOpen size={16} />
 						</IconButton>
 					</Flex>
-					<Box flex="1" overflowY="auto" px="4" pb="4">
-						{children}
-					</Box>
-				</Flex>
-			)}
-		</Box>
+				) : (
+					<Flex direction="column" h="full">
+						<Flex justify="flex-end" px="3" pt="3">
+							<IconButton
+								data-testid="context-rail-toggle"
+								aria-label="Collapse context rail"
+								variant="ghost"
+								size="sm"
+								onClick={() => setCollapsed(true)}
+							>
+								<PanelRightClose size={16} />
+							</IconButton>
+						</Flex>
+						<Box flex="1" overflowY="auto" px="4" pb="4">
+							{children}
+						</Box>
+					</Flex>
+				)}
+			</Box>
+		</RailRootContext.Provider>
 	);
 };
 ContextRailRoot.displayName = "ContextRail";
@@ -88,38 +123,36 @@ ContextRailRoot.displayName = "ContextRail";
 export interface ContextRailHeaderProps {
 	eyebrow?: React.ReactNode;
 	title: React.ReactNode;
-	onClose?: () => void;
 }
 
-const ContextRailHeader = ({
-	eyebrow,
-	title,
-	onClose: _onClose,
-}: ContextRailHeaderProps) => (
-	<Box mb="4" pb="3" borderBottomWidth="1px" borderBottomColor="border">
-		{eyebrow && (
-			<Text
-				fontSize="2xs"
+const ContextRailHeader = ({ eyebrow, title }: ContextRailHeaderProps) => {
+	useWarnIfOutsideRailRoot("ContextRail.Header");
+	return (
+		<Box mb="4" pb="3" borderBottomWidth="1px" borderBottomColor="border">
+			{eyebrow && (
+				<Text
+					fontSize="2xs"
+					fontWeight="semibold"
+					letterSpacing="wider"
+					textTransform="uppercase"
+					color="muted"
+					mb="1"
+				>
+					{eyebrow}
+				</Text>
+			)}
+			<Heading
+				as="h2"
+				fontSize="lg"
 				fontWeight="semibold"
-				letterSpacing="wider"
-				textTransform="uppercase"
-				color="muted"
-				mb="1"
+				color="default"
+				letterSpacing="-0.01em"
 			>
-				{eyebrow}
-			</Text>
-		)}
-		<Heading
-			as="h2"
-			fontSize="lg"
-			fontWeight="semibold"
-			color="default"
-			letterSpacing="-0.01em"
-		>
-			{title}
-		</Heading>
-	</Box>
-);
+				{title}
+			</Heading>
+		</Box>
+	);
+};
 ContextRailHeader.displayName = "ContextRail.Header";
 
 // Section
@@ -140,6 +173,7 @@ const ContextRailSection = ({
 	action,
 	children,
 }: ContextRailSectionProps) => {
+	useWarnIfOutsideRailRoot("ContextRail.Section");
 	const [open, setOpen] = useState(defaultOpen);
 	return (
 		<Box


### PR DESCRIPTION
## Summary

Quality patch hardening `<ContextRail>` after the first consumer (odon) silently rendered Header/Section inside a fragment with no `<ContextRail>` Root, missing column width / collapse toggle / padding / persistence.

- **Doc:** `docs/page-patterns.md` §4 gains an explicit "Rail Root contract (required)" subsection that calls out the silent-failure mode with correct/incorrect examples. "Common rail mistakes" callout now leads with this.
- **Dev nudge:** Root provides a private `RailRootContext`; `<ContextRail.Header>` / `<ContextRail.Section>` consume it on mount and `console.warn` once when rendered outside Root, in non-production builds only. No throw, no production behavior change.
- **De-dup styling:** Removed `bg="bg-surface"` / `borderLeftWidth="1px"` / `borderLeftColor="border"` from `<ContextRail>` Root. Source of truth is now exclusively `<AppShell>`'s rail column (set in 1.9.3 / PR #95), which applies regardless of whether rail content is `<ContextRail>` or anything else. Storybook stories wrap the rail in an equivalent column so isolation visuals still match production.
- **Removed dead prop:** `<ContextRail.Header>` `onClose?: () => void` is gone. It was destructured as `_onClose` and never wired up — the Root already provides a collapse toggle. Type-only break, no real consumers.
- **Tests:** 4 new tests cover the dev-warning behavior. All 109 tests pass; typecheck / lint / build / storybook build all clean.
- **Version:** 1.9.3 → 1.9.4.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (109 passed, including 4 new dev-warning tests)
- [x] `npm run build`
- [x] `npm run build:storybook`
- [ ] Visual check in storybook that the Default and CollapsedByDefault rail stories still look correct (white surface + left divider) — provided by the new `RailColumn` wrapper in the stories file.
- [ ] After merge: tag v1.9.4 and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)