### PR TITLE
feat(cells): IdentityCell + DeviceCell + cell library hoisted in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.0] — 2026-05-05
+
+Two new cells (`IdentityCell`, `DeviceCell`); `subText` prop on `TruncatedTextCell`; `tooltip` prop on `StatusBadgeCell`; cell library hoisted in docs.
+
+### Added
+
+- **`IdentityCell`** (`@knkcs/anker/components/data-table/cells`) — avatar + primary name + optional sub-text. The canonical "person" cell for users, members, requesters, and similar references in DataTables. Initials are auto-derived from `name` when `avatarFallback` is omitted; `size` defaults to `"sm"` to match table density. Null `name` falls back to `emptyCellValue` like every other cell. Closes #97.
+- **`DeviceCell`** (`@knkcs/anker/components/data-table/cells`) — User-Agent string → "Chrome on macOS" label, with the raw UA shown muted below and reachable via hover tooltip. Optional `badge` slot to mark "Current" sessions or similar affordances. Internal `parseUserAgent` / `formatUserAgent` helpers cover Chrome, Safari, Firefox, Edge, and Opera on macOS, iOS, Windows, Android, and Linux; both are exported so solutions can reuse the same parser outside table contexts. Replaces odon's hand-rolled `web/src/utils/user-agent.ts` plus inline session-row JSX. Closes #98.
+- **`TruncatedTextCell` `subText` prop** — optional secondary line rendered below the primary value in smaller muted text (`lineClamp={1}`). Primary value still respects `maxLength`. Backwards compatible; consumers that don't pass `subText` see no change. Replaces inline `<Stack><Text/><Text/></Stack>` compositions for "name + creation date" / "target + ID" patterns. Closes #99.
+- **`StatusBadgeCell` `tooltip` prop** — optional `ReactNode` that wraps the rendered Badge in `<Tooltip>` from `@knkcs/anker/primitives`. Use for status descriptions, full metadata payloads, or any "expand on hover" affordance that doesn't fit on the badge label. Composes cleanly with the existing `detail` prop. Backwards compatible. Closes #100.
+
+### Documentation
+
+- **`docs/page-patterns.md` §11.13 — DataTable cells.** New section that surfaces the cell library: states the rule (cells are the contract; file an issue before hand-rolling), lists all 16 cells with one-line use cases, and gives a mapping guide for common column intents (status → `StatusBadgeCell`, timestamp → `DateCell`, mono ID → `SlugCell`/`CodeCell`, action button → `ActionCell`, person reference → `IdentityCell`, device/UA → `DeviceCell`, primary + sub text → `TruncatedTextCell` with `subText`). Links out to the full slot/prop tables in `docs/react-table-reference.md`.
+- **`CLAUDE-ANKER.md` — DataTable cells.** New compact section right after "Page templates" that bakes the cells contract into the rules file consumers `@`-import. AI sessions working on solution code now see cells as a first-class option alongside templates and primitives. Includes the import path and pointers to the deeper docs.
+- **`docs/react-table-reference.md` — Cell components.** Bumped from "11 cells" (stale; main was already at 14) to "16 cells" (14 existing + `IdentityCell` + `DeviceCell`). Cell table sorted alphabetically; new `subText` (TruncatedTextCell) and `tooltip` (StatusBadgeCell) props called out. The rule from §11.13 is repeated at the top of the cells section so this doc remains self-contained. File map updated with `device-cell.tsx`, `identity-cell.tsx`, and `user-agent.ts`.
+
+### Discoverability
+
+The first consumer (odon) used **zero** cells in its initial DataTable rollouts — every column file pulled `Badge`, `Box`, `Text`, `Tooltip` from primitives and hand-rolled cell content. The library existed but wasn't surfaced anywhere AI sessions or new contributors would see it. This release fixes the discoverability gap on three sides: the page-patterns spec, the AI rules file, and the React Table reference all now lead with cells.
+
 ## [1.9.4] — 2026-05-05
 
 Doc clarification on `<ContextRail>` Root wrapper requirement; dev-mode warning when Header/Section is rendered outside Root; de-duped styling between AppShell rail column and ContextRail Root; removed dead `onClose` prop on Header.

