### PR TITLE
fix: outline button hover respects colorPalette + sticky sidebar/rail in AppShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.4] — 2026-05-05
+
+### Fixed
+
+- **Outline button hover now respects `colorPalette`.** Previously the `outline` variant hard-coded `gray.50`/`gray.700` for `_hover`, `_checked`, and `_active`, so a `<Button colorPalette="red" variant="outline">` showed a gray hover background instead of a red-tinted one. The variant now uses the `colorPalette.50`/`colorPalette.100` and `colorPalette.900/40`/`colorPalette.800` semantic tokens so the tint follows the active palette (red outline → light red hover, primary outline → light primary hover, gray outline → light gray hover — matching previous default behavior). The `secondary` variant is intentionally unchanged: it is meant to be a neutral gray outline regardless of the consumer's `colorPalette`.
+- **AppShell sidebar and rail columns are now sticky.** `position: sticky` with `top: 0`, `align-self: start`, `max-height: 100vh`, and `overflow-y: auto` keeps the sidebar and rail in place while the main column scrolls. Previously the entire grid scrolled when the main content overflowed the viewport, so the navigation disappeared on long pages.
+
 ## [1.10.3] — 2026-05-05
 
 ### CI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/atoms/button/button.stories.tsx
+++ b/src/atoms/button/button.stories.tsx
@@ -102,3 +102,22 @@ export const SolidDefaultsPrimary: Story = {
 		</HStack>
 	),
 };
+
+// Outline variant resolves hover/active backgrounds via the active
+// `colorPalette`. Hover each button to verify the tint follows the palette.
+export const OutlineColorPalettes: Story = {
+	render: () => (
+		<HStack gap={4}>
+			<Button variant="outline">Primary (default)</Button>
+			<Button variant="outline" colorPalette="red">
+				Deactivate account
+			</Button>
+			<Button variant="outline" colorPalette="green">
+				Approve
+			</Button>
+			<Button variant="outline" colorPalette="gray">
+				Neutral
+			</Button>
+		</HStack>
+	),
+};

--- a/src/templates/app-shell.stories.tsx
+++ b/src/templates/app-shell.stories.tsx
@@ -125,3 +125,34 @@ export const DescendantDrivenRail: Story = {
 		</AppShell>
 	),
 };
+
+// Long-scrolling main content. Use this story to verify that the sidebar and
+// rail columns stay sticky at the top of the viewport while the main column
+// scrolls underneath them.
+export const StickyColumnsWithLongContent: Story = {
+	render: () => (
+		<AppShell sidebar={<SampleSidebar />} rail={<SampleRail />}>
+			<Box px="8" py="6">
+				<Heading as="h1" size="lg" mb="2">
+					Long page
+				</Heading>
+				<Text color="muted" mb="6">
+					Scroll the main column — the sidebar and rail should stay put.
+				</Text>
+				{Array.from({ length: 60 }).map((_, i) => (
+					<Box
+						// biome-ignore lint/suspicious/noArrayIndexKey: static demo content
+						key={i}
+						py="4"
+						borderBottomWidth="1px"
+						borderColor="border"
+					>
+						<Text>
+							Row {i + 1} — filler content to force the page to scroll.
+						</Text>
+					</Box>
+				))}
+			</Box>
+		</AppShell>
+	),
+};

--- a/src/templates/app-shell.test.tsx
+++ b/src/templates/app-shell.test.tsx
@@ -105,6 +105,31 @@ describe("AppShell", () => {
 		expect(cs.background).toContain("--chakra-colors-bg-surface");
 	});
 
