### PR TITLE
feat: tabbed-template API (bodyTabs + subheader) — 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.12.0 — 2026-05-08
+
+### Added
+- `DetailPageTemplate.bodyTabs` and `SettingsPageTemplate.bodyTabs` —
+  declarative owned-panel tabs. Template wraps `<Tabs.Root>` with
+  `lazyMount unmountOnExit` so only the active tab mounts. Eliminates
+  the stuck-header-actions footgun from consumer-owned Tabs.Root.
+- `DetailPageTemplate.subheader` — ReactNode rendered between the
+  PageHeader and tabs/body. Use for identity-card-style summaries.
+
+### Changed
+- `tabs` prop on Detail/SettingsPageTemplate now documented as
+  nav-mode/filter-mode only (Tabs.List with no Tabs.Content). For
+  owned-panel tabs, use `bodyTabs`. Passing both throws.
+
 ## [1.10.4] — 2026-05-05
 
 ### Fixed

--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -64,6 +64,7 @@ The full human-facing spec lives at the anker GitHub Pages docs site (linked fro
 - **No new color introductions.** If a color isn't in `colors.ts`, it doesn't exist. Why: the palette is closed by design — adding ad-hoc colors fragments the system.
 - **No `maxW` on a Card inside a settings/detail template body.** The template controls width; per-card overrides break visual rhythm and produce orphaned narrow cards on full-width pages. Why: the template is the contract for body width — cards are the contract for content surfacing.
 - **No inline create-forms above a DataTable.** Use a header-action button (or `usePageActions` from a tab) that opens a `Modal`. Why: inline forms steal vertical space, drift from the master pattern, and split form state from the rest of the page.
+- **Don't own `<Tabs.Root>` for an owned-panels tab page.** Use `SettingsPageTemplate.bodyTabs` or `DetailPageTemplate.bodyTabs`. Why: the template enforces `lazyMount unmountOnExit` so `usePageActions` registrations from inactive tabs can't collide with the active tab's. Consumer-owned `<Tabs.Root>` was the cause of the "stuck Add button" bug fixed in anker 1.12. The `tabs` prop on those templates is for nav-mode/filter-mode strips only (Tabs.List, no Tabs.Content).
 
 ---
 

--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -62,6 +62,8 @@ The full human-facing spec lives at the anker GitHub Pages docs site (linked fro
 - **No animations over 300ms.** Outside marketing/onboarding. Why: long animations slow down power users; the design language values immediacy.
 - **No Chakra v2 patterns.** No `extendTheme`, `colorScheme`, `useColorMode` from `@chakra-ui/react`. Use `createSystem`, `colorPalette`, `next-themes`. Why: anker is built on Chakra v3 throughout; v2 patterns either error at build time or silently no-op.
 - **No new color introductions.** If a color isn't in `colors.ts`, it doesn't exist. Why: the palette is closed by design — adding ad-hoc colors fragments the system.
+- **No `maxW` on a Card inside a settings/detail template body.** The template controls width; per-card overrides break visual rhythm and produce orphaned narrow cards on full-width pages. Why: the template is the contract for body width — cards are the contract for content surfacing.
+- **No inline create-forms above a DataTable.** Use a header-action button (or `usePageActions` from a tab) that opens a `Modal`. Why: inline forms steal vertical space, drift from the master pattern, and split form state from the rest of the page.
 
 ---
 

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -887,6 +887,59 @@ or list, optionally filtered.
 - The toolbar can be omitted entirely — pass `toolbar={null}` (or just
   omit the prop). Don't fake a toolbar with a `<Box>`.
 
+#### Contract
+
+Every index page composes these slots, in this order:
+
+1. **Header** (`IndexPageTemplate` props):
+   - `breadcrumbs`, `title` — required.
+   - `actions` slot — dedicated to the **primary-add** trigger (a `Button` that opens a `Modal`). Secondary actions (Export, Import) follow.
+   - `tabs` — optional. When present, lives between header and toolbar.
+2. **Toolbar** (in this order, left → right):
+   - `Toolbar.Search` — typeahead input. Always present unless the dataset is bounded (≤ ~5 rows).
+   - `Toolbar.Filters` — `FilterChip` for boolean toggles (zero-or-more), `NativeSelect` for exclusive enums with > 3 values, omit otherwise.
+   - `Toolbar.Right` — optional secondary actions, then `Toolbar.Count`.
+3. **DataTable**:
+   - `selectable` + `rowSelection` / `onRowSelectionChange` / `getRowId` — when the entity has bulk verbs.
+   - `onRowClick` — when a detail page exists.
+4. **BulkActionBar swap-in** — when `selectedIds.length > 0`, the *toolbar element* is replaced (not appended) by a `BulkActionBar` carrying the bulk verbs. Render a single ternary:
+
+   ```tsx
+   const toolbar = selectedIds.length > 0
+     ? <BulkActionBar ...>{actions}</BulkActionBar>
+     : <Toolbar>...</Toolbar>;
+   ```
+
+5. **Create flow** — header-actions button → `Modal`. Inline forms above the toolbar are an anti-pattern: they steal vertical space, are easy to miss, and split form state from the rest of the page.
+
+#### Index-in-Tab sub-pattern
+
+For index-style content rendered inside `Tabs.Content` (typical inside `SettingsPageTemplate` and `DetailPageTemplate`):
+
+- The same Toolbar / DataTable / BulkActionBar contract applies inside the tab body.
+- **Tab-scoped primary-add lifts to the parent template's header-actions slot** via `usePageActions(<AddButton/>)`. This places the action where users expect it (top-right of page) without nesting a second header inside the tab. Anker's slot store handles registration/cleanup on tab switch automatically.
+- No second `<PageHeader>` inside the tab.
+- The tab does not own breadcrumbs; the parent page does.
+
+```tsx
+// Inside MembersTab body
+function MembersTab() {
+  const [addOpen, setAddOpen] = useState(false);
+  usePageActions(
+    <Button variant="solid" colorPalette="primary" size="sm" onClick={() => setAddOpen(true)}>
+      Add member
+    </Button>
+  );
+  return (
+    <>
+      <Toolbar>...</Toolbar>
+      <DataTable ... />
+      <Modal open={addOpen} onClose={() => setAddOpen(false)} ... />
+    </>
+  );
+}
+```
+
 ### 11.2 DetailPageTemplate
 
 **When to use.** Any "single entity" page: a single user, a single

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -914,31 +914,13 @@ Every index page composes these slots, in this order:
 
 #### Index-in-Tab sub-pattern
 
-For index-style content rendered inside `Tabs.Content` (typical inside `SettingsPageTemplate` and `DetailPageTemplate`):
+For index-style content rendered inside a tab body of `SettingsPageTemplate` or `DetailPageTemplate`, use the parent template's **`bodyTabs`** API. The template owns `<Tabs.Root>` with `lazyMount unmountOnExit`, so only the active tab mounts — `usePageActions` from inside a tab body registers exactly when that tab is active and clears on unmount.
 
 - The same Toolbar / DataTable / BulkActionBar contract applies inside the tab body.
-- **Tab-scoped primary-add lifts to the parent template's header-actions slot** via `usePageActions(<AddButton/>)`. This places the action where users expect it (top-right of page) without nesting a second header inside the tab. Anker's slot store handles registration/cleanup on tab switch automatically.
+- Tab-scoped primary-add lifts to the parent template's header-actions slot via `usePageActions(<AddButton/>)`. Because `bodyTabs` lazy-mounts, only the active tab's `usePageActions` registration is alive — no collisions, no stale buttons.
 - No second `<PageHeader>` inside the tab.
 - The tab does not own breadcrumbs; the parent page does.
-
-```tsx
-// Inside MembersTab body
-function MembersTab() {
-  const [addOpen, setAddOpen] = useState(false);
-  usePageActions(
-    <Button variant="solid" colorPalette="primary" size="sm" onClick={() => setAddOpen(true)}>
-      Add member
-    </Button>
-  );
-  return (
-    <>
-      <Toolbar>...</Toolbar>
-      <DataTable ... />
-      <Modal open={addOpen} onClose={() => setAddOpen(false)} ... />
-    </>
-  );
-}
-```
+- **Don't** wrap `bodyTabs` content in your own `<Tabs.Root>`. The template owns it.
 
 ### 11.2 DetailPageTemplate
 
@@ -997,6 +979,42 @@ OAuth client, a single audit event detail, a single webhook config.
   requirement. A detail page without tabs is fine — render the body
   however the entity demands.
 
+#### `bodyTabs` — owned panels
+
+Use `bodyTabs` for tab bodies that are direct children of the template. The template wraps `<Tabs.Root>` with `lazyMount unmountOnExit`; only the active panel mounts. Use this any time each tab has its own body component.
+
+```tsx
+<DetailPageTemplate
+  breadcrumbs={[...]}
+  title={user.displayName}
+  bodyTabs={{
+    defaultValue: "profile",
+    items: [
+      { value: "profile",  label: "Profile",  content: <ProfileTab user={user} /> },
+      { value: "security", label: "Security", content: <SecurityTab user={user} /> },
+    ],
+  }}
+/>
+```
+
+For controlled tabs (e.g. URL deep-linking), pass `value` + `onValueChange` instead of `defaultValue`.
+
+#### `subheader`
+
+A `ReactNode` rendered between the PageHeader and the tabs (or body). Use for identity-card-style summaries that sit under the title bar.
+
+```tsx
+<DetailPageTemplate
+  title={user.displayName}
+  subheader={<UserIdentityCard user={user} />}
+  bodyTabs={{ ... }}
+/>
+```
+
+#### `tabs` (legacy / nav-mode)
+
+The `tabs` prop is for nav-mode tab strips (Tabs.List with no Tabs.Content; the body comes from `children`, typically a route's outlet). `bodyTabs` and `tabs` are mutually exclusive — passing both throws.
+
 ### 11.3 SettingsPageTemplate
 
 **When to use.** Any "preferences / configuration" page composed of
@@ -1037,6 +1055,28 @@ organization settings, IDP settings, admin → general.
 - A single-tab settings page is a sign you should be using
   DetailPageTemplate instead. Use SettingsPageTemplate only when there
   are ≥ 2 tabs.
+
+#### `bodyTabs` — owned panels
+
+Same shape as `DetailPageTemplate.bodyTabs`. Prefer this for settings pages over the legacy `tabs` + `children` pattern; the template handles `lazyMount unmountOnExit` automatically so `usePageActions` from inside a tab body never collides with another tab's registration.
+
+```tsx
+<SettingsPageTemplate
+  breadcrumbs={[...]}
+  title={org.name}
+  bodyPadding="none"
+  maxBodyWidth="full"
+  bodyTabs={{
+    defaultValue: "general",
+    items: [
+      { value: "general", label: "General",  content: <GeneralTab .../> },
+      { value: "members", label: "Members",  content: <MembersTab .../> },
+    ],
+  }}
+/>
+```
+
+`bodyTabs` and `tabs` are mutually exclusive — passing both throws.
 
 ### 11.4 DashboardPageTemplate
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/templates/detail-page-template.test.tsx
+++ b/src/templates/detail-page-template.test.tsx
@@ -2,7 +2,7 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AppShell } from "./app-shell";
 import { DetailPageTemplate } from "./detail-page-template";
 
@@ -65,5 +65,57 @@ describe("DetailPageTemplate", () => {
 			</AppShell>,
 		);
 		expect(screen.getByTestId("tabs")).toBeInTheDocument();
+	});
+
+	it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate
+					title="X"
+					bodyTabs={{
+						defaultValue: "a",
+						items: [
+							{ value: "a", label: "Tab A", content: <div data-testid="content-a">A</div> },
+							{ value: "b", label: "Tab B", content: <div data-testid="content-b">B</div> },
+						],
+					}}
+				/>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("content-a")).toBeInTheDocument();
+		expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
+	});
+
+	it("renders the subheader between header and tabs", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<DetailPageTemplate
+					title="X"
+					subheader={<div data-testid="subheader">subheader</div>}
+				>
+					<div data-testid="body">body</div>
+				</DetailPageTemplate>
+			</AppShell>,
+		);
+		const sub = screen.getByTestId("subheader");
+		const body = screen.getByTestId("body");
+		expect(sub).toBeInTheDocument();
+		expect(sub.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	});
+
+	it("throws when both bodyTabs and tabs are passed", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() =>
+			renderWithChakra(
+				<AppShell sidebar={<div />}>
+					<DetailPageTemplate
+						title="X"
+						tabs={<div />}
+						bodyTabs={{ defaultValue: "a", items: [{ value: "a", label: "A", content: <div /> }] }}
+					/>
+				</AppShell>,
+			),
+		).toThrow(/mutually exclusive/i);
+		spy.mockRestore();
 	});
 });

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -7,20 +7,52 @@
 //   ┌─────────────────────────────────────────┐
 //   │ PageHeader  (breadcrumbs · title · …)   │
 //   ├─────────────────────────────────────────┤
