### PR TITLE
feat(cells): IdentityCell colorPalette + StatusBadgeCell icon (1.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.2] — 2026-05-05
+
+`colorPalette` prop on `IdentityCell` (forwards to underlying Avatar); `icon` prop on `StatusBadgeCell` (renders before label inside the badge).
+
+### Added
+
+- **`IdentityCell` `colorPalette` prop** — optional `string` forwarded to the underlying `Avatar` primitive (e.g. `"primary"`, `"secondary"`). Tints the fallback initials circle with the chosen palette so consumers can match their app's accent color instead of the default neutral-gray. Backwards compatible: omitting the prop preserves the current look. Restores odon's pre-anker `UserAvatar` "dark blue circles" appearance.
+- **`StatusBadgeCell` `icon` prop** — optional `React.ReactNode` rendered inline before the label inside the Badge with a small gap. Use a `lucide-react` glyph (or any icon component) to mark statuses like 2FA "On" / "Off". Backwards compatible: omitting `icon` keeps the current label-only badge. Composes with `detail` and `tooltip`. Restores odon's pre-anker `MfaBadge` icon affordance.
+
 ## [1.10.1] — 2026-05-06
 
 ### Fixed

--- a/docs/react-table-reference.md
+++ b/docs/react-table-reference.md
@@ -122,12 +122,12 @@ Cells never import from `@tanstack/react-table`. The `info.getValue()` call happ
 | `CountCell` | `array \| object \| number` | "N items" with pluralization |
 | `DateCell` | `string \| Date \| number` | Formatted date, optional relative tooltip |
 | `DeviceCell` | `string` (User-Agent) | "Chrome on macOS" + UA tooltip + optional badge |
-| `IdentityCell` | `string` (name) | Avatar + name + optional sub-text (person reference) |
+| `IdentityCell` | `string` (name) | Avatar + name + optional sub-text (person reference); supports `colorPalette` to tint the avatar |
 | `LinkCell` | `string` | Clickable internal link (anker `Link` primitive) |
 | `MenuCell` | N/A (uses `actions` prop) | Row overflow menu |
 | `NumberCell` | `number \| string` | Locale-aware number formatting |
 | `SlugCell` | `string` | Monospace identifiers |
-| `StatusBadgeCell` | `string` | Colored status badge; supports `detail` line and `tooltip` |
+| `StatusBadgeCell` | `string` | Colored status badge; supports `detail` line, `tooltip`, and `icon` (rendered before the label) |
 | `SwitchCell` | `boolean` | Inline toggle bound to a row value |
 | `TruncatedTextCell` | `string` | General text with optional truncation; supports `subText` |
 | `UrlCell` | `string` | Clickable external link |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/atoms/status-badge/status-badge.tsx
