### PR TITLE
docs(cells): correct cell import path to @knkcs/anker/components

### DIFF
--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -92,7 +92,7 @@ Full spec with composition diagrams, slot tables, and authoring rules: `docs/pag
 
 ## DataTable cells
 
-anker ships 16 reusable cell components for `<DataTable>` columns under `@knkcs/anker/components/data-table/cells`. **Use cells before composing primitives.** Inline `<Badge>` / `<Box>` / `<Text>` / `<Tooltip>` cell content fragments the visual language and silently misses later improvements (a11y, dark mode, density).
+anker ships 16 reusable cell components for `<DataTable>` columns. They are exported from `@knkcs/anker/components` (the same import path as `DataTable`, `Card`, `Modal`, etc.). **Use cells before composing primitives.** Inline `<Badge>` / `<Box>` / `<Text>` / `<Tooltip>` cell content fragments the visual language and silently misses later improvements (a11y, dark mode, density).
 
 **Rule:** cells are the contract — if no cell fits, file an issue and propose a new cell. Don't hand-roll.
 
@@ -115,7 +115,11 @@ anker ships 16 reusable cell components for `<DataTable>` columns under `@knkcs/
 | `TruncatedTextCell` | text (+ optional `subText`, `maxLength`) |
 | `UrlCell` | external URL |
 
-Import path: `@knkcs/anker/components/data-table/cells`.
+Import path: `@knkcs/anker/components`.
+
+```ts
+import { IdentityCell, StatusBadgeCell, DateCell } from "@knkcs/anker/components";
+```
 
 Full slot/prop tables: `docs/react-table-reference.md`. Mapping guide for common column intents: `docs/page-patterns.md` §11.13.
 

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -1229,9 +1229,8 @@ Operators serve this from a static asset or fallback handler.
 
 ### 11.13 DataTable cells
 
-**Rule.** Cells from `@knkcs/anker/components/data-table/cells` are
-the contract — **never inline cell JSX from primitives unless no cell
-fits**. If no cell fits, file an issue and propose a new cell. Inline
+**Rule.** Cells from `@knkcs/anker/components` are the contract — **never
+inline cell JSX from primitives unless no cell fits**. If no cell fits, file an issue and propose a new cell. Inline
 `<Badge>`, `<Box>`, `<Text>`, `<Tooltip>` compositions in column
 files are the kind of drift the cells library was built to prevent;
 they fragment the visual language across solutions and silently miss
@@ -1243,15 +1242,16 @@ single browser frame. Tables are the single most common surface in
 the platform. Visually divergent rows — even by 1–2px of padding or
 a slightly different muted color — read as broken to operators.
 
-**Available cells.** Anker ships 16 cells today. All live behind one
-import path:
+**Available cells.** Anker ships 16 cells today. All exported from the
+same path as `DataTable` itself (`Card`, `Modal`, etc. — one path for
+every component-level export):
 
 ```tsx
 import {
   ActionCell, BooleanCell, CodeCell, ColorSwatchCell, CountCell,
   DateCell, DeviceCell, IdentityCell, LinkCell, MenuCell, NumberCell,
   SlugCell, StatusBadgeCell, SwitchCell, TruncatedTextCell, UrlCell,
-} from "@knkcs/anker/components/data-table/cells";
+} from "@knkcs/anker/components";
 ```
 
 | Cell | Use case |

--- a/docs/react-table-reference.md
+++ b/docs/react-table-reference.md
@@ -92,9 +92,9 @@ Acceptable for simple cases but gives weaker type inference.
 
 ## Cell Components
 
-Anker provides 16 reusable cell components in `src/components/data-table/cells/`. They are **plain React components with zero TanStack coupling** — they receive pre-extracted values and render UI.
+Anker provides 16 reusable cell components. The source lives under `src/components/data-table/cells/` and each cell is re-exported from the components barrel — consumers import them from `@knkcs/anker/components` (the same path as `DataTable`, `Card`, `Modal`, etc.). Cells are **plain React components with zero TanStack coupling** — they receive pre-extracted values and render UI.
 
-> **Rule:** cells from `@knkcs/anker/components/data-table/cells` are the contract — never inline cell JSX from primitives unless no cell fits. If no cell fits, file an issue and propose a new cell. See `docs/page-patterns.md` §11.13 for the cell-mapping guide.
+> **Rule:** cells from `@knkcs/anker/components` are the contract — never inline cell JSX from primitives unless no cell fits. If no cell fits, file an issue and propose a new cell. See `docs/page-patterns.md` §11.13 for the cell-mapping guide.
 
 ### Pattern: cells receive values, not TanStack context
 


### PR DESCRIPTION
## Summary
- The cell library docs reference an import subpath that doesn't exist in \`package.json\`'s exports map.
- Cells live inside the \`components\` bundle (re-exported from the components barrel by PR #103). The working import is \`@knkcs/anker/components\` — same path as DataTable, Card, Modal, every other component-level export.
- odon's PR #124 implementer hit this mismatch and used the actual working path; the doc-written path would have failed module resolution.
- Update CLAUDE-ANKER.md, page-patterns.md, and react-table-reference.md so AI sessions and human readers learn the correct path on first read.

## Test plan
- [ ] Read each updated doc — references to \`@knkcs/anker/components\` (not the cells subpath)
- [ ] One remaining \`src/components/data-table/cells/\` reference in react-table-reference.md is intentional (filesystem path for source-level readers)

No code change.