--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -90,6 +90,37 @@ Full spec with composition diagrams, slot tables, and authoring rules: `docs/pag
 
 ---
 
+## DataTable cells
+
+anker ships 16 reusable cell components for `<DataTable>` columns under `@knkcs/anker/components/data-table/cells`. **Use cells before composing primitives.** Inline `<Badge>` / `<Box>` / `<Text>` / `<Tooltip>` cell content fragments the visual language and silently misses later improvements (a11y, dark mode, density).
+
+**Rule:** cells are the contract — if no cell fits, file an issue and propose a new cell. Don't hand-roll.
+
+| Cell | Use for |
+|---|---|
+| `ActionCell` | row action icons |
+| `BooleanCell` | yes/no |
+| `CodeCell` | monospace code |
+| `ColorSwatchCell` | color swatch |
+| `CountCell` | "N items" |
+| `DateCell` | timestamps |
+| `DeviceCell` | User-Agent → browser/OS + tooltip |
+| `IdentityCell` | avatar + name (+ subText) |
+| `LinkCell` | internal link |
+| `MenuCell` | row overflow menu |
+| `NumberCell` | numbers |
+| `SlugCell` | mono IDs |
+| `StatusBadgeCell` | status pill (+ optional `tooltip`) |
+| `SwitchCell` | inline toggle |
+| `TruncatedTextCell` | text (+ optional `subText`, `maxLength`) |
+| `UrlCell` | external URL |
+
+Import path: `@knkcs/anker/components/data-table/cells`.
+
+Full slot/prop tables: `docs/react-table-reference.md`. Mapping guide for common column intents: `docs/page-patterns.md` §11.13.
+
+---
+
 ## Pointers
 
 - Full spec: anker GitHub Pages docs site (`/design-system`, `/page-patterns`)

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -1227,6 +1227,81 @@ Operators serve this from a static asset or fallback handler.
 
 ---
 
+### 11.13 DataTable cells
+
+**Rule.** Cells from `@knkcs/anker/components/data-table/cells` are
+the contract — **never inline cell JSX from primitives unless no cell
+fits**. If no cell fits, file an issue and propose a new cell. Inline
+`<Badge>`, `<Box>`, `<Text>`, `<Tooltip>` compositions in column
+files are the kind of drift the cells library was built to prevent;
+they fragment the visual language across solutions and silently miss
+later improvements (a11y fixes, dark-mode tweaks, density updates).
+
+**Why it matters.** Module federation will assemble multiple knkCMS
+solutions (Odon, Core, Template, MAS, Aufgabenmanagement, …) into a
+single browser frame. Tables are the single most common surface in
+the platform. Visually divergent rows — even by 1–2px of padding or
+a slightly different muted color — read as broken to operators.
+
+**Available cells.** Anker ships 16 cells today. All live behind one
+import path:
+
+```tsx
+import {
+  ActionCell, BooleanCell, CodeCell, ColorSwatchCell, CountCell,
+  DateCell, DeviceCell, IdentityCell, LinkCell, MenuCell, NumberCell,
+  SlugCell, StatusBadgeCell, SwitchCell, TruncatedTextCell, UrlCell,
+} from "@knkcs/anker/components/data-table/cells";
+```
+
+| Cell | Use case |
+|---|---|
+| `ActionCell` | Row action icon buttons (edit / delete / download) |
+| `BooleanCell` | Yes/No labels with configurable strings |
+| `CodeCell` | Monospace inline code (SQL, JSON snippets) |
+| `ColorSwatchCell` | Color circle + hex value |
+| `CountCell` | "N items" / "1 item" with pluralization |
+| `DateCell` | Formatted date with optional relative-time tooltip |
+| `DeviceCell` | User-Agent → "Chrome on macOS" + UA tooltip + optional badge |
+| `IdentityCell` | Avatar + primary name + optional sub-text (person reference) |
+| `LinkCell` | Internal Link via the anker `Link` primitive |
+| `MenuCell` | Row overflow menu (`⋯`) |
+| `NumberCell` | Locale-aware number formatting |
+| `SlugCell` | Monospace identifiers (KSUID, slug, handle) |
+| `StatusBadgeCell` | Colored status badge; supports `detail` and `tooltip` |
+| `SwitchCell` | Inline toggle bound to a row value |
+| `TruncatedTextCell` | General text with optional truncation; supports `subText` |
+| `UrlCell` | External clickable link |
+
+**Mapping examples.** Common column patterns and the cell to reach
+for:
+
+| Column intent | Reach for |
+|---|---|
+| Status / state pill | `StatusBadgeCell` (use `tooltip` for descriptions; `detail` for error-line under the badge) |
+| Timestamp | `DateCell` |
+| Mono ID / KSUID | `SlugCell` (small / inline) or `CodeCell` (block-y) |
+| Per-row actions | `ActionCell` (small set) or `MenuCell` (overflow) |
+| Person reference (user, member, requester, author) | `IdentityCell` |
+| Device / User-Agent | `DeviceCell` |
+| Primary value with creation date / context line | `TruncatedTextCell` with `subText` |
+| Yes/No flag | `BooleanCell` |
+| Numeric quantity | `NumberCell` |
+| Colored swatch (theme color, brand color) | `ColorSwatchCell` |
+| "N rows / N items" | `CountCell` |
+| Internal navigation link | `LinkCell` |
+| External URL | `UrlCell` |
+| Inline toggle | `SwitchCell` |
+| Long free text | `TruncatedTextCell` (set `maxLength`) |
+
+All cells share the same null-handling contract: a null / undefined
+value renders the `emptyCellValue` em-dash (`"—"`).
+
+**Full slot / prop tables.** See [`docs/react-table-reference.md`](./react-table-reference.md)
+for prop tables, value-type signatures, and the file map.
+
+---
+
 ## 12. Slot mechanism
 
 `<AppShell>` exposes two write-side hooks for descendant components to

--- a/docs/react-table-reference.md
+++ b/docs/react-table-reference.md
@@ -92,7 +92,9 @@ Acceptable for simple cases but gives weaker type inference.
 
 ## Cell Components
 
-Anker provides 11 reusable cell components in `src/components/data-table/cells/`. They are **plain React components with zero TanStack coupling** — they receive pre-extracted values and render UI.
+Anker provides 16 reusable cell components in `src/components/data-table/cells/`. They are **plain React components with zero TanStack coupling** — they receive pre-extracted values and render UI.
+
+> **Rule:** cells from `@knkcs/anker/components/data-table/cells` are the contract — never inline cell JSX from primitives unless no cell fits. If no cell fits, file an issue and propose a new cell. See `docs/page-patterns.md` §11.13 for the cell-mapping guide.
 
 ### Pattern: cells receive values, not TanStack context
 
@@ -113,17 +115,29 @@ Cells never import from `@tanstack/react-table`. The `info.getValue()` call happ
 
 | Cell | Value type | Use case |
 |------|-----------|----------|
-| `TruncatedTextCell` | `string` | General text with optional truncation |
-| `NumberCell` | `number \| string` | Locale-aware number formatting |
+| `ActionCell` | N/A (uses `actions` prop) | Row action icon buttons |
 | `BooleanCell` | `boolean` | Yes/No labels (configurable) |
-| `SlugCell` | `string` | Monospace identifiers |
 | `CodeCell` | `string` | Monospace with background |
-| `UrlCell` | `string` | Clickable external link |
 | `ColorSwatchCell` | `string` | Color circle + hex value |
 | `CountCell` | `array \| object \| number` | "N items" with pluralization |
-| `StatusBadgeCell` | `string` | Colored status badge |
-| `ActionCell` | N/A (uses `actions` prop) | Row action icon buttons |
 | `DateCell` | `string \| Date \| number` | Formatted date, optional relative tooltip |
+| `DeviceCell` | `string` (User-Agent) | "Chrome on macOS" + UA tooltip + optional badge |
+| `IdentityCell` | `string` (name) | Avatar + name + optional sub-text (person reference) |
+| `LinkCell` | `string` | Clickable internal link (anker `Link` primitive) |
+| `MenuCell` | N/A (uses `actions` prop) | Row overflow menu |
+| `NumberCell` | `number \| string` | Locale-aware number formatting |
+| `SlugCell` | `string` | Monospace identifiers |
+| `StatusBadgeCell` | `string` | Colored status badge; supports `detail` line and `tooltip` |
+| `SwitchCell` | `boolean` | Inline toggle bound to a row value |
+| `TruncatedTextCell` | `string` | General text with optional truncation; supports `subText` |
+| `UrlCell` | `string` | Clickable external link |
+
+The library also exports two non-cell helpers used by `DeviceCell`:
+
+| Export | Purpose |
+|---|---|
+| `parseUserAgent(ua)` | `{ browser, os }` from a UA string |
+| `formatUserAgent(ua)` | `"Chrome on macOS"` style label |
 
 ### Null handling
 
@@ -289,17 +303,23 @@ src/components/data-table/
 │   └── data-table.test.tsx # Rendering, empty state, loading, pagination
 └── cells/
     ├── cell-utils.ts       # emptyCellValue, truncateText, pluralize
+    ├── user-agent.ts       # parseUserAgent, formatUserAgent (used by DeviceCell)
     ├── index.ts            # Cell barrel
     ├── cells.stories.tsx   # All cells in a DataTable demo
-    ├── truncated-text-cell.tsx
-    ├── number-cell.tsx
+    ├── action-cell.tsx
     ├── boolean-cell.tsx
-    ├── slug-cell.tsx
     ├── code-cell.tsx
-    ├── url-cell.tsx
     ├── color-swatch-cell.tsx
     ├── count-cell.tsx
+    ├── date-cell.tsx
+    ├── device-cell.tsx
+    ├── identity-cell.tsx
+    ├── link-cell.tsx
+    ├── menu-cell.tsx
+    ├── number-cell.tsx
+    ├── slug-cell.tsx
     ├── status-badge-cell.tsx
-    ├── action-cell.tsx
-    └── date-cell.tsx
+    ├── switch-cell.tsx
+    ├── truncated-text-cell.tsx
+    └── url-cell.tsx
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/data-table/cells/device-cell.mdx
+++ b/src/components/data-table/cells/device-cell.mdx
@@ -1,0 +1,28 @@
+import { Canvas, Meta, ArgTypes } from "@storybook/blocks";
+import * as Stories from "./device-cell.stories";
+
+<Meta of={Stories} />
+
+# DeviceCell
+
+Renders a User-Agent string as a human-readable browser + OS label ("Chrome on macOS"). The raw UA is displayed below in muted text and is also available via a hover tooltip — useful for sessions, devices, and login-history columns. An optional `badge` slot to the right of the primary line marks affordances like "Current session". Null/empty UA falls back to `emptyCellValue`.
+
+The internal `parseUserAgent` matcher recognises Chrome, Safari, Firefox, Edge, and Opera on macOS, iOS, Windows, Android, and Linux. Unknown browsers render as "Unknown" with no OS suffix.
+
+## Usage
+
+<Canvas of={Stories.ChromeOnMac} />
+
+## With Badge
+
+<Canvas of={Stories.WithBadge} />
+
+## Other browsers / platforms
+
+<Canvas of={Stories.SafariOnIOS} />
+<Canvas of={Stories.EdgeOnWindows} />
+<Canvas of={Stories.FirefoxOnLinux} />
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/src/components/data-table/cells/device-cell.stories.tsx
+++ b/src/components/data-table/cells/device-cell.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DeviceCell } from "./device-cell";
+
+const CHROME_MAC =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const SAFARI_IOS =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+const EDGE_WIN =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
+const FIREFOX_LINUX =
+	"Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0";
+
+const meta = {
+	title: "Components/DataTable/Cells/DeviceCell",
+	component: DeviceCell,
+	args: {
+		userAgent: CHROME_MAC,
+	},
+} satisfies Meta<typeof DeviceCell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ChromeOnMac: Story = {
+	args: { userAgent: CHROME_MAC },
+};
+
+export const SafariOnIOS: Story = {
+	args: { userAgent: SAFARI_IOS },
+};
+
+export const EdgeOnWindows: Story = {
+	args: { userAgent: EDGE_WIN },
+};
+
+export const FirefoxOnLinux: Story = {
+	args: { userAgent: FIREFOX_LINUX },
+};
+
+export const WithBadge: Story = {
+	args: {
+		userAgent: CHROME_MAC,
+		badge: { label: "Current", colorPalette: "green" },
+	},
+};
+
+export const NullValue: Story = {
+	args: { userAgent: null },
+};

--- a/src/components/data-table/cells/device-cell.test.tsx
+++ b/src/components/data-table/cells/device-cell.test.tsx
@@ -1,0 +1,80 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { emptyCellValue } from "./cell-utils";
+import { DeviceCell } from "./device-cell";
+import { formatUserAgent, parseUserAgent } from "./user-agent";
+
+const CHROME_MAC =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const SAFARI_IOS =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+const EDGE_WIN =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
+const FIREFOX_LINUX =
+	"Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0";
+const ANDROID_CHROME =
+	"Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36";
+const OPERA =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 OPR/110.0.0.0";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("parseUserAgent", () => {
+	it.each([
+		[CHROME_MAC, { browser: "Chrome", os: "macOS" }],
+		[SAFARI_IOS, { browser: "Safari", os: "iOS" }],
+		[EDGE_WIN, { browser: "Edge", os: "Windows" }],
+		[FIREFOX_LINUX, { browser: "Firefox", os: "Linux" }],
+		[ANDROID_CHROME, { browser: "Chrome", os: "Android" }],
+		[OPERA, { browser: "Opera", os: "Windows" }],
+	])("parses %s", (ua, expected) => {
+		expect(parseUserAgent(ua)).toEqual(expected);
+	});
+
+	it("returns Unknown / empty for empty input", () => {
+		expect(parseUserAgent("")).toEqual({ browser: "Unknown", os: "" });
+		expect(parseUserAgent(undefined)).toEqual({ browser: "Unknown", os: "" });
+		expect(parseUserAgent(null)).toEqual({ browser: "Unknown", os: "" });
+	});
+});
+
+describe("formatUserAgent", () => {
+	it('formats with "browser on os" when os is known', () => {
+		expect(formatUserAgent(CHROME_MAC)).toBe("Chrome on macOS");
+	});
+
+	it("returns the bare browser name when os is unknown", () => {
+		expect(formatUserAgent("SomeWeirdBot/1.0")).toBe("Unknown");
+	});
+});
+
+describe("DeviceCell", () => {
+	it("renders the formatted label and the raw UA", () => {
+		renderWithChakra(<DeviceCell userAgent={CHROME_MAC} />);
+		expect(screen.getByText("Chrome on macOS")).toBeInTheDocument();
+		expect(screen.getAllByText(CHROME_MAC).length).toBeGreaterThan(0);
+	});
+
+	it("renders the optional badge", () => {
+		renderWithChakra(
+			<DeviceCell
+				userAgent={CHROME_MAC}
+				badge={{ label: "Current", colorPalette: "green" }}
+			/>,
+		);
+		expect(screen.getByText("Current")).toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when userAgent is null", () => {
+		renderWithChakra(<DeviceCell userAgent={null} />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when userAgent is empty string", () => {
+		renderWithChakra(<DeviceCell userAgent="" />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+});

--- a/src/components/data-table/cells/device-cell.tsx
+++ b/src/components/data-table/cells/device-cell.tsx
@@ -1,0 +1,41 @@
+import type React from "react";
+import { Badge } from "../../../primitives/badge";
+import { HStack, VStack } from "../../../primitives/layout";
+import { Tooltip } from "../../../primitives/tooltip";
+import { Text } from "../../../primitives/typography";
+import { emptyCellValue } from "./cell-utils";
+import { formatUserAgent } from "./user-agent";
+
+export interface DeviceCellProps {
+	/** Raw User-Agent string. Null/empty renders the empty cell value. */
+	userAgent: string | null | undefined;
+	/** Optional badge displayed to the right of the primary line (e.g. "Current"). */
+	badge?: { label: string; colorPalette?: string };
+}
+
+export const DeviceCell: React.FC<DeviceCellProps> = ({ userAgent, badge }) => {
+	if (userAgent == null || userAgent === "") {
+		return <span>{emptyCellValue}</span>;
+	}
+	const label = formatUserAgent(userAgent);
+	return (
+		<Tooltip content={userAgent} showArrow>
+			<VStack align="start" gap={0}>
+				<HStack gap={2} align="center">
+					<Text fontSize="sm" fontWeight="medium" lineClamp={1}>
+						{label}
+					</Text>
+					{badge && (
+						<Badge colorPalette={badge.colorPalette} size="xs">
+							{badge.label}
+						</Badge>
+					)}
+				</HStack>
+				<Text fontSize="xs" color="fg.muted" lineClamp={1}>
+					{userAgent}
+				</Text>
+			</VStack>
+		</Tooltip>
+	);
+};
+DeviceCell.displayName = "DeviceCell";

--- a/src/components/data-table/cells/identity-cell.mdx
+++ b/src/components/data-table/cells/identity-cell.mdx
@@ -1,0 +1,24 @@
+import { Canvas, Meta, ArgTypes } from "@storybook/blocks";
+import * as Stories from "./identity-cell.stories";
+
+<Meta of={Stories} />
+
+# IdentityCell
+
+Renders an avatar plus a primary name with optional secondary text — the canonical "person" cell for users, members, requesters, and similar references. Avatar size defaults to `sm` to match DataTable row density. Initials are auto-derived from `name` when `avatarFallback` is omitted. Null/undefined `name` falls back to `emptyCellValue`.
+
+## Usage
+
+<Canvas of={Stories.Default} />
+
+## With Image
+
+<Canvas of={Stories.WithImage} />
+
+## Name Only
+
+<Canvas of={Stories.NameOnly} />
+
+## Props
+
+<ArgTypes of={Stories} />

--- a/src/components/data-table/cells/identity-cell.stories.tsx
+++ b/src/components/data-table/cells/identity-cell.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { IdentityCell } from "./identity-cell";
+
+const meta = {
+	title: "Components/DataTable/Cells/IdentityCell",
+	component: IdentityCell,
+	args: {
+		name: "Jane Doe",
+		subText: "jane@example.com",
+	},
+} satisfies Meta<typeof IdentityCell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithImage: Story = {
+	args: {
+		name: "Jane Doe",
+		subText: "jane@example.com",
+		avatarSrc: "https://i.pravatar.cc/150?u=jane",
+	},
+};
+
+export const NameOnly: Story = {
+	args: {
+		name: "Jane Doe",
+	},
+};
+
+export const ExplicitFallback: Story = {
+	args: {
+		name: "Jane Doe",
+		subText: "Admin",
+		avatarFallback: "JD",
+	},
+};
+
+export const SizeMd: Story = {
+	args: {
+		name: "Jane Doe",
+		subText: "jane@example.com",
+		size: "md",
+	},
+};
+
+export const NullName: Story = {
+	args: {
+		name: null,
+	},
+};

--- a/src/components/data-table/cells/identity-cell.test.tsx
+++ b/src/components/data-table/cells/identity-cell.test.tsx
@@ -1,0 +1,49 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { emptyCellValue } from "./cell-utils";
+import { IdentityCell } from "./identity-cell";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("IdentityCell", () => {
+	it("renders the name as primary text", () => {
+		renderWithChakra(<IdentityCell name="Jane Doe" />);
+		expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+	});
+
+	it("renders subText below the name", () => {
+		renderWithChakra(
+			<IdentityCell name="Jane Doe" subText="jane@example.com" />,
+		);
+		expect(screen.getByText("jane@example.com")).toBeInTheDocument();
+	});
+
+	it("derives initials from a two-word name when avatarFallback is omitted", () => {
+		renderWithChakra(<IdentityCell name="Jane Doe" />);
+		expect(screen.getByText("JD")).toBeInTheDocument();
+	});
+
+	it("derives initials from a single-word name", () => {
+		renderWithChakra(<IdentityCell name="Cher" />);
+		expect(screen.getByText("CH")).toBeInTheDocument();
+	});
+
+	it("uses the explicit avatarFallback over derived initials", () => {
+		renderWithChakra(<IdentityCell name="Jane Doe" avatarFallback="ZZ" />);
+		expect(screen.getByText("ZZ")).toBeInTheDocument();
+		expect(screen.queryByText("JD")).not.toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when name is null", () => {
+		renderWithChakra(<IdentityCell name={null} />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when name is undefined", () => {
+		renderWithChakra(<IdentityCell name={undefined} />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+});

--- a/src/components/data-table/cells/identity-cell.tsx
+++ b/src/components/data-table/cells/identity-cell.tsx
@@ -1,0 +1,52 @@
+import type React from "react";
+import { Avatar } from "../../../primitives/avatar";
+import { HStack, VStack } from "../../../primitives/layout";
+import { Text } from "../../../primitives/typography";
+import { emptyCellValue } from "./cell-utils";
+
+export interface IdentityCellProps {
+	/** Primary display name. Null/undefined renders the empty cell value. */
+	name: string | null | undefined;
+	/** Optional secondary line below the name (e.g., email, ID). */
+	subText?: React.ReactNode;
+	/** Avatar image source URL. */
+	avatarSrc?: string;
+	/** Initials shown as the avatar fallback. Auto-derived from `name` when omitted. */
+	avatarFallback?: string;
+	/** Avatar size; defaults to "sm" to match table density. */
+	size?: "sm" | "md";
+}
+
+function deriveInitials(name: string): string {
+	const parts = name.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0) return "";
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+	return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export const IdentityCell: React.FC<IdentityCellProps> = ({
+	name,
+	subText,
+	avatarSrc,
+	avatarFallback,
+	size = "sm",
+}) => {
+	if (name == null) return <span>{emptyCellValue}</span>;
+	const initials = avatarFallback ?? deriveInitials(name);
+	return (
+		<HStack gap={2} align="center">
+			<Avatar size={size} name={name} src={avatarSrc} fallback={initials} />
+			<VStack align="start" gap={0}>
+				<Text fontSize="sm" fontWeight="semibold" lineClamp={1}>
+					{name}
+				</Text>
+				{subText != null && (
+					<Text fontSize="xs" color="fg.muted" lineClamp={1}>
+						{subText}
+					</Text>
+				)}
+			</VStack>
+		</HStack>
+	);
+};
+IdentityCell.displayName = "IdentityCell";

--- a/src/components/data-table/cells/index.ts
+++ b/src/components/data-table/cells/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./color-swatch-cell";
 export { CountCell, type CountCellProps } from "./count-cell";
 export { DateCell, type DateCellProps } from "./date-cell";
+export { DeviceCell, type DeviceCellProps } from "./device-cell";
 export { IdentityCell, type IdentityCellProps } from "./identity-cell";
 export { LinkCell, type LinkCellProps } from "./link-cell";
 export {
@@ -31,3 +32,4 @@ export {
 	type TruncatedTextCellProps,
 } from "./truncated-text-cell";
 export { UrlCell, type UrlCellProps } from "./url-cell";
+export { formatUserAgent, parseUserAgent } from "./user-agent";

--- a/src/components/data-table/cells/index.ts
+++ b/src/components/data-table/cells/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./color-swatch-cell";
 export { CountCell, type CountCellProps } from "./count-cell";
 export { DateCell, type DateCellProps } from "./date-cell";
+export { IdentityCell, type IdentityCellProps } from "./identity-cell";
 export { LinkCell, type LinkCellProps } from "./link-cell";
 export {
 	MenuCell,

--- a/src/components/data-table/cells/status-badge-cell.mdx
+++ b/src/components/data-table/cells/status-badge-cell.mdx
@@ -15,6 +15,12 @@ Renders a `StatusBadge` for a string status value. Pass a `colorMap` to associat
 
 <Canvas of={Stories.NoColorMap} />
 
+## With Tooltip
+
+The optional `tooltip` prop wraps the badge in `<Tooltip>` from `@knkcs/anker/primitives`. Use it for status descriptions, full metadata payloads, or any "expand on hover" affordance that doesn't fit on the badge label.
+
+<Canvas of={Stories.WithTooltip} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/src/components/data-table/cells/status-badge-cell.stories.tsx
+++ b/src/components/data-table/cells/status-badge-cell.stories.tsx
@@ -56,6 +56,23 @@ export const WithDetailCustomColor: Story = {
 	},
 };
 
+export const WithTooltip: Story = {
+	args: {
+		value: "metadata",
+		colorMap: { metadata: "blue" },
+		tooltip: "Click the row to inspect the full payload",
+	},
+};
+
+export const WithTooltipAndDetail: Story = {
+	args: {
+		value: "failed",
+		colorMap: { ...statusColorMap, failed: "red" },
+		detail: "Export timed out after 30s",
+		tooltip: "Retried 3 times before giving up",
+	},
+};
+
 export const NullValue: Story = {
 	args: {
 		value: null,

--- a/src/components/data-table/cells/status-badge-cell.test.tsx
+++ b/src/components/data-table/cells/status-badge-cell.test.tsx
@@ -1,0 +1,52 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { emptyCellValue } from "./cell-utils";
+import { StatusBadgeCell } from "./status-badge-cell";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("StatusBadgeCell", () => {
+	it("renders the value as the badge label", () => {
+		renderWithChakra(<StatusBadgeCell value="published" />);
+		expect(screen.getByText("published")).toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when value is null", () => {
+		renderWithChakra(<StatusBadgeCell value={null} />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+
+	it("renders the detail line below the badge when detail is set", () => {
+		renderWithChakra(
+			<StatusBadgeCell value="failed" detail="Export timed out" />,
+		);
+		expect(screen.getByText("Export timed out")).toBeInTheDocument();
+	});
+
+	it("renders without crashing when tooltip is provided", () => {
+		// Tooltip content only mounts on hover/focus; verify the badge still
+		// renders and the component does not throw when wired up.
+		renderWithChakra(
+			<StatusBadgeCell
+				value="metadata"
+				tooltip="Click row to inspect payload"
+			/>,
+		);
+		expect(screen.getByText("metadata")).toBeInTheDocument();
+	});
+
+	it("combines detail + tooltip without crashing", () => {
+		renderWithChakra(
+			<StatusBadgeCell
+				value="failed"
+				detail="Export timed out"
+				tooltip="Retried 3 times"
+			/>,
+		);
+		expect(screen.getByText("failed")).toBeInTheDocument();
+		expect(screen.getByText("Export timed out")).toBeInTheDocument();
+	});
+});

--- a/src/components/data-table/cells/status-badge-cell.tsx
+++ b/src/components/data-table/cells/status-badge-cell.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { StatusBadge } from "../../../atoms/status-badge";
 import { VStack } from "../../../primitives/layout";
+import { Tooltip } from "../../../primitives/tooltip";
 import { Text } from "../../../primitives/typography";
 import { emptyCellValue } from "./cell-utils";
 
@@ -13,6 +14,12 @@ export interface StatusBadgeCellProps {
 	detail?: string | null;
 	/** Color for the detail text. @default "fg.error" */
 	detailColor?: string;
+	/**
+	 * Optional tooltip content shown on hover/focus over the badge. Useful
+	 * for status descriptions, full JSON payloads, or contextual hints that
+	 * don't fit on the badge label.
+	 */
+	tooltip?: React.ReactNode;
 }
 
 export const StatusBadgeCell: React.FC<StatusBadgeCellProps> = ({
@@ -21,10 +28,19 @@ export const StatusBadgeCell: React.FC<StatusBadgeCellProps> = ({
 	fallbackColor = "gray",
 	detail,
 	detailColor = "fg.error",
+	tooltip,
 }) => {
 	if (value == null) return <span>{emptyCellValue}</span>;
 	const color = colorMap?.[value] ?? fallbackColor;
-	const badge = <StatusBadge label={value} color={color} />;
+	let badge: React.ReactNode = <StatusBadge label={value} color={color} />;
+
+	if (tooltip != null) {
+		badge = (
+			<Tooltip content={tooltip} showArrow>
+				<span>{badge}</span>
+			</Tooltip>
+		);
+	}
 
 	if (detail) {
 		return (
@@ -37,6 +53,6 @@ export const StatusBadgeCell: React.FC<StatusBadgeCellProps> = ({
 		);
 	}
 
-	return badge;
+	return <>{badge}</>;
 };
 StatusBadgeCell.displayName = "StatusBadgeCell";

--- a/src/components/data-table/cells/truncated-text-cell.mdx
+++ b/src/components/data-table/cells/truncated-text-cell.mdx
@@ -15,6 +15,14 @@ Displays a text value, optionally truncating it to a maximum character length wi
 
 <Canvas of={Stories.WithTruncation} />
 
+## With Sub-text
+
+The optional `subText` prop renders a smaller muted line below the primary value — useful for "name + creation date", "target + ID", and similar two-line cells. Sub-text is `lineClamp={1}` and is not affected by `maxLength`.
+
+<Canvas of={Stories.WithSubText} />
+
+<Canvas of={Stories.TruncationWithSubText} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/src/components/data-table/cells/truncated-text-cell.stories.tsx
+++ b/src/components/data-table/cells/truncated-text-cell.stories.tsx
@@ -32,7 +32,8 @@ export const WithSubText: Story = {
 
 export const TruncationWithSubText: Story = {
 	args: {
-		value: "A long description that may need to be truncated if it exceeds the limit",
+		value:
+			"A long description that may need to be truncated if it exceeds the limit",
 		maxLength: 30,
 		subText: "Owner: jane@example.com",
 	},

--- a/src/components/data-table/cells/truncated-text-cell.stories.tsx
+++ b/src/components/data-table/cells/truncated-text-cell.stories.tsx
@@ -23,6 +23,21 @@ export const WithTruncation: Story = {
 	},
 };
 
+export const WithSubText: Story = {
+	args: {
+		value: "service-account-key",
+		subText: "Created 2 days ago",
+	},
+};
+
+export const TruncationWithSubText: Story = {
+	args: {
+		value: "A long description that may need to be truncated if it exceeds the limit",
+		maxLength: 30,
+		subText: "Owner: jane@example.com",
+	},
+};
+
 export const NullValue: Story = {
 	args: {
 		value: null,

--- a/src/components/data-table/cells/truncated-text-cell.test.tsx
+++ b/src/components/data-table/cells/truncated-text-cell.test.tsx
@@ -1,0 +1,58 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { emptyCellValue } from "./cell-utils";
+import { TruncatedTextCell } from "./truncated-text-cell";
+
+function renderWithChakra(ui: React.ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("TruncatedTextCell", () => {
+	it("renders the value untouched when no maxLength is set", () => {
+		renderWithChakra(<TruncatedTextCell value="Hello world" />);
+		expect(screen.getByText("Hello world")).toBeInTheDocument();
+	});
+
+	it("truncates the value when it exceeds maxLength", () => {
+		renderWithChakra(
+			<TruncatedTextCell value="abcdefghijklmnop" maxLength={5} />,
+		);
+		expect(screen.getByText("abcde…")).toBeInTheDocument();
+	});
+
+	it("does not truncate when value is shorter than maxLength", () => {
+		renderWithChakra(<TruncatedTextCell value="abc" maxLength={10} />);
+		expect(screen.getByText("abc")).toBeInTheDocument();
+	});
+
+	it("renders the empty cell value when value is null", () => {
+		renderWithChakra(<TruncatedTextCell value={null} />);
+		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
+	});
+
+	it("renders subText below the primary value when provided", () => {
+		renderWithChakra(
+			<TruncatedTextCell value="api-key-name" subText="Created 2 days ago" />,
+		);
+		expect(screen.getByText("api-key-name")).toBeInTheDocument();
+		expect(screen.getByText("Created 2 days ago")).toBeInTheDocument();
+	});
+
+	it("respects maxLength on the primary value when subText is set", () => {
+		renderWithChakra(
+			<TruncatedTextCell
+				value="abcdefghijklmnop"
+				maxLength={5}
+				subText="meta"
+			/>,
+		);
+		expect(screen.getByText("abcde…")).toBeInTheDocument();
+		expect(screen.getByText("meta")).toBeInTheDocument();
+	});
+
+	it("does not render subText when value is null", () => {
+		renderWithChakra(<TruncatedTextCell value={null} subText="hidden" />);
+		expect(screen.queryByText("hidden")).not.toBeInTheDocument();
+	});
+});

--- a/src/components/data-table/cells/truncated-text-cell.tsx
+++ b/src/components/data-table/cells/truncated-text-cell.tsx
@@ -1,18 +1,40 @@
 import type React from "react";
+import { VStack } from "../../../primitives/layout";
+import { Text } from "../../../primitives/typography";
 import { emptyCellValue, truncateText } from "./cell-utils";
 
 export interface TruncatedTextCellProps {
 	value: string | null | undefined;
 	maxLength?: number;
+	/**
+	 * Optional secondary line rendered below the primary value in smaller,
+	 * muted text (e.g. "created 2 days ago", target ID, contextual hint).
+	 * Sub-text is `lineClamp={1}` and is not affected by `maxLength`.
+	 */
+	subText?: React.ReactNode;
 }
 
 export const TruncatedTextCell: React.FC<TruncatedTextCellProps> = ({
 	value,
 	maxLength,
+	subText,
 }) => {
 	if (value == null) return <span>{emptyCellValue}</span>;
 	const isTruncated = maxLength != null && value.length > maxLength;
 	const display = isTruncated ? truncateText(value, maxLength) : value;
-	return <span title={isTruncated ? value : undefined}>{display}</span>;
+	const primary = (
+		<span title={isTruncated ? value : undefined}>{display}</span>
+	);
+
+	if (subText == null) return primary;
+
+	return (
+		<VStack align="start" gap={0}>
+			{primary}
+			<Text fontSize="xs" color="fg.muted" lineClamp={1}>
+				{subText}
+			</Text>
+		</VStack>
+	);
 };
 TruncatedTextCell.displayName = "TruncatedTextCell";

--- a/src/components/data-table/cells/user-agent.ts
+++ b/src/components/data-table/cells/user-agent.ts
@@ -1,0 +1,41 @@
+/**
+ * Parse a User-Agent string into a coarse browser + OS label.
+ *
+ * Used by `DeviceCell` to render "Chrome on macOS" style labels in
+ * sessions / device lists. The matchers are intentionally simple —
+ * they cover the common power-user browsers (Chrome, Safari, Firefox,
+ * Edge, Opera) on the common platforms (macOS, Windows, iOS, Android,
+ * Linux). Unknown browsers return `"Unknown"`; unknown OSes return `""`.
+ */
+export function parseUserAgent(ua: string | undefined | null): {
+	browser: string;
+	os: string;
+} {
+	if (!ua) return { browser: "Unknown", os: "" };
+
+	// Browser detection — order matters because Chromium-based browsers
+	// also match the Chrome and Safari markers.
+	let browser = "Unknown";
+	if (/Edg\//.test(ua)) browser = "Edge";
+	else if (/Firefox\//.test(ua)) browser = "Firefox";
+	else if (/OPR\/|Opera/.test(ua)) browser = "Opera";
+	else if (/Chrome\//.test(ua)) browser = "Chrome";
+	else if (/Safari\//.test(ua)) browser = "Safari";
+
+	// OS detection — iOS check precedes macOS so iPad/iPhone don't fall
+	// through to the Macintosh matcher.
+	let os = "";
+	if (/Windows NT/.test(ua)) os = "Windows";
+	else if (/iPhone|iPad/.test(ua)) os = "iOS";
+	else if (/Mac OS X|Macintosh/.test(ua)) os = "macOS";
+	else if (/Android/.test(ua)) os = "Android";
+	else if (/Linux/.test(ua)) os = "Linux";
+
+	return { browser, os };
+}
+
+/** Format a parsed UA into the "Chrome on macOS" style label. */
+export function formatUserAgent(ua: string | undefined | null): string {
+	const { browser, os } = parseUserAgent(ua);
+	return os ? `${browser} on ${os}` : browser;
+}


### PR DESCRIPTION
## Summary

A cohesive 1.10.0 release that closes five outstanding cell-library
issues: two new cells, two additive props on existing cells, and a
documentation hoist that makes the library discoverable.

### New cells

- **`IdentityCell`** — avatar + primary name + optional sub-text.
  The canonical "person" cell for users, members, requesters,
  authors. Initials auto-derived from `name` when `avatarFallback`
  is omitted. (#97)
- **`DeviceCell`** — User-Agent → "Chrome on macOS" label, raw UA
  shown muted below + in hover tooltip, optional `badge` slot for
  "Current session" affordances. Internal `parseUserAgent` /
  `formatUserAgent` helpers also exported. (#98)

### Additive props on existing cells

- **`TruncatedTextCell` `subText`** — optional muted second line below
  the primary value, `lineClamp={1}`. Backwards compatible. (#99)
- **`StatusBadgeCell` `tooltip`** — optional `ReactNode` that wraps
  the badge in `<Tooltip>` from anker primitives. Backwards
  compatible; composes with the existing `detail` prop. (#100)

### Documentation hoist

The first consumer (odon) used zero cells in its initial DataTable
rollouts — every column file pulled `Badge`, `Box`, `Text`,
`Tooltip` from primitives and hand-rolled cell content. The library
existed but wasn't surfaced anywhere AI sessions or new contributors
would see it. This release fixes the discoverability gap on three
sides: (#101)

- `docs/page-patterns.md` §11.13 "DataTable cells" — new section
  with the rule, the full 16-cell list, and a column-intent → cell
  mapping guide.
- `CLAUDE-ANKER.md` — new "DataTable cells" section after "Page
  templates", in the file consumers `@`-import into their root
  `CLAUDE.md`.
- `docs/react-table-reference.md` — bumped from "11 cells" (stale)
  to "16 cells", alphabetised, called out the new props, updated
  the file map.

### Version

- `package.json`: `1.9.4` → `1.10.0` (minor — additive features).
- `CHANGELOG.md`: full `[1.10.0]` entry under Added + Documentation.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings remain)
- [x] `npm test` — 141 tests across 14 files all green (32 in
      cells, including 25 new tests for the four cells touched)
- [x] `npm run build` clean (tsup ESM + DTS)
- [x] `npm run build:storybook` clean
- [x] All four touched cells have `.tsx` + `.stories.tsx` + `.mdx` +
      `.test.tsx` (the new ones) following the existing conventions
- [x] Backwards-compatible — existing `TruncatedTextCell` and
      `StatusBadgeCell` consumers are unchanged when the new props
      are omitted
- [x] No new design tokens, no new colors

Closes #97, #98, #99, #100, #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)