+++ b/src/atoms/status-badge/status-badge.tsx
@@ -8,10 +8,12 @@ export interface StatusBadgeProps {
 	label: string;
 	/** The background color for the badge (hex format, e.g. "#ff0000") */
 	color: string;
+	/** Optional icon rendered inline before the label inside the badge. */
+	icon?: React.ReactNode;
 }
 
 export const StatusBadge: React.FC<StatusBadgeProps> = (props) => {
-	const { label, color } = props;
+	const { label, color, icon } = props;
 
 	const textColor = useMemo(() => {
 		try {
@@ -28,7 +30,9 @@ export const StatusBadge: React.FC<StatusBadgeProps> = (props) => {
 			rounded="base"
 			px={2}
 			marginInlineStart={1}
+			gap={1}
 		>
+			{icon}
 			{label}
 		</Badge>
 	);

--- a/src/components/data-table/cells/identity-cell.mdx
+++ b/src/components/data-table/cells/identity-cell.mdx
@@ -19,6 +19,14 @@ Renders an avatar plus a primary name with optional secondary text — the canon
 
 <Canvas of={Stories.NameOnly} />
 
+## Color Palette
+
+Forward a Chakra `colorPalette` to tint the avatar fallback circle. Use this when the default neutral-gray look doesn't match your app's accent.
+
+<Canvas of={Stories.ColorPalettePrimary} />
+
+<Canvas of={Stories.ColorPaletteSecondary} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/src/components/data-table/cells/identity-cell.stories.tsx
+++ b/src/components/data-table/cells/identity-cell.stories.tsx
@@ -45,6 +45,22 @@ export const SizeMd: Story = {
 	},
 };
 
+export const ColorPalettePrimary: Story = {
+	args: {
+		name: "Jane Doe",
+		subText: "jane@example.com",
+		colorPalette: "primary",
+	},
+};
+
+export const ColorPaletteSecondary: Story = {
+	args: {
+		name: "Jane Doe",
+		subText: "jane@example.com",
+		colorPalette: "secondary",
+	},
+};
+
 export const NullName: Story = {
 	args: {
 		name: null,

--- a/src/components/data-table/cells/identity-cell.test.tsx
+++ b/src/components/data-table/cells/identity-cell.test.tsx
@@ -46,4 +46,14 @@ describe("IdentityCell", () => {
 		renderWithChakra(<IdentityCell name={undefined} />);
 		expect(screen.getByText(emptyCellValue)).toBeInTheDocument();
 	});
+
+	it("renders with colorPalette without crashing", () => {
+		// Chakra v3 does not expose colorPalette in outerHTML — visual
+		// confirmation is required post-release. This test verifies the
+		// IdentityCell accepts the prop, forwards it to the underlying
+		// Avatar primitive, and does not throw.
+		renderWithChakra(<IdentityCell name="Jane Doe" colorPalette="primary" />);
+		expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+		expect(screen.getByText("JD")).toBeInTheDocument();
+	});
 });

--- a/src/components/data-table/cells/identity-cell.tsx
+++ b/src/components/data-table/cells/identity-cell.tsx
@@ -15,6 +15,12 @@ export interface IdentityCellProps {
 	avatarFallback?: string;
 	/** Avatar size; defaults to "sm" to match table density. */
 	size?: "sm" | "md";
+	/**
+	 * Optional Chakra `colorPalette` forwarded to the underlying `Avatar`
+	 * primitive (e.g. `"primary"`, `"secondary"`). Tints the fallback circle
+	 * with the chosen palette. Omit for the default neutral-gray look.
+	 */
+	colorPalette?: string;
 }
 
 function deriveInitials(name: string): string {
@@ -30,12 +36,19 @@ export const IdentityCell: React.FC<IdentityCellProps> = ({
 	avatarSrc,
 	avatarFallback,
 	size = "sm",
+	colorPalette,
 }) => {
 	if (name == null) return <span>{emptyCellValue}</span>;
 	const initials = avatarFallback ?? deriveInitials(name);
 	return (
 		<HStack gap={2} align="center">
-			<Avatar size={size} name={name} src={avatarSrc} fallback={initials} />
+			<Avatar
+				size={size}
+				name={name}
+				src={avatarSrc}
+				fallback={initials}
+				colorPalette={colorPalette}
+			/>
 			<VStack align="start" gap={0}>
 				<Text fontSize="sm" fontWeight="semibold" lineClamp={1}>
 					{name}

--- a/src/components/data-table/cells/status-badge-cell.mdx
+++ b/src/components/data-table/cells/status-badge-cell.mdx
@@ -21,6 +21,14 @@ The optional `tooltip` prop wraps the badge in `<Tooltip>` from `@knkcs/anker/pr
 
 <Canvas of={Stories.WithTooltip} />
 
+## With Icon
+
+The optional `icon` prop renders a `ReactNode` inline before the label inside the badge — typically a small `lucide-react` glyph. Pairs naturally with status values like 2FA "On" / "Off".
+
+<Canvas of={Stories.WithIconOn} />
+
+<Canvas of={Stories.WithIconOff} />
+
 ## Props
 
 <ArgTypes of={Stories} />

--- a/src/components/data-table/cells/status-badge-cell.stories.tsx
+++ b/src/components/data-table/cells/status-badge-cell.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Eye, EyeOff, ShieldCheck } from "lucide-react";
 import { StatusBadgeCell } from "./status-badge-cell";
 
 const statusColorMap: Record<string, string> = {
@@ -70,6 +71,31 @@ export const WithTooltipAndDetail: Story = {
 		colorMap: { ...statusColorMap, failed: "red" },
 		detail: "Export timed out after 30s",
 		tooltip: "Retried 3 times before giving up",
+	},
+};
+
+export const WithIconOn: Story = {
+	args: {
+		value: "On",
+		colorMap: { On: "green", Off: "gray" },
+		icon: <Eye size={12} />,
+	},
+};
+
+export const WithIconOff: Story = {
+	args: {
+		value: "Off",
+		colorMap: { On: "green", Off: "gray" },
+		icon: <EyeOff size={12} />,
+	},
+};
+
+export const WithIconAndTooltip: Story = {
+	args: {
+		value: "Verified",
+		colorMap: { Verified: "green" },
+		icon: <ShieldCheck size={12} />,
+		tooltip: "Account 2FA is enabled",
 	},
 };
 

--- a/src/components/data-table/cells/status-badge-cell.test.tsx
+++ b/src/components/data-table/cells/status-badge-cell.test.tsx
@@ -49,4 +49,27 @@ describe("StatusBadgeCell", () => {
 		expect(screen.getByText("failed")).toBeInTheDocument();
 		expect(screen.getByText("Export timed out")).toBeInTheDocument();
 	});
+
+	it("renders the icon before the label inside the badge when provided", () => {
+		renderWithChakra(
+			<StatusBadgeCell
+				value="On"
+				icon={<svg data-testid="badge-icon" aria-hidden="true" />}
+			/>,
+		);
+		const icon = screen.getByTestId("badge-icon");
+		const badge = screen.getByText("On");
+		expect(icon).toBeInTheDocument();
+		expect(badge).toBeInTheDocument();
+		// The icon lives inside the Badge element that holds the label text,
+		// and precedes the label in document order.
+		expect(badge.contains(icon)).toBe(true);
+		expect(badge.firstChild).toBe(icon);
+	});
+
+	it("renders without an icon by default (backwards compatible)", () => {
+		renderWithChakra(<StatusBadgeCell value="published" />);
+		expect(screen.queryByTestId("badge-icon")).not.toBeInTheDocument();
+		expect(screen.getByText("published")).toBeInTheDocument();
+	});
 });

--- a/src/components/data-table/cells/status-badge-cell.tsx
+++ b/src/components/data-table/cells/status-badge-cell.tsx
@@ -20,6 +20,11 @@ export interface StatusBadgeCellProps {
 	 * don't fit on the badge label.
 	 */
 	tooltip?: React.ReactNode;
+	/**
+	 * Optional icon rendered inline before the label inside the badge (e.g.
+	 * a `lucide-react` glyph). A small gap separates it from the label.
+	 */
+	icon?: React.ReactNode;
 }
 
 export const StatusBadgeCell: React.FC<StatusBadgeCellProps> = ({
@@ -29,10 +34,13 @@ export const StatusBadgeCell: React.FC<StatusBadgeCellProps> = ({
 	detail,
 	detailColor = "fg.error",
 	tooltip,
+	icon,
 }) => {
 	if (value == null) return <span>{emptyCellValue}</span>;
 	const color = colorMap?.[value] ?? fallbackColor;
-	let badge: React.ReactNode = <StatusBadge label={value} color={color} />;
+	let badge: React.ReactNode = (
+		<StatusBadge label={value} color={color} icon={icon} />
+	);
 
 	if (tooltip != null) {
 		badge = (


### PR DESCRIPTION
## Summary

- `IdentityCell` gains an optional `colorPalette` prop that forwards to the underlying `Avatar` primitive. Lets consumers tint the fallback initials circle (e.g. `"primary"`, `"secondary"`) instead of the default neutral gray.
- `StatusBadgeCell` gains an optional `icon` prop. When provided, the icon renders inline before the label inside the badge with a small gap. Composes with `detail` and `tooltip`.
- Both props are backwards compatible: omitting them preserves current behavior.
- Restores two pre-anker visual affordances odon lost when migrating to `IdentityCell`/`StatusBadgeCell` in 1.10.1: dark-blue avatar circles (`UserAvatar`) and the inline 2FA on/off icon (`MfaBadge`).

## Changes

- `src/components/data-table/cells/identity-cell.tsx` — new `colorPalette?: string` prop, forwarded to `Avatar`.
- `src/atoms/status-badge/status-badge.tsx` — new optional `icon` prop rendered before the label, with a small `gap`.
- `src/components/data-table/cells/status-badge-cell.tsx` — new `icon?: React.ReactNode` prop forwarded into `StatusBadge`.
- Stories + MDX docs updated with `colorPalette="primary"` / `colorPalette="secondary"` examples and icon variants (using `lucide-react` glyphs).
- Tests updated for both cells.
- `docs/react-table-reference.md` — cells table notes the new props.
- `CHANGELOG.md` — `[1.10.2]` entry.
- `package.json` — `1.10.1` → `1.10.2`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings only, no errors)
- [x] `npm test` — 144/144 passing
- [x] `npm run build` clean
- [x] `npm run build:storybook` clean
- [x] `grep -c "IdentityCell\|DeviceCell\|StatusBadgeCell" dist/components/index.js` → 7 (≥6 expected)
- [x] `src/components/index.ts` still exports `IdentityCell`, `DeviceCell`, `StatusBadgeCell` (the 1.10.0 regression won't recur)
- [ ] Visual confirmation in Storybook (`IdentityCell` with `colorPalette="primary"` shows blue avatar; `StatusBadgeCell` with icon renders glyph before label)

Do not enable auto-merge. Do not push the `v1.10.2` tag — operator will tag.