-//   │ Tabs (optional — pinned beneath header) │
+//   │ subheader (optional — e.g. identity card)│
 //   ├─────────────────────────────────────────┤
-//   │ children (identity card · panes · …)    │
+//   │ Tabs (optional — pinned beneath subhead) │
+//   ├─────────────────────────────────────────┤
+//   │ children OR bodyTabs panes               │
 //   └─────────────────────────────────────────┘
 //
-// Use for pages that show one entity: a single user, a single OAuth client,
-// a single audit-event detail. Detail pages often have an identity Card at
-// the top followed by tabbed sections — DetailPageTemplate is intentionally
-// thin so consumers can compose those freely under `children`.
+// Two ways to render tabs:
+//
+// 1. `bodyTabs` — declarative panels owned by the template. Template wraps
+//    Tabs.Root with `lazyMount unmountOnExit` so only the active panel
+//    mounts. Use this for any case where each tab has its own body
+//    component (Members, Security, Sessions panes).
+//
+// 2. `tabs` — ReactNode slot for nav-mode or filter-mode tab strips
+//    (Tabs.List with no Tabs.Content; the body comes from `children`,
+//    typically a route's outlet). Use this when each tab is a separate
+//    route or when tab state is controlled externally.
+//
+// `bodyTabs` and `tabs` are mutually exclusive. Passing both throws.
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Tabs } from "../primitives/tabs";
 import { Box, Flex } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
