### PR TITLE
feat: DescriptionList primitive — 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.13.0 — 2026-05-08
+
+### Added
+- `<DescriptionList>` component with `<DescriptionList.Row>` children. Supports `orientation="horizontal"` (default) and `orientation="vertical"`. Replaces hand-rolled Flex/Box patterns for read-only metadata blocks.
+
 ## 1.12.0 — 2026-05-08
 
 ### Added

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -1678,6 +1678,33 @@ These rules are the contract for solution authors.
 
 ---
 
+## 14. Primitives
+
+#### DescriptionList
+
+For label/value lists (read-only metadata blocks, identity summaries, etc.) use `<DescriptionList>` rather than hand-rolling `<Flex justify="space-between">` rows. Two orientations:
+
+- `horizontal` (default) — label muted on left, value on right. Single-line per row. Use inside a Card body or under a settings form.
+- `vertical` — label above value. Use as building block inside a `<Grid>` for stat-tile layouts.
+
+```tsx
+<DescriptionList>
+  <DescriptionList.Row label="Email">{user.email}</DescriptionList.Row>
+  <DescriptionList.Row label="ID" mono>{user.id}</DescriptionList.Row>
+</DescriptionList>
+
+<Grid templateColumns="repeat(3, 1fr)" gap="6">
+  <DescriptionList orientation="vertical">
+    <DescriptionList.Row label="Status">Active</DescriptionList.Row>
+  </DescriptionList>
+  ...
+</Grid>
+```
+
+Don't use `<DescriptionList>` for editable form fields — pair `<TextInput>` with explicit labels instead.
+
+---
+
 ## 15. References
 
 - [`docs/design-system.md`](./design-system.md) — token system and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/description-list.stories.tsx
+++ b/src/components/description-list.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Grid } from "../primitives/layout";
+import { DescriptionList } from "./description-list";
+
+const meta = {
+	title: "Components/DescriptionList",
+	component: DescriptionList,
+} satisfies Meta<typeof DescriptionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+	render: () => (
+		<DescriptionList>
+			<DescriptionList.Row label="Email">jana@knk.de</DescriptionList.Row>
+			<DescriptionList.Row label="ID" mono>
+				2P9XmR3sJk
+			</DescriptionList.Row>
+			<DescriptionList.Row label="Created">
+				2026-04-12 09:31
+			</DescriptionList.Row>
+		</DescriptionList>
+	),
+};
+
+export const Vertical: Story = {
+	render: () => (
+		<DescriptionList orientation="vertical">
+			<DescriptionList.Row label="Status">Active</DescriptionList.Row>
+			<DescriptionList.Row label="Last seen">2 hours ago</DescriptionList.Row>
+		</DescriptionList>
+	),
+};
+
+export const VerticalGrid: Story = {
+	render: () => (
+		<Grid templateColumns="repeat(3, 1fr)" gap="6">
+			<DescriptionList orientation="vertical">
+				<DescriptionList.Row label="Status">Active</DescriptionList.Row>
+			</DescriptionList>
+			<DescriptionList orientation="vertical">
+				<DescriptionList.Row label="MFA">Enabled</DescriptionList.Row>
+			</DescriptionList>
+			<DescriptionList orientation="vertical">
+				<DescriptionList.Row label="Last login">
+					2 hours ago
+				</DescriptionList.Row>
+			</DescriptionList>
+		</Grid>
+	),
+};

