### PR TITLE
fix(lint): biome auto-fixes for 1.12.0 publish

### DIFF
--- a/src/templates/detail-page-template.test.tsx
+++ b/src/templates/detail-page-template.test.tsx
@@ -75,8 +75,16 @@ describe("DetailPageTemplate", () => {
 					bodyTabs={{
 						defaultValue: "a",
 						items: [
-							{ value: "a", label: "Tab A", content: <div data-testid="content-a">A</div> },
-							{ value: "b", label: "Tab B", content: <div data-testid="content-b">B</div> },
+							{
+								value: "a",
+								label: "Tab A",
+								content: <div data-testid="content-a">A</div>,
+							},
+							{
+								value: "b",
+								label: "Tab B",
+								content: <div data-testid="content-b">B</div>,
+							},
 						],
 					}}
 				/>
@@ -100,7 +108,9 @@ describe("DetailPageTemplate", () => {
 		const sub = screen.getByTestId("subheader");
 		const body = screen.getByTestId("body");
 		expect(sub).toBeInTheDocument();
-		expect(sub.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(
+			sub.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 	});
 
 	it("throws when both bodyTabs and tabs are passed", () => {
@@ -111,7 +121,10 @@ describe("DetailPageTemplate", () => {
 					<DetailPageTemplate
 						title="X"
 						tabs={<div />}
-						bodyTabs={{ defaultValue: "a", items: [{ value: "a", label: "A", content: <div /> }] }}
+						bodyTabs={{
+							defaultValue: "a",
+							items: [{ value: "a", label: "A", content: <div /> }],
+						}}
 					/>
 				</AppShell>,
 			),

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -30,8 +30,8 @@
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
-import { Tabs } from "../primitives/tabs";
 import { Box, Flex } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
 import { useRegisteredPageActions } from "./app-shell";
 
 export interface BodyTabsItem {

--- a/src/templates/settings-page-template.test.tsx
+++ b/src/templates/settings-page-template.test.tsx
@@ -7,42 +7,53 @@ import { AppShell } from "./app-shell";
 import { SettingsPageTemplate } from "./settings-page-template";
 
 function renderWithChakra(ui: ReactElement) {
-    return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
 }
 
 describe("SettingsPageTemplate", () => {
-    it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
-        renderWithChakra(
-            <AppShell sidebar={<div />}>
-                <SettingsPageTemplate
-                    title="X"
-                    bodyTabs={{
-                        defaultValue: "a",
-                        items: [
-                            { value: "a", label: "Tab A", content: <div data-testid="content-a">A</div> },
-                            { value: "b", label: "Tab B", content: <div data-testid="content-b">B</div> },
-                        ],
-                    }}
-                />
-            </AppShell>,
-        );
-        expect(screen.getByTestId("content-a")).toBeInTheDocument();
-        expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
-    });
+	it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate
+					title="X"
+					bodyTabs={{
+						defaultValue: "a",
+						items: [
+							{
+								value: "a",
+								label: "Tab A",
+								content: <div data-testid="content-a">A</div>,
+							},
+							{
+								value: "b",
+								label: "Tab B",
+								content: <div data-testid="content-b">B</div>,
+							},
+						],
+					}}
+				/>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("content-a")).toBeInTheDocument();
+		expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
+	});
 
-    it("throws when both bodyTabs and tabs are passed", () => {
-        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-        expect(() =>
-            renderWithChakra(
-                <AppShell sidebar={<div />}>
-                    <SettingsPageTemplate
-                        title="X"
-                        tabs={<div />}
-                        bodyTabs={{ defaultValue: "a", items: [{ value: "a", label: "A", content: <div /> }] }}
-                    />
-                </AppShell>,
-            ),
-        ).toThrow(/mutually exclusive/i);
-        spy.mockRestore();
-    });
+	it("throws when both bodyTabs and tabs are passed", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() =>
+			renderWithChakra(
+				<AppShell sidebar={<div />}>
+					<SettingsPageTemplate
+						title="X"
+						tabs={<div />}
+						bodyTabs={{
+							defaultValue: "a",
+							items: [{ value: "a", label: "A", content: <div /> }],
+						}}
+					/>
+				</AppShell>,
+			),
+		).toThrow(/mutually exclusive/i);
+		spy.mockRestore();
+	});
 });

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -22,8 +22,8 @@
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
-import { Tabs } from "../primitives/tabs";
 import { Box, Flex } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
 import { useRegisteredPageActions } from "./app-shell";
 import type { BodyTabsProp } from "./detail-page-template";
 


### PR DESCRIPTION
## Summary

Biome lint failures in #108 blocked the v1.12.0 publish workflow. Pure `biome check --write` auto-fixes (import order + whitespace in the test files); no behavioral changes.

## Test plan

- [x] `npm run lint` passes locally.
- [ ] CI green → re-tag v1.12.0 to this commit → publish runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)