+
+export interface BodyTabsItem {
+	value: string;
+	label: ReactNode;
+	content: ReactNode;
+}
+
+export type BodyTabsProp =
+	| {
+			items: BodyTabsItem[];
+			defaultValue: string;
+			value?: never;
+			onValueChange?: never;
+	  }
+	| {
+			items: BodyTabsItem[];
+			value: string;
+			onValueChange: (next: string) => void;
+			defaultValue?: never;
+	  };
 
 export interface DetailPageTemplateProps
 	extends Pick<
@@ -29,18 +61,28 @@ export interface DetailPageTemplateProps
 	> {
 	actions?: ReactNode;
 	/**
-	 * Tab strip rendered immediately under the PageHeader. Typically a
-	 * `<Tabs.Root>` containing a `<Tabs.List>` and one `<Tabs.Content>` per
-	 * pane. The template does not render `<Tabs.Content>` separately —
-	 * consumers control the tab body composition entirely.
+	 * Tab strip rendered immediately under the PageHeader / subheader.
+	 * Use this for nav-mode/filter-mode tabs (Tabs.List, no Tabs.Content);
+	 * the body comes from `children`. For owned-panel tabs, use `bodyTabs`
+	 * instead. Mutually exclusive with `bodyTabs`.
 	 */
 	tabs?: ReactNode;
 	/**
-	 * Page body — the entity's identity card, tab bodies, edit forms, etc.
-	 * Rendered flush against the canvas. Add internal padding inside
-	 * `children` if you need it.
+	 * Owned-panel tabs. Template renders Tabs.Root with `lazyMount
+	 * unmountOnExit`; only the active item's `content` mounts. Mutually
+	 * exclusive with `tabs` and `children` is ignored when this is set.
 	 */
-	children: ReactNode;
+	bodyTabs?: BodyTabsProp;
+	/**
+	 * ReactNode rendered between the PageHeader and the tabs (or the body
+	 * if no tabs). Use for identity-card-style summaries.
+	 */
+	subheader?: ReactNode;
+	/**
+	 * Page body — rendered when `bodyTabs` is not set. Flush against the
+	 * canvas; add internal padding inside `children` if you need it.
+	 */
+	children?: ReactNode;
 }
 
 export function DetailPageTemplate({
@@ -50,10 +92,64 @@ export function DetailPageTemplate({
 	eyebrow,
 	actions,
 	tabs,
+	bodyTabs,
+	subheader,
 	children,
 }: DetailPageTemplateProps) {
+	if (tabs && bodyTabs) {
+		throw new Error(
+			"DetailPageTemplate: `tabs` and `bodyTabs` are mutually exclusive — use `bodyTabs` for owned panels, `tabs` for nav/filter strips.",
+		);
+	}
 	const registered = useRegisteredPageActions();
 	const resolvedActions = actions ?? registered;
+
+	if (bodyTabs) {
+		const tabsRootProps =
+			bodyTabs.value !== undefined
+				? {
+						value: bodyTabs.value,
+						onValueChange: (d: { value: string }) =>
+							bodyTabs.onValueChange!(d.value),
+					}
+				: { defaultValue: bodyTabs.defaultValue };
+		return (
+			<Flex
+				data-testid="detail-page-template"
+				direction="column"
+				flex="1"
+				minH="0"
+			>
+				<PageHeader
+					breadcrumbs={breadcrumbs}
+					title={title}
+					subtitle={subtitle}
+					eyebrow={eyebrow}
+					actions={resolvedActions}
+				/>
+				{subheader ? <Box>{subheader}</Box> : null}
+				<Tabs.Root lazyMount unmountOnExit {...tabsRootProps}>
+					<Box>
+						<Tabs.List>
+							{bodyTabs.items.map((item) => (
+								<Tabs.Trigger key={item.value} value={item.value}>
+									{item.label}
+								</Tabs.Trigger>
+							))}
+						</Tabs.List>
+					</Box>
+					<Box flex="1" minH="0">
+						{bodyTabs.items.map((item) => (
+							<Tabs.Content key={item.value} value={item.value}>
+								{item.content}
+							</Tabs.Content>
+						))}
+					</Box>
+				</Tabs.Root>
+			</Flex>
+		);
+	}
+
 	return (
 		<Flex
 			data-testid="detail-page-template"
@@ -68,6 +164,7 @@ export function DetailPageTemplate({
 				eyebrow={eyebrow}
 				actions={resolvedActions}
 			/>
+			{subheader ? <Box>{subheader}</Box> : null}
 			{tabs ? <Box>{tabs}</Box> : null}
 			<Box flex="1" minH="0">
 				{children}

--- a/src/templates/settings-page-template.test.tsx
+++ b/src/templates/settings-page-template.test.tsx
@@ -1,0 +1,48 @@
+// src/templates/settings-page-template.test.tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AppShell } from "./app-shell";
+import { SettingsPageTemplate } from "./settings-page-template";
+
+function renderWithChakra(ui: ReactElement) {
+    return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("SettingsPageTemplate", () => {
+    it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
+        renderWithChakra(
+            <AppShell sidebar={<div />}>
+                <SettingsPageTemplate
+                    title="X"
+                    bodyTabs={{
+                        defaultValue: "a",
+                        items: [
+                            { value: "a", label: "Tab A", content: <div data-testid="content-a">A</div> },
+                            { value: "b", label: "Tab B", content: <div data-testid="content-b">B</div> },
+                        ],
+                    }}
+                />
+            </AppShell>,
+        );
+        expect(screen.getByTestId("content-a")).toBeInTheDocument();
+        expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
+    });
+
+    it("throws when both bodyTabs and tabs are passed", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        expect(() =>
+            renderWithChakra(
+                <AppShell sidebar={<div />}>
+                    <SettingsPageTemplate
+                        title="X"
+                        tabs={<div />}
+                        bodyTabs={{ defaultValue: "a", items: [{ value: "a", label: "A", content: <div /> }] }}
+                    />
+                </AppShell>,
+            ),
+        ).toThrow(/mutually exclusive/i);
+        spy.mockRestore();
+    });
+});

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -1,26 +1,33 @@
 // src/templates/settings-page-template.tsx
 //
 // SettingsPageTemplate — for any "preferences / configuration" page that
-// uses a tabbed split between mixed form / list content. Visually identical
-// to DetailPageTemplate today, but exposed as a separate template so its
-// authoring rules (tabs are required, body is padded, max-width on forms)
-// can evolve independently.
+// uses a tabbed split between mixed form / list content.
 //
 //   ┌─────────────────────────────────────────┐
 //   │ PageHeader  (breadcrumbs · title · …)   │
 //   ├─────────────────────────────────────────┤
 //   │ Tabs (required for settings)            │
 //   ├─────────────────────────────────────────┤
-//   │ children (form cards · lists · …)       │
+//   │ children OR bodyTabs panes              │
 //   └─────────────────────────────────────────┘
 //
-// Use this template for: personal-settings (profile, password, MFA tabs),
-// organization settings, identity-provider settings, admin → general.
+// Two ways to render tabs (mutually exclusive):
+//
+// 1. `bodyTabs` — declarative panels owned by the template. Template
+//    wraps Tabs.Root with `lazyMount unmountOnExit`. Prefer this for
+//    settings pages.
+//
+// 2. `tabs` + `children` — consumer owns Tabs.Root and Tabs.Content.
+//    Retained for back-compat / advanced cases.
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
+import { Tabs } from "../primitives/tabs";
 import { Box, Flex } from "../primitives/layout";
 import { useRegisteredPageActions } from "./app-shell";
+import type { BodyTabsProp } from "./detail-page-template";
+
+export type { BodyTabsItem, BodyTabsProp } from "./detail-page-template";
 
 export interface SettingsPageTemplateProps
 	extends Pick<
@@ -29,32 +36,28 @@ export interface SettingsPageTemplateProps
 	> {
 	actions?: ReactNode;
 	/**
-	 * Tab strip. Settings pages should always have at least two tabs — if
-	 * you only have one section, use DetailPageTemplate instead.
+	 * Tab strip (consumer-owned). Mutually exclusive with `bodyTabs`.
+	 * Settings pages should always have at least two tabs — if you only
+	 * have one section, use DetailPageTemplate instead.
 	 */
-	tabs: ReactNode;
-	/** Page body — typically Card-wrapped forms or DataLists. */
-	children: ReactNode;
+	tabs?: ReactNode;
 	/**
-	 * Constrain the body width for readability. Settings forms read better
-	 * at ~720px even on wide viewports. Pass a Chakra width token (`"3xl"`,
-	 * `"4xl"`) or any CSS length. @default "3xl" (= 768px)
-	 *
+	 * Owned-panel tabs. Template renders Tabs.Root with `lazyMount
+	 * unmountOnExit`; only the active item's `content` mounts. Mutually
+	 * exclusive with `tabs`.
+	 */
+	bodyTabs?: BodyTabsProp;
+	/** Page body when `bodyTabs` is not set. */
+	children?: ReactNode;
+	/**
+	 * Constrain the body width for readability. @default "3xl" (= 768px).
 	 * Pass `"full"` to disable the constraint entirely.
 	 */
 	maxBodyWidth?: string;
 	/**
 	 * Padding applied to the body between the tab strip and the page
-	 * content. Defaults to `"default"` (`px="8" pt="6"`) which aligns
-	 * Card-wrapped forms with the PageHeader's horizontal inset.
-	 *
-	 * Pass `"none"` to render the body flush — useful when a settings tab
-	 * embeds a full-width `<DataTable>` that should extend edge-to-edge.
-	 * When using `"none"`, tabs that still need padding (e.g. form-Card
-	 * tabs) should wrap their own content in `<Box px="8" py="6">`.
-	 * Avoid negative-margin workarounds (`mx="-8"`).
-	 *
-	 * @default "default"
+	 * content. @default "default" (`px="8" pt="6"`). Pass `"none"` to
+	 * render flush.
 	 */
 	bodyPadding?: "default" | "none";
 }
@@ -66,14 +69,77 @@ export function SettingsPageTemplate({
 	eyebrow,
 	actions,
 	tabs,
+	bodyTabs,
 	children,
 	maxBodyWidth = "3xl",
 	bodyPadding = "default",
 }: SettingsPageTemplateProps) {
+	if (tabs && bodyTabs) {
+		throw new Error(
+			"SettingsPageTemplate: `tabs` and `bodyTabs` are mutually exclusive — use `bodyTabs` for owned panels, `tabs` for consumer-owned tab strips.",
+		);
+	}
 	const registered = useRegisteredPageActions();
 	const resolvedActions = actions ?? registered;
 	const bodyPx = bodyPadding === "none" ? "0" : "8";
 	const bodyPt = bodyPadding === "none" ? "0" : "6";
+
+	const renderBody = (node: ReactNode) => (
+		<Box flex="1" minH="0" px={bodyPx} pt={bodyPt}>
+			<Box
+				maxW={maxBodyWidth}
+				marginInline={maxBodyWidth === "full" ? "0" : "auto"}
+			>
+				{node}
+			</Box>
+		</Box>
+	);
+
+	if (bodyTabs) {
+		const tabsRootProps =
+			bodyTabs.value !== undefined
+				? {
+						value: bodyTabs.value,
+						onValueChange: (d: { value: string }) =>
+							bodyTabs.onValueChange!(d.value),
+					}
+				: { defaultValue: bodyTabs.defaultValue };
+		return (
+			<Flex
+				data-testid="settings-page-template"
+				direction="column"
+				flex="1"
+				minH="0"
+			>
+				<PageHeader
+					breadcrumbs={breadcrumbs}
+					title={title}
+					subtitle={subtitle}
+					eyebrow={eyebrow}
+					actions={resolvedActions}
+				/>
+				<Tabs.Root lazyMount unmountOnExit {...tabsRootProps}>
+					<Box>
+						<Tabs.List>
+							{bodyTabs.items.map((item) => (
+								<Tabs.Trigger key={item.value} value={item.value}>
+									{item.label}
+								</Tabs.Trigger>
+							))}
+						</Tabs.List>
+					</Box>
+					{renderBody(
+						bodyTabs.items.map((item) => (
+							<Tabs.Content key={item.value} value={item.value}>
+								{item.content}
+							</Tabs.Content>
+						)),
+					)}
+				</Tabs.Root>
+			</Flex>
+		);
+	}
+
 	return (
 		<Flex
 			data-testid="settings-page-template"
@@ -89,14 +155,7 @@ export function SettingsPageTemplate({
 				actions={resolvedActions}
 			/>
 			<Box>{tabs}</Box>
-			<Box flex="1" minH="0" px={bodyPx} pt={bodyPt}>
-				<Box
-					maxW={maxBodyWidth}
-					marginInline={maxBodyWidth === "full" ? "0" : "auto"}
-				>
-					{children}
-				</Box>
-			</Box>
+			{renderBody(children)}
 		</Flex>
 	);
 }


### PR DESCRIPTION
## Summary

- New `bodyTabs` prop on `DetailPageTemplate` and `SettingsPageTemplate` — declarative owned-panel tabs. Template wraps `<Tabs.Root>` with `lazyMount unmountOnExit` so only the active panel mounts. Eliminates the "stuck header-actions" footgun caused by consumer-owned `Tabs.Root` + concurrent panel mounting.
- New `subheader` prop on `DetailPageTemplate` — `ReactNode` rendered between the PageHeader and tabs. Replaces the bespoke identity-card-in-body workaround in odon's `UserDetailLayout`.
- `tabs` prop on both templates narrowed in docs to nav-mode/filter-mode only (Tabs.List, no Tabs.Content). `bodyTabs` and `tabs` are mutually exclusive — passing both throws.
- Docs (page-patterns.md §11.2, §11.3, revised §11.1 Index-in-Tab) and CLAUDE-ANKER.md updated.
- Version bump to **1.12.0**.

## Why

odon's index-page-uniformity refactor placed `usePageActions(<AddButton/>)` inside multiple `<Tabs.Content>` siblings. Chakra v3 Tabs keep inactive panels mounted by default, so all tabs' `usePageActions` registrations raced for the single header-actions slot — leaving a stale "Add member" button on every tab.

A docs-only fix would require every consumer to remember `lazyMount unmountOnExit` on every `<Tabs.Root>`. The clean fix is to make the template own `Tabs.Root` and enforce `lazyMount` itself — wrong usage becomes impossible.

`subheader` came along because `UserDetailLayout` had to hand-roll its identity-card placement (between page header and tab strip). Now it's a first-class slot.

## Migration

odon will follow in a separate PR: `OrgSettingsPage`, `WorkspaceDetailPage` migrate to `bodyTabs`; `UserDetailLayout` migrates to `subheader` + `tabs`.

## Test plan

- [x] New tests cover: `bodyTabs` uncontrolled rendering (only active tab mounts); `subheader` DOM ordering; mutual-exclusion error when both `bodyTabs` and `tabs` passed.
- [x] Existing tests for both templates still pass.
- [x] `npm run build` + `npm run verify-exports` pass.
- [ ] After merge: tag `v1.12.0` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)