--- a/src/components/description-list.test.tsx
+++ b/src/components/description-list.test.tsx
@@ -1,0 +1,89 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { DescriptionList } from "./description-list";
+
+function renderWithChakra(ui: ReactElement) {
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("DescriptionList", () => {
+	it("renders rows with labels and values", () => {
+		renderWithChakra(
+			<DescriptionList>
+				<DescriptionList.Row label="Email">
+					user@example.com
+				</DescriptionList.Row>
+				<DescriptionList.Row label="ID" mono>
+					abc123
+				</DescriptionList.Row>
+			</DescriptionList>,
+		);
+		expect(screen.getByText("Email")).toBeInTheDocument();
+		expect(screen.getByText("user@example.com")).toBeInTheDocument();
+		expect(screen.getByText("ID")).toBeInTheDocument();
+		expect(screen.getByText("abc123")).toBeInTheDocument();
+	});
+
+	it("applies a different CSS class when mono prop is set vs not set", () => {
+		// Chakra v3 uses Emotion — styles are CSS classes, not inline styles.
+		// We verify that the mono element gets a different class than a non-mono
+		// element, confirming the fontFamily prop is actually applied.
+		const { rerender } = renderWithChakra(
+			<DescriptionList>
+				<DescriptionList.Row label="ID" mono>
+					abc123
+				</DescriptionList.Row>
+			</DescriptionList>,
+		);
+		const monoClass = screen.getByText("abc123").getAttribute("class");
+
+		rerender(
+			<ChakraProvider value={defaultSystem}>
+				<DescriptionList>
+					<DescriptionList.Row label="ID">abc123</DescriptionList.Row>
+				</DescriptionList>
+			</ChakraProvider>,
+		);
+		const nonMonoClass = screen.getByText("abc123").getAttribute("class");
+
+		expect(monoClass).not.toBe(nonMonoClass);
+	});
+
+	it("renders horizontally by default (label and value in a flex row)", () => {
+		const { container } = renderWithChakra(
+			<DescriptionList>
+				<DescriptionList.Row label="X">y</DescriptionList.Row>
+			</DescriptionList>,
+		);
+		// Horizontal orientation: outer flex with justify-between
+		const flex = container.querySelector("[class*='css-']");
+		expect(flex).toBeTruthy();
+	});
+
+	it("renders vertically when orientation=vertical (label above value)", () => {
+		renderWithChakra(
+			<DescriptionList orientation="vertical">
+				<DescriptionList.Row label="Status">Active</DescriptionList.Row>
+			</DescriptionList>,
+		);
+		const label = screen.getByText("Status");
+		const value = screen.getByText("Active");
+		// vertical orientation: label sits above value in DOM
+		expect(
+			label.compareDocumentPosition(value) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("supports rich ReactNode values", () => {
+		renderWithChakra(
+			<DescriptionList>
+				<DescriptionList.Row label="State">
+					<span data-testid="badge">Active</span>
+				</DescriptionList.Row>
+			</DescriptionList>,
+		);
+		expect(screen.getByTestId("badge")).toBeInTheDocument();
+	});
+});

--- a/src/components/description-list.tsx
+++ b/src/components/description-list.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
+import { Box, Flex } from "../primitives/layout";
+import { Text } from "../primitives/typography";
+
+export interface DescriptionListProps {
+	orientation?: "horizontal" | "vertical";
+	gap?: string;
+	children: ReactNode;
+}
+
+interface DescriptionListContextShape {
+	orientation: "horizontal" | "vertical";
+}
+
+const DescriptionListContext = createContext<DescriptionListContextShape>({
+	orientation: "horizontal",
+});
+
+export function DescriptionList({
+	orientation = "horizontal",
+	gap = "3",
+	children,
+}: DescriptionListProps) {
+	return (
+		<DescriptionListContext.Provider value={{ orientation }}>
+			<Box>
+				<Flex direction="column" gap={gap}>
+					{children}
+				</Flex>
+			</Box>
+		</DescriptionListContext.Provider>
+	);
+}
+DescriptionList.displayName = "DescriptionList";
+
+export interface DescriptionListRowProps {
+	label: ReactNode;
+	mono?: boolean;
+	children: ReactNode;
+}
+
+function DescriptionListRow({
+	label,
+	mono,
+	children,
+}: DescriptionListRowProps) {
+	const { orientation } = useContext(DescriptionListContext);
+
+	if (orientation === "vertical") {
+		return (
+			<Box>
+				<Text fontSize="xs" color="muted" mb="0.5">
+					{label}
+				</Text>
+				<Text
+					fontSize="sm"
+					fontFamily={mono ? "mono" : undefined}
+					wordBreak="break-all"
+				>
+					{children}
+				</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Flex justify="space-between" align="baseline" gap="3">
+			<Text color="muted" fontSize="sm">
+				{label}
+			</Text>
+			<Text
+				fontSize="sm"
+				fontFamily={mono ? "mono" : undefined}
+				textAlign="right"
+				wordBreak="break-all"
+			>
+				{children}
+			</Text>
+		</Flex>
+	);
+}
+DescriptionListRow.displayName = "DescriptionList.Row";
+
+DescriptionList.Row = DescriptionListRow;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -74,6 +74,12 @@ export {
 	truncateText,
 	UrlCell,
 } from "./data-table";
+// DescriptionList
+export type {
+	DescriptionListProps,
+	DescriptionListRowProps,
+} from "./description-list";
+export { DescriptionList } from "./description-list";
 // Drawer
 export type { DrawerProps } from "./drawer";
 export { DrawerRoot } from "./drawer";


### PR DESCRIPTION
## Summary

- Adds `<DescriptionList>` component with `<DescriptionList.Row>` children
- Two orientations: `horizontal` (default — label muted-left, value right) and `vertical` (label above value, for stat-tile grid layouts)
- Optional `mono` prop on `Row` applies monospace font family for IDs and code values
- Replaces hand-rolled `<Flex justify="space-between">` patterns and per-feature `KVRow` helpers in odon

## Why

Odon's detail pages (user, OAuth client, API key, etc.) all hand-roll the same label/value flex pattern. A shared primitive enforces consistent spacing, muted labels, and `break-all` word wrapping — and gives the design system a single place to update if the pattern evolves.

## Test plan

- [x] `npx vitest run src/components/description-list.test.tsx` — 5 tests pass
- [x] `npm run lint` — no errors (20 pre-existing warnings unchanged)
- [x] `npm run build` — ESM + DTS build succeeds
- [x] Stories: `Horizontal`, `Vertical`, `VerticalGrid` cover both orientations and grid usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)