### PR TITLE
docs: Card composition rule + Don't anti-pattern

### DIFF
--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -65,6 +65,7 @@ The full human-facing spec lives at the anker GitHub Pages docs site (linked fro
 - **No `maxW` on a Card inside a settings/detail template body.** The template controls width; per-card overrides break visual rhythm and produce orphaned narrow cards on full-width pages. Why: the template is the contract for body width — cards are the contract for content surfacing.
 - **No inline create-forms above a DataTable.** Use a header-action button (or `usePageActions` from a tab) that opens a `Modal`. Why: inline forms steal vertical space, drift from the master pattern, and split form state from the rest of the page.
 - **Don't own `<Tabs.Root>` for an owned-panels tab page.** Use `SettingsPageTemplate.bodyTabs` or `DetailPageTemplate.bodyTabs`. Why: the template enforces `lazyMount unmountOnExit` so `usePageActions` registrations from inactive tabs can't collide with the active tab's. Consumer-owned `<Tabs.Root>` was the cause of the "stuck Add button" bug fixed in anker 1.12. The `tabs` prop on those templates is for nav-mode/filter-mode strips only (Tabs.List, no Tabs.Content).
+- **Don't wrap Card children in `<Box p="N">`.** `<Card>` body has built-in padding via Chakra's CardBody (~24px). Wrapping in `<Box p>` doubles it. Pass content directly (use `<Stack>` for layout). Why: a uniform Card body padding is the visual contract; per-Card overrides break visual rhythm and make Cards look heavier than the rest of the design system.
 
 ---
 

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -1420,6 +1420,29 @@ value renders the `emptyCellValue` em-dash (`"—"`).
 **Full slot / prop tables.** See [`docs/react-table-reference.md`](./react-table-reference.md)
 for prop tables, value-type signatures, and the file map.
 
+#### Card composition
+
+`<Card>` wraps `children` in a `<ChakraCard.Body>` which has built-in padding (~24px on all sides). Pass content directly — do **not** wrap in your own `<Box p="N">`, which doubles the padding.
+
+```tsx
+// ✓ Correct
+<Card title="General">
+  <Stack gap="4">
+    <FormField .../>
+    <FormField .../>
+  </Stack>
+</Card>
+
+// ✗ Wrong — doubles the padding
+<Card title="General">
+  <Box p="6">
+    <Stack gap="4">...</Stack>
+  </Box>
+</Card>
+```
+
+If you need a flush body (e.g. a `<DataTable>` inside a Card), file an issue — anker should add a `bodyPadding="none"` prop rather than having every consumer hand-roll the workaround.
+
 ---
 
 ## 12. Slot mechanism


### PR DESCRIPTION
Documents Chakra-default Card body padding so consumers stop wrapping children in Box p=6 (which doubles the padding). Adds a CLAUDE-ANKER Don't rule.