+	it("sidebar column is sticky to the viewport top", () => {
+		// Regression: previously the sidebar scrolled away with the grid when
+		// the main column overflowed the viewport. The sidebar must stay put.
+		renderWithChakra(
+			<AppShell sidebar={<div data-testid="sb">sidebar</div>}>
+				<div>main</div>
+			</AppShell>,
+		);
+		const sidebarCol = screen.getByTestId("app-shell-sidebar");
+		expect(sidebarCol).toHaveStyle({ position: "sticky", top: "0" });
+	});
+
+	it("rail column is sticky to the viewport top", () => {
+		renderWithChakra(
+			<AppShell
+				sidebar={<div data-testid="sb" />}
+				rail={<div data-testid="rail">rail</div>}
+			>
+				<div>main</div>
+			</AppShell>,
+		);
+		const railCol = screen.getByTestId("app-shell-rail");
+		expect(railCol).toHaveStyle({ position: "sticky", top: "0" });
+	});
+
 	it("rail column renders on the surface with a left divider", () => {
 		renderWithAnkerTheme(
 			<AppShell

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -249,7 +249,16 @@ function AppShellInner({ sidebar, rail, children }: AppShellProps) {
 			minH="100vh"
 			bg="bg-canvas"
 		>
-			<Box gridColumn="1" minW="0">
+			<Box
+				data-testid="app-shell-sidebar"
+				gridColumn="1"
+				minW="0"
+				position="sticky"
+				top="0"
+				alignSelf="start"
+				maxH="100vh"
+				overflowY="auto"
+			>
 				{sidebar}
 			</Box>
 			<Flex
@@ -269,6 +278,11 @@ function AppShellInner({ sidebar, rail, children }: AppShellProps) {
 					data-testid="app-shell-rail"
 					gridColumn="3"
 					minW="0"
+					position="sticky"
+					top="0"
+					alignSelf="start"
+					maxH="100vh"
+					overflowY="auto"
 					bg="bg-surface"
 					borderLeftWidth="1px"
 					borderColor="border"

--- a/src/theme/recipes/button.ts
+++ b/src/theme/recipes/button.ts
@@ -136,17 +136,21 @@ export const buttonTheme = defineRecipe({
 				},
 			},
 
-			// Outline: white background with subtle hover/active states
+			// Outline: white background with subtle hover/active states.
+			// Uses the `colorPalette` semantic tokens so the hover/active tints
+			// follow whichever palette the consumer set on the Button (e.g.
+			// `colorPalette="red"` -> red-tinted hover). Defaults to the
+			// `primary` palette via the recipe's `defaultVariants`.
 			outline: {
 				bg: { base: "white", _dark: "gray.800" },
 				_hover: {
-					bg: { base: "gray.50", _dark: "gray.700/40" },
+					bg: { base: "colorPalette.50", _dark: "colorPalette.900/40" },
 				},
 				_checked: {
-					bg: { base: "gray.100", _dark: "gray.700" },
+					bg: { base: "colorPalette.100", _dark: "colorPalette.800" },
 				},
 				_active: {
-					bg: { base: "gray.100", _dark: "gray.700" },
+					bg: { base: "colorPalette.100", _dark: "colorPalette.800" },
 				},
 			},
 


### PR DESCRIPTION
## Summary

Two reported regressions, both shipped in **v1.10.4**:

### 1. Outline button hover ignored `colorPalette`

`src/theme/recipes/button.ts` hard-coded `gray.50`/`gray.700` for the `outline` variant's `_hover`, `_checked`, and `_active` backgrounds. As a result a destructive button such as

```tsx
<Button colorPalette="red" variant="outline">Deactivate account</Button>
```

hovered with a **gray** background, not a red-tinted one. Same for any non-default palette.

**Fix:** swap the literal gray tokens for `colorPalette.50` / `colorPalette.100` (and `colorPalette.900/40` / `colorPalette.800` in dark mode), Chakra v3's semantic palette references. The tint now follows whichever palette is active on the button instance:

- `colorPalette="primary"` (default) -> light primary on hover
- `colorPalette="red"` -> light red on hover (e.g. "Deactivate account")
- `colorPalette="gray"` -> light gray on hover (preserves prior default behavior)

**Decision: leave `secondary` alone.** The `secondary` variant has the same gray-literal pattern, but it's meant to be a neutral gray outline regardless of the consumer's `colorPalette` — its name implies a fixed neutral surface. Changing it would break consumers that pair `<Button variant="secondary" colorPalette="primary">` to get a neutral cancel-button next to a primary CTA. If we ever need a palette-aware secondary, that can be a separate, opt-in API.

The `solid` and `link` variants already resolve through `colorPalette.X` correctly, so they're untouched.

### 2. AppShell sidebar and rail scrolled away on long pages

`src/templates/app-shell.tsx` placed the sidebar in a plain `<Box>`. When the main column's content overflowed the viewport, the whole grid scrolled — the sidebar disappeared off-screen with it, which violates the expectation that nav stays visible while the content area scrolls.

**Fix:** make the sidebar and rail columns sticky:

```tsx
<Box
  gridColumn="1"
  position="sticky"
  top="0"
  alignSelf="start"
  maxH="100vh"
  overflowY="auto"
>
  {sidebar}
</Box>
```

(Same for the rail column.) The main column stays a regular `<Flex>` — that's the column we want to scroll. When the sidebar's own content is taller than the viewport, the column's own `overflowY="auto"` kicks in.

### Issue 1.5 — page-too-tall on short content

The brief flagged that `<DetailPageTemplate>` with one Card still produces a vertical scrollbar. I investigated: `DetailPageTemplate` is clean (no extraneous `minH`), and the AppShell grid is `minH="100vh"` with the main column also `minH="100vh"`. With sticky sidebar/rail, an unintended page-overflow would only happen if the main column exceeds viewport height, which it shouldn't on a short detail page (`PageHeader` + `Box flex="1"` with one Card). I could not reproduce a definite "scrollbar with one Card" repro inside Storybook against the existing `Templates/DetailPageTemplate` story, so I'm not changing layout sizing in this PR. If the issue persists in odon after upgrading to 1.10.4 the next step would be to look at the consumer-side wrapper around `<AppShell>` (e.g. an extra wrapper with margin/padding pushing the main column over 100vh).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no errors (warnings unchanged from main)
- [x] `npm test` — 144 tests pass (added 2 sticky-position assertions on the AppShell)
- [x] `npm run build` — clean
- [x] `npm run verify-exports` — clean
- [x] `npm run build:storybook` — clean
- [x] Storybook visual check: `Atoms/Button` -> `OutlineColorPalettes` story shows red/green/gray/primary outline buttons; hovering each tints the background with the matching palette.
- [x] Storybook visual check: `Templates/AppShell` -> `StickyColumnsWithLongContent` story scrolls the main column while the sidebar and rail stay pinned at the top.

## Release

- Bumped `package.json`: 1.10.3 -> 1.10.4
- Added `[1.10.4]` CHANGELOG entry
- **Do not auto-merge** and **do not tag** — user will handle both.