### PR TITLE
feat: three-row page header (breadcrumb · detail · tabs)

### DIFF
--- a/CLAUDE-ANKER.md
+++ b/CLAUDE-ANKER.md
@@ -78,8 +78,9 @@ Available templates:
 | Template | Use for |
 |---|---|
 | `<AppShell>` | Authenticated chrome (sidebar · main · rail). Provides `usePageActions(node)`, `usePageHeader(node)`, and `usePageRail(node)` hooks. Page templates register their `<PageHeader>` via `usePageHeader`, which renders it as a band spanning main + rail. |
+| `<PageHeader>` | Three-row page header band (breadcrumb · detail · tabs). Props: `breadcrumbs`, `title`, `subtitle`, `eyebrow`, `actions`, `avatar`, `badges`, `meta`, `tabs`. Each row is independently optional except title. See `docs/page-patterns.md` §Page header anatomy. |
 | `<IndexPageTemplate>` | List pages — header + optional tabs + toolbar + DataTable |
-| `<DetailPageTemplate>` | Single-entity pages — header + optional tabs + body |
+| `<DetailPageTemplate>` | Single-entity pages — registers a three-row header band via `usePageHeader`. New props: `avatar`, `badges`, `meta`, `tabs`. `subheader` and `bodyTabs` were removed in v2.2.0 — migrate to the slot props on PageHeader. |
 | `<SettingsPageTemplate>` | Tabbed settings pages with form Cards |
 | `<DashboardPageTemplate>` | Widget-grid overview pages |
 | `<AuthPageTemplate>` | Login, register, MFA, verify — centered card, no shell |

--- a/docs/page-patterns.md
+++ b/docs/page-patterns.md
@@ -47,8 +47,10 @@ by the `<AppShell>` template:
 
 ```
 ┌────────────┬────────────────────────────────────────────────────┐
-│            │                  Page header                       │
-│            │     (breadcrumbs · title · page actions)           │
+│            │   page header band:                                │
+│            │     [ breadcrumb ]                                 │
+│            │     [ detail row (avatar · title · actions)      ] │
+│            │     [ tabs (optional)                            ] │
 │  Sidebar   ├────────────────────────────────────┬───────────────┤
 │   240px    │         Main content               │ ContextRail   │
 │ ↔ 60px     │            (fluid)                 │    320px      │
@@ -94,7 +96,8 @@ Two named slots are exposed:
 The rail column's coordinate origin sits in grid row 2, below the header
 band. Its `position: sticky; top: 0` therefore pins to the bottom of the
 header, not to the viewport top. The sidebar still spans both rows and
-remains sticky to the viewport top.
+remains sticky to the viewport top. When the page header includes a tabs row, the rail's coordinate origin
+sits **below the tabs row** — i.e. below the entire header band.
 
 The store uses `useSyncExternalStore` so that producers (deep child
 components rendered after the consumer) and consumers (AppShell, the page
@@ -166,6 +169,72 @@ via `usePageRail`. Omit both (or pass `rail={null}`) and AppShell drops
 the third grid column entirely — the main column expands to fill the
 freed space. This is the right shape for solutions that don't have a
 contextual side panel.
+
+---
+
+## Page header anatomy
+
+The page header band is one `<PageHeader>` instance, registered into the
+header slot via `usePageHeader(...)` from a page template. It renders up
+to three vertically-stacked rows on `bg-surface`, separated by spacing
+(not borders). The bottom border of the band marks the transition to
+the body and rail.
+
+| Row | Purpose | Props |
+|-----|---------|-------|
+| 1 — Breadcrumb | Trail to the current page. Last crumb non-link. | `breadcrumbs` |
+| 2 — Detail | Identity of the current page or entity: optional avatar (left), title + badges + meta (center), actions (right). | `avatar`, `title`, `badges`, `subtitle`, `meta`, `actions` |
+| 3 — Tabs | In-page navigation or filter state. | `tabs` |
+
+Each row is independently optional except for the title in row 2, which
+is required.
+
+**Detail page example:**
+
+```tsx
+<DetailPageTemplate
+  breadcrumbs={[{ label: "Identity", to: "/identity" }, { label: "Users", to: "/identity/users" }, { label: "Jana Schmid" }]}
+  title="Jana Schmid"
+  avatar={<Avatar name="Jana Schmid" size="lg" />}
+  badges={<><Badge colorPalette="green">Aktiv</Badge><Badge colorPalette="blue">Admin</Badge></>}
+  meta={<Flex gap="4" fontSize="sm"><span>jana.schmid@knk.de</span><span>Produkt</span></Flex>}
+  actions={<Button>Bearbeiten</Button>}
+  tabs={
+    <Tabs.Root value={activeTab}>
+      <Tabs.List>
+        <Tabs.Trigger value="overview">Übersicht</Tabs.Trigger>
+        <Tabs.Trigger value="apps">Anwendungen</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  }
+>
+  {/* body cards */}
+</DetailPageTemplate>
+```
+
+**Index page example:**
+
+```tsx
+<IndexPageTemplate
+  breadcrumbs={[{ label: "Identity" }, { label: "Users" }]}
+  title="Users"
+  actions={<Button>Nutzer einladen</Button>}
+  tabs={
+    <Tabs.Root value={filter}>
+      <Tabs.List>
+        <Tabs.Trigger value="all">Alle</Tabs.Trigger>
+        <Tabs.Trigger value="active">Aktiv</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  }
+  toolbar={<SearchBar />}
+>
+  <DataTable … />
+</IndexPageTemplate>
+```
+
+Index pages omit `avatar`, `badges`, and `meta` — the detail row collapses
+to title + actions.
 
 ---
 
@@ -282,12 +351,15 @@ setting.
 >   Webhooks / Audit Log as separate index pages. Each is a top-level
 >   navigation target with its own page header.
 >
-> **Rule of thumb:** if the page header (title, breadcrumb, identity
-> card) stays the same across the items, they're tabs. If each item has
-> its own page header, they're sub-section nav.
+> **Rule of thumb:** if the in-page navigation keeps the entity identity
+> (breadcrumb, avatar, title, badges) constant across the destinations,
+> they belong in `tabs` on the page header. If each destination is a
+> distinct top-level page with its own breadcrumb and title, render them
+> as separate index pages in the sidebar.
 >
-> Don't mix the two in the same view — both UIs competing for the user's
-> eye is more noise than signal. Pick one based on the rule above.
+> Within a single page, prefer the `tabs` row over rendering a custom
+> in-body tab strip — it keeps the navigation surface consistent across
+> solutions.
 
 ---
 
@@ -957,12 +1029,15 @@ OAuth client, a single audit event detail, a single webhook config.
 >   Webhooks / Audit Log as separate index pages. Each is a top-level
 >   navigation target with its own page header.
 >
-> **Rule of thumb:** if the page header (title, breadcrumb, identity
-> card) stays the same across the items, they're tabs. If each item has
-> its own page header, they're sub-section nav.
+> **Rule of thumb:** if the in-page navigation keeps the entity identity
+> (breadcrumb, avatar, title, badges) constant across the destinations,
+> they belong in `tabs` on the page header. If each destination is a
+> distinct top-level page with its own breadcrumb and title, render them
+> as separate index pages in the sidebar.
 >
-> Don't mix the two in the same view — both UIs competing for the user's
-> eye is more noise than signal. Pick one based on the rule above.
+> Within a single page, prefer the `tabs` row over rendering a custom
+> in-body tab strip — it keeps the navigation surface consistent across
+> solutions.
 
 **Composition.**
 

--- a/docs/superpowers/plans/2026-05-13-page-header-redesign.md
+++ b/docs/superpowers/plans/2026-05-13-page-header-redesign.md
@@ -1,0 +1,1428 @@
+# Page Header Three-Row Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reshape anker's `<PageHeader>` into a three-row band (breadcrumb · detail · tabs) and migrate `IndexPageTemplate`, `DetailPageTemplate`, `SettingsPageTemplate`, plus odon's `UserDetailLayout` and `UserIdentityCard` to the new shape. End state: every solution renders a single continuous header band, with the rail starting below it.
+
+**Architecture:** `PageHeader` grows four optional props (`avatar`, `badges`, `meta`, `tabs`) and renders three vertically-stacked rows on its existing `bg="bg-surface"` band. Page templates stop rendering `subheader` / `tabs` as siblings below the header — both flow into `<PageHeader>` instead. Odon's `<UserIdentityCard>` is deleted; `UserDetailLayout` constructs the avatar / badges / meta nodes directly. `DetailPageTemplate.bodyTabs` is removed (it can't bridge the new slot/body split); consumers migrate to nav-link tabs (one `<Tabs.Root>` with only a `<Tabs.List>` inside).
+
+**Tech Stack:** React 18 + TypeScript, Chakra UI v3, Vitest + Testing Library, Biome, tsup, Storybook MDX. Spec: `docs/superpowers/specs/2026-05-13-page-header-redesign-design.md`.
+
+**Repos and branches:**
+- Anker: `/Users/jeskoiwanovski/repo/anker`, branch `feature/page-header-redesign` (already checked out, spec commit `396f4e8` present).
+- Odon: `/Users/jeskoiwanovski/repo/odon`, branch `feature/anker-2.2-header-band` (create when reaching Task 13).
+
+---
+
+## Task 1: PageHeader — `avatar` / `badges` / `meta` props (detail row)
+
+**Files:**
+- Modify: `src/components/page-header.tsx`
+- Test: `src/components/page-header.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src/components/page-header.test.tsx`. Read the file to learn the existing render helper and assertion patterns. Add this block inside the existing `describe("PageHeader", () => { … })`:
+
+```tsx
+it("renders avatar to the left of the title when provided", () => {
+    renderWithChakra(
+        <PageHeader
+            title="Jana Schmid"
+            avatar={<div data-testid="avatar">JS</div>}
+        />,
+    );
+    const avatar = screen.getByTestId("avatar");
+    const title = screen.getByRole("heading", { name: "Jana Schmid" });
+    expect(avatar).toBeInTheDocument();
+    // Avatar appears before the title in document order.
+    expect(
+        avatar.compareDocumentPosition(title) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+});
+
+it("renders badges inline with the title", () => {
+    renderWithChakra(
+        <PageHeader
+            title="Jana Schmid"
+            badges={
+                <>
+                    <span data-testid="b1">Aktiv</span>
+                    <span data-testid="b2">Admin</span>
+                </>
+            }
+        />,
+    );
+    expect(screen.getByTestId("b1")).toBeInTheDocument();
+    expect(screen.getByTestId("b2")).toBeInTheDocument();
+});
+
+it("renders the meta line below the title", () => {
+    renderWithChakra(
+        <PageHeader
+            title="Jana Schmid"
+            meta={<span data-testid="meta">jana@example.test</span>}
+        />,
+    );
+    const meta = screen.getByTestId("meta");
+    const title = screen.getByRole("heading", { name: "Jana Schmid" });
+    expect(meta).toBeInTheDocument();
+    // Meta appears after the title in document order.
+    expect(
+        title.compareDocumentPosition(meta) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+});
+
+it("does not render avatar/badges/meta containers when those props are absent", () => {
+    renderWithChakra(<PageHeader title="Plain" />);
+    expect(screen.queryByTestId("page-header-avatar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-header-badges")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("page-header-meta")).not.toBeInTheDocument();
+});
+```
+
+If `renderWithChakra` doesn't exist in this file, copy it from `src/templates/app-shell.test.tsx` (the `ChakraProvider value={defaultSystem}` wrapper).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/components/page-header.test.tsx`
+Expected: FAIL — `PageHeader` rejects unknown props or doesn't render the new elements.
+
+- [ ] **Step 3: Add the new props and render them**
+
+In `src/components/page-header.tsx`, update the `PageHeaderProps` interface (currently lines 11–17):
+
+```tsx
+export interface PageHeaderProps {
+    breadcrumbs?: PageHeaderBreadcrumb[];
+    title: React.ReactNode;
+    subtitle?: React.ReactNode;
+    actions?: React.ReactNode;
+    eyebrow?: React.ReactNode;
+    avatar?: React.ReactNode;
+    badges?: React.ReactNode;
+    meta?: React.ReactNode;
+}
+```
+
+Then update the function signature and the return body. Replace the existing `<Flex align="center" justify="space-between" gap="4">…</Flex>` block (currently lines 91–118) with this detail-row structure:
+
+```tsx
+<Flex align="flex-start" justify="space-between" gap="4">
+    {avatar ? (
+        <Box data-testid="page-header-avatar" flexShrink={0}>
+            {avatar}
+        </Box>
+    ) : null}
+    <Box flex="1" minW="0">
+        <Flex align="center" gap="2" wrap="wrap">
+            <Heading
+                as="h1"
+                fontSize="2xl"
+                fontWeight="semibold"
+                color="default"
+                letterSpacing="-0.02em"
+            >
+                {title}
+            </Heading>
+            {badges ? (
+                <Flex data-testid="page-header-badges" align="center" gap="2">
+                    {badges}
+                </Flex>
+            ) : null}
+        </Flex>
+        {subtitle && (
+            <Text
+                data-testid="page-header-subtitle"
+                fontSize="sm"
+                color="muted"
+                mt="1"
+            >
+                {subtitle}
+            </Text>
+        )}
+        {meta ? (
+            <Box data-testid="page-header-meta" mt="2">
+                {meta}
+            </Box>
+        ) : null}
+    </Box>
+    {hasActions && (
+        <Flex align="center" gap="2" flexShrink={0}>
+            {actions}
+        </Flex>
+    )}
+</Flex>
+```
+
+Make sure `avatar`, `badges`, `meta` are destructured at the top of the function alongside the existing props.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/components/page-header.test.tsx`
+Expected: all tests pass (existing tests still pass; the four new ones pass).
+
+If the existing `subtitle` test fails because `subtitle` now appears in a different position, leave it — it's still rendered, just inside the title block. Adjust the assertion only if it asserts a specific DOM sibling relationship.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/page-header.tsx src/components/page-header.test.tsx
+git commit -m "feat(page-header): add avatar, badges, and meta slots"
+```
+
+---
+
+## Task 2: PageHeader — `tabs` prop (third row)
+
+**Files:**
+- Modify: `src/components/page-header.tsx`
+- Test: `src/components/page-header.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the existing `describe("PageHeader", …)` in `src/components/page-header.test.tsx`:
+
+```tsx
+it("renders a tabs row at the bottom of the band when tabs is provided", () => {
+    renderWithChakra(
+        <PageHeader
+            title="Users"
+            tabs={
+                <div data-testid="tabs-strip">
+                    <button type="button">All</button>
+                    <button type="button">Active</button>
+                </div>
+            }
+        />,
+    );
+    const tabsRow = screen.getByTestId("page-header-tabs");
+    const tabsStrip = screen.getByTestId("tabs-strip");
+    const title = screen.getByRole("heading", { name: "Users" });
+    expect(tabsRow).toContainElement(tabsStrip);
+    // Tabs row appears after the title in document order.
+    expect(
+        title.compareDocumentPosition(tabsRow) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+});
+
+it("does not render a tabs row when tabs prop is absent", () => {
+    renderWithChakra(<PageHeader title="Users" />);
+    expect(screen.queryByTestId("page-header-tabs")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run src/components/page-header.test.tsx`
+Expected: FAIL — `page-header-tabs` element missing; `tabs` prop unrecognized.
+
+- [ ] **Step 3: Add the `tabs` prop and render the row**
+
+In `src/components/page-header.tsx`, add `tabs?: React.ReactNode` to `PageHeaderProps`:
+
+```tsx
+export interface PageHeaderProps {
+    breadcrumbs?: PageHeaderBreadcrumb[];
+    title: React.ReactNode;
+    subtitle?: React.ReactNode;
+    actions?: React.ReactNode;
+    eyebrow?: React.ReactNode;
+    avatar?: React.ReactNode;
+    badges?: React.ReactNode;
+    meta?: React.ReactNode;
+    tabs?: React.ReactNode;
+}
+```
+
+Destructure `tabs` in the function and append a tabs row immediately AFTER the closing `</Flex>` of the detail row (and before the outer `</Box>` close). The full inner structure of the return should now read:
+
+```tsx
+return (
+    <Box
+        py="4"
+        px="8"
+        borderBottomWidth="1px"
+        borderBottomColor="border"
+        bg="bg-surface"
+    >
+        {eyebrow && (
+            <Text … />
+        )}
+        {hasCrumbs && (
+            <Flex … />
+        )}
+        <Flex align="flex-start" justify="space-between" gap="4">
+            … detail row from Task 1 …
+        </Flex>
+        {tabs ? (
+            <Box data-testid="page-header-tabs" mt="4" mx="-8">
+                {tabs}
+            </Box>
+        ) : null}
+    </Box>
+);
+```
+
+The `mx="-8"` cancels the band's horizontal padding so the tab strip extends edge-to-edge and its bottom underline meets the band's bottom border. The tab strip itself supplies its own horizontal padding (Chakra's `Tabs.List` already provides this).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run src/components/page-header.test.tsx`
+Expected: PASS for all tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/page-header.tsx src/components/page-header.test.tsx
+git commit -m "feat(page-header): add tabs slot for third-row tab strip"
+```
+
+---
+
+## Task 3: PageHeader — Storybook stories for new slots
+
+**Files:**
+- Modify: `src/components/page-header.stories.tsx`
+
+- [ ] **Step 1: Read the existing stories file**
+
+Open `src/components/page-header.stories.tsx`. Note the `meta` / `default` exports and the story format (the file is small — under 60 lines). The existing stories likely include `Default`, `WithBreadcrumbs`, `WithActions`, or similar.
+
+- [ ] **Step 2: Add new stories**
+
+Append the following stories to the bottom of `src/components/page-header.stories.tsx`. Use whatever import conventions are already in the file (e.g., if existing stories use a `Template`, mirror it; otherwise use the `StoryObj` pattern shown here):
+
+```tsx
+import { Avatar, Badge } from "../atoms/avatar"; // adjust if your barrel path differs
+import { Tabs } from "../primitives/tabs";
+import { Box, Flex, Text } from "../primitives/layout";
+
+export const WithDetailSlots: StoryObj = {
+    render: () => (
+        <PageHeader
+            breadcrumbs={[
+                { label: "Identity", to: "#" },
+                { label: "Users", to: "#" },
+                { label: "Jana Schmid" },
+            ]}
+            title="Jana Schmid"
+            avatar={
+                <Box
+                    w="16"
+                    h="16"
+                    bg="bg-emphasis"
+                    color="white"
+                    borderRadius="full"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    fontWeight="bold"
+                    fontSize="xl"
+                >
+                    JS
+                </Box>
+            }
+            badges={
+                <>
+                    <Box
+                        bg="green.50"
+                        color="green.700"
+                        px="2"
+                        py="0.5"
+                        borderRadius="full"
+                        fontSize="xs"
+                        fontWeight="medium"
+                    >
+                        Aktiv
+                    </Box>
+                    <Box
+                        bg="blue.50"
+                        color="blue.700"
+                        px="2"
+                        py="0.5"
+                        borderRadius="full"
+                        fontSize="xs"
+                        fontWeight="medium"
+                    >
+                        Admin
+                    </Box>
+                </>
+            }
+            meta={
+                <Flex gap="4" fontSize="sm" color="muted" wrap="wrap">
+                    <Text>jana.schmid@knk.de</Text>
+                    <Text>Produktmanagement</Text>
+                    <Text fontFamily="mono">usr_8f3c2b9a4e7d</Text>
+                </Flex>
+            }
+            actions={
+                <>
+                    <button type="button">Passwort zurücksetzen</button>
+                    <button type="button">Bearbeiten</button>
+                </>
+            }
+        />
+    ),
+};
+
+export const WithTabs: StoryObj = {
+    render: () => (
+        <PageHeader
+            breadcrumbs={[
+                { label: "Identity", to: "#" },
+                { label: "Users" },
+            ]}
+            title="Users"
+            actions={
+                <>
+                    <button type="button">CSV importieren</button>
+                    <button type="button">Nutzer einladen</button>
+                </>
+            }
+            tabs={
+                <Tabs.Root defaultValue="all">
+                    <Tabs.List>
+                        <Tabs.Trigger value="all">Alle</Tabs.Trigger>
+                        <Tabs.Trigger value="active">Aktiv</Tabs.Trigger>
+                        <Tabs.Trigger value="invited">Eingeladen</Tabs.Trigger>
+                        <Tabs.Trigger value="suspended">Gesperrt</Tabs.Trigger>
+                    </Tabs.List>
+                </Tabs.Root>
+            }
+        />
+    ),
+};
+
+export const FullBand: StoryObj = {
+    render: () => (
+        <PageHeader
+            breadcrumbs={[
+                { label: "Identity", to: "#" },
+                { label: "Users", to: "#" },
+                { label: "Jana Schmid" },
+            ]}
+            title="Jana Schmid"
+            avatar={
+                <Box
+                    w="16"
+                    h="16"
+                    bg="bg-emphasis"
+                    color="white"
+                    borderRadius="full"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    fontWeight="bold"
+                    fontSize="xl"
+                >
+                    JS
+                </Box>
+            }
+            badges={
+                <Box
+                    bg="green.50"
+                    color="green.700"
+                    px="2"
+                    py="0.5"
+                    borderRadius="full"
+                    fontSize="xs"
+                    fontWeight="medium"
+                >
+                    Aktiv
+                </Box>
+            }
+            meta={
+                <Text fontSize="sm" color="muted">
+                    jana.schmid@knk.de
+                </Text>
+            }
+            actions={<button type="button">Bearbeiten</button>}
+            tabs={
+                <Tabs.Root defaultValue="overview">
+                    <Tabs.List>
+                        <Tabs.Trigger value="overview">Übersicht</Tabs.Trigger>
+                        <Tabs.Trigger value="apps">Anwendungen</Tabs.Trigger>
+                        <Tabs.Trigger value="sessions">Sitzungen</Tabs.Trigger>
+                    </Tabs.List>
+                </Tabs.Root>
+            }
+        />
+    ),
+};
+```
+
+If the existing stories file does not import `StoryObj`, follow the file's own typing convention. If imports of `Avatar`, `Tabs`, or `Box` don't match your codebase, replace them with the correct paths — `Tabs` is at `../primitives/tabs`, `Box`/`Flex`/`Text` at `../primitives/layout`, badges are inline div-based.
+
+- [ ] **Step 3: Verify with typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/page-header.stories.tsx
+git commit -m "docs(stories): add detail-slot and tabs stories for PageHeader"
+```
+
+---
+
+## Task 4: IndexPageTemplate — pipe `tabs` into PageHeader
+
+**Files:**
+- Modify: `src/templates/index-page-template.tsx`
+
+- [ ] **Step 1: Open the template**
+
+Read `src/templates/index-page-template.tsx`. Today it constructs `<PageHeader breadcrumbs … title … actions={resolvedActions} />` and registers it via `usePageHeader`, then renders `tabs` and `toolbar` as siblings of the header inside the template body.
+
+- [ ] **Step 2: Move `tabs` into PageHeader**
+
+Update the `usePageHeader(...)` call to include `tabs`:
+
+```tsx
+usePageHeader(
+    <PageHeader
+        breadcrumbs={breadcrumbs}
+        title={title}
+        subtitle={subtitle}
+        eyebrow={eyebrow}
+        actions={resolvedActions}
+        tabs={tabs}
+    />,
+);
+```
+
+Then remove the inline `{tabs ? <Box>{tabs}</Box> : null}` rendering from the template's return tree. The body return should now contain only `toolbar` and `children`:
+
+```tsx
+return (
+    <Flex
+        data-testid="index-page-template"
+        direction="column"
+        flex="1"
+        minH="0"
+    >
+        {toolbar ? <Box>{toolbar}</Box> : null}
+        <Box flex="1" minH="0">
+            {children}
+        </Box>
+    </Flex>
+);
+```
+
+- [ ] **Step 3: Run the existing test suite for this file**
+
+Run: `pnpm vitest run src/templates/index-page-template`
+Expected: any test that asserted the tabs were a child of `index-page-template` Flex fails. Fix those tests: change the assertion to query inside `screen.getByTestId("app-shell-header")` (use `within` from `@testing-library/react`) and wrap the render in `<AppShell sidebar={…}>` if it wasn't already. Tests that don't reference tabs should still pass.
+
+Example fix (if an existing test renders without AppShell and asserts a tab label appears anywhere):
+
+```tsx
+import { within } from "@testing-library/react";
+import { AppShell } from "./app-shell";
+
+it("renders tabs in the page header", () => {
+    renderWithChakra(
+        <AppShell sidebar={<div />}>
+            <IndexPageTemplate
+                title="Users"
+                tabs={<button data-testid="tab-all">All</button>}
+            >
+                body
+            </IndexPageTemplate>
+        </AppShell>,
+    );
+    const header = screen.getByTestId("app-shell-header");
+    expect(within(header).getByTestId("tab-all")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 4: Verify all template tests pass**
+
+Run: `pnpm vitest run src/templates/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/templates/index-page-template.tsx src/templates/index-page-template.test.tsx 2>/dev/null || git add src/templates/index-page-template.tsx
+git commit -m "feat(index-page-template): pipe tabs into PageHeader"
+```
+
+(If no test file exists for index-page-template, omit it from `git add`.)
+
+---
+
+## Task 5: DetailPageTemplate — replace `subheader`, pipe `tabs`, remove `bodyTabs`
+
+**Files:**
+- Modify: `src/templates/detail-page-template.tsx`
+- Test: `src/templates/detail-page-template.test.tsx`
+
+- [ ] **Step 1: Read the file**
+
+Open `src/templates/detail-page-template.tsx`. Note the current `DetailPageTemplateProps` interface, the `bodyTabs` branch, and the inline `<PageHeader>` usage (lifted to `usePageHeader` by an earlier migration).
+
+- [ ] **Step 2: Update the props interface**
+
+Replace the existing props that reference `subheader` and `bodyTabs`:
+
+```tsx
+export interface DetailPageTemplateProps
+    extends Pick<
+        PageHeaderProps,
+        "breadcrumbs" | "title" | "subtitle" | "eyebrow"
+    > {
+    actions?: ReactNode;
+    avatar?: ReactNode;
+    badges?: ReactNode;
+    meta?: ReactNode;
+    tabs?: ReactNode;
+    children?: ReactNode;
+}
+```
+
+Delete the `bodyTabs` prop entry and any helper type for it (e.g., `DetailPageTemplateBodyTabs`).
+
+- [ ] **Step 3: Update the function body**
+
+The function should now have a single straight-through return (no `bodyTabs` branching). Replace the whole body with:
+
+```tsx
+export function DetailPageTemplate({
+    breadcrumbs,
+    title,
+    subtitle,
+    eyebrow,
+    actions,
+    avatar,
+    badges,
+    meta,
+    tabs,
+    children,
+}: DetailPageTemplateProps) {
+    const registered = useRegisteredPageActions();
+    const resolvedActions = actions ?? registered;
+    usePageHeader(
+        <PageHeader
+            breadcrumbs={breadcrumbs}
+            title={title}
+            subtitle={subtitle}
+            eyebrow={eyebrow}
+            actions={resolvedActions}
+            avatar={avatar}
+            badges={badges}
+            meta={meta}
+            tabs={tabs}
+        />,
+    );
+    return (
+        <Flex
+            data-testid="detail-page-template"
+            direction="column"
+            flex="1"
+            minH="0"
+        >
+            <Box flex="1" minH="0">
+                {children}
+            </Box>
+        </Flex>
+    );
+}
+```
+
+Remove the `subheader` references and the entire `if (bodyTabs)` branch. The `if (tabs && bodyTabs) throw` guard is also gone (no more `bodyTabs`).
+
+If `<Tabs.Root>` is no longer used anywhere in the file, remove its import.
+
+- [ ] **Step 4: Update the test file**
+
+Open `src/templates/detail-page-template.test.tsx`. Identify:
+- Tests that pass `subheader={…}` → either delete them, or change them to assert that the same content reaches the header via `avatar` / `badges` / `meta` props.
+- Tests that pass `bodyTabs={…}` → delete them entirely. Add a comment in the file's top describing the migration: `// bodyTabs was removed in the page-header-redesign change. See spec docs/superpowers/specs/2026-05-13-page-header-redesign-design.md.`
+- Tests that pass `tabs={…}` and assert the tabs appear → wrap in `<AppShell>` and query inside `app-shell-header` (same pattern as Task 4).
+
+For the remaining tests, add this case asserting the new props are forwarded:
+
+```tsx
+it("forwards avatar, badges, meta, and tabs into the registered PageHeader", () => {
+    renderWithChakra(
+        <AppShell sidebar={<div />}>
+            <DetailPageTemplate
+                title="Jana Schmid"
+                avatar={<div data-testid="av">JS</div>}
+                badges={<span data-testid="bd">Aktiv</span>}
+                meta={<span data-testid="mt">jana@example.test</span>}
+                tabs={<div data-testid="tb">tab list</div>}
+            >
+                body
+            </DetailPageTemplate>
+        </AppShell>,
+    );
+    const header = screen.getByTestId("app-shell-header");
+    expect(within(header).getByTestId("av")).toBeInTheDocument();
+    expect(within(header).getByTestId("bd")).toBeInTheDocument();
+    expect(within(header).getByTestId("mt")).toBeInTheDocument();
+    expect(within(header).getByTestId("tb")).toBeInTheDocument();
+});
+```
+
+Add the `import { within } from "@testing-library/react";` and `import { AppShell } from "./app-shell";` lines if not already present.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm vitest run src/templates/detail-page-template`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/templates/detail-page-template.tsx src/templates/detail-page-template.test.tsx
+git commit -m "feat(detail-page-template)!: replace subheader/bodyTabs with avatar/badges/meta + tabs slot"
+```
+
+The `!` after the type marks this as a breaking change per Conventional Commits — `subheader` and `bodyTabs` are removed.
+
+---
+
+## Task 6: SettingsPageTemplate — same migration pattern
+
+**Files:**
+- Modify: `src/templates/settings-page-template.tsx`
+- Test: `src/templates/settings-page-template.test.tsx`
+
+- [ ] **Step 1: Read the file**
+
+Open `src/templates/settings-page-template.tsx`. Inspect whether it has `subheader`, `bodyTabs`, or `tabs` props.
+
+- [ ] **Step 2: Apply the same migration as Task 5**
+
+For each prop the file already has:
+- `subheader` → remove. Add `avatar`, `badges`, `meta` props and pipe them into `<PageHeader>`.
+- `bodyTabs` → remove. Keep `tabs` (the page passes whatever it wants there).
+- `tabs` → pipe into `<PageHeader tabs={tabs}>` (no longer rendered as a sibling).
+
+If SettingsPageTemplate has no `subheader` / `bodyTabs` props to begin with, just add `tabs` piping into `<PageHeader>` (mirroring Task 4's IndexPageTemplate change).
+
+The body return should render only `children` (plus whatever else is settings-template-specific, like tab panels managed by the page itself).
+
+- [ ] **Step 3: Update the test file**
+
+Same approach as Task 5: remove tests for removed props, update tab/header tests to query under `app-shell-header`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm vitest run src/templates/settings-page-template`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/templates/settings-page-template.tsx src/templates/settings-page-template.test.tsx
+git commit -m "feat(settings-page-template)!: align with three-row header redesign"
+```
+
+---
+
+## Task 7: Update `app-shell.tsx` top-of-file comment
+
+**Files:**
+- Modify: `src/templates/app-shell.tsx`
+
+- [ ] **Step 1: Update the ASCII diagram**
+
+In `src/templates/app-shell.tsx`, find the ASCII diagram at the top of the file (added by the context-rail-position work). Update its inner depiction of the header band to indicate three rows. Replace the diagram block with:
+
+```
+//     ┌─────────┬───────────────────────────────────┐
+//     │         │   page header band                │
+//     │         │   ┌ breadcrumb ─────────────────┐ │
+//     │         │   ┌ detail (avatar/title/etc.) ─┐ │
+//     │         │   ┌ tabs (optional) ────────────┐ │
+//     │         ├───────────────────────┬───────────┤
+//     │ sidebar │       children        │   rail    │
+//     │         │   (body / cards / …)  │           │
+//     │         │                       │           │
+//     └─────────┴───────────────────────┴───────────┘
+```
+
+The "Slot mechanism" comment section below the diagram doesn't need changes — the slot names (`actions` / `header` / `rail`) are unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/templates/app-shell.tsx
+git commit -m "docs(app-shell): update diagram for three-row header band"
+```
+
+---
+
+## Task 8: Update `docs/page-patterns.md`
+
+**Files:**
+- Modify: `docs/page-patterns.md`
+
+- [ ] **Step 1: Update the App-shell composition diagram**
+
+Find the ASCII diagram of the app shell (around lines 48–55, last updated by the rail-position work). Update the "page header" portion to show three rows:
+
+```
+┌────────────┬────────────────────────────────────────────────────┐
+│            │   page header band:                                │
+│            │     [ breadcrumb ]                                 │
+│            │     [ detail row (avatar · title · actions)      ] │
+│            │     [ tabs (optional)                            ] │
+│  Sidebar   ├────────────────────────────────────┬───────────────┤
+│   240px    │         Main content               │ ContextRail   │
+│ ↔ 60px     │            (fluid)                 │    320px      │
+│ collapsed  │                                    │  ↔ 44px       │
+│            │                                    │  collapsed    │
+└────────────┴────────────────────────────────────┴───────────────┘
+```
+
+- [ ] **Step 2: Add a new "Page header anatomy" section**
+
+Add a new H2 section titled `## Page header anatomy` AFTER the existing "App-shell composition" section and BEFORE the Sidebar section. Body:
+
+```markdown
+The page header band is one `<PageHeader>` instance, registered into the
+header slot via `usePageHeader(...)` from a page template. It renders up
+to three vertically-stacked rows on `bg-surface`, separated by spacing
+(not borders). The bottom border of the band marks the transition to
+the body and rail.
+
+| Row | Purpose | Props |
+|-----|---------|-------|
+| 1 — Breadcrumb | Trail to the current page. Last crumb non-link. | `breadcrumbs` |
+| 2 — Detail | Identity of the current page or entity: optional avatar (left), title + badges + meta (center), actions (right). | `avatar`, `title`, `badges`, `subtitle`, `meta`, `actions` |
+| 3 — Tabs | In-page navigation or filter state. | `tabs` |
+
+Each row is independently optional except for the title in row 2, which
+is required.
+
+**Detail page example** (anker imports omitted):
+
+\`\`\`tsx
+<DetailPageTemplate
+  breadcrumbs={[{ label: "Identity", to: "/identity" }, { label: "Users", to: "/identity/users" }, { label: "Jana Schmid" }]}
+  title="Jana Schmid"
+  avatar={<Avatar name="Jana Schmid" size="lg" />}
+  badges={<><Badge colorPalette="green">Aktiv</Badge><Badge colorPalette="blue">Admin</Badge></>}
+  meta={<Flex gap="4" fontSize="sm"><span>jana.schmid@knk.de</span><span>Produkt</span></Flex>}
+  actions={<Button>Bearbeiten</Button>}
+  tabs={
+    <Tabs.Root value={activeTab}>
+      <Tabs.List>
+        <Tabs.Trigger value="overview">Übersicht</Tabs.Trigger>
+        <Tabs.Trigger value="apps">Anwendungen</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  }
+>
+  {/* body cards */}
+</DetailPageTemplate>
+\`\`\`
+
+**Index page example**:
+
+\`\`\`tsx
+<IndexPageTemplate
+  breadcrumbs={[{ label: "Identity" }, { label: "Users" }]}
+  title="Users"
+  actions={<Button>Nutzer einladen</Button>}
+  tabs={
+    <Tabs.Root value={filter}>
+      <Tabs.List>
+        <Tabs.Trigger value="all">Alle</Tabs.Trigger>
+        <Tabs.Trigger value="active">Aktiv</Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  }
+  toolbar={<SearchBar />}
+>
+  <DataTable … />
+</IndexPageTemplate>
+\`\`\`
+
+Index pages omit `avatar`, `badges`, and `meta` — the detail row collapses
+to title + actions.
+```
+
+- [ ] **Step 3: Update the "Tabs vs sub-section nav" guidance**
+
+Find the existing rule-of-thumb block (around lines 282–287, mentioning "page header" and "identity card"). Replace it with:
+
+```markdown
+> **Rule of thumb:** if the in-page navigation keeps the entity identity
+> (breadcrumb, avatar, title, badges) constant across the destinations,
+> they belong in `tabs` on the page header. If each destination is a
+> distinct top-level page with its own breadcrumb and title, render them
+> as separate index pages in the sidebar.
+>
+> Within a single page, prefer the `tabs` row over rendering a custom
+> in-body tab strip — it keeps the navigation surface consistent across
+> solutions.
+```
+
+- [ ] **Step 4: Update the ContextRail section**
+
+Find the section that describes the rail's vertical origin (added by the rail-position work, around lines 94–97 or near §ContextRail patterns). Add this clarifying sentence:
+
+```markdown
+When the page header includes a tabs row, the rail's coordinate origin
+sits **below the tabs row** — i.e. below the entire header band.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/page-patterns.md
+git commit -m "docs(page-patterns): three-row page header band"
+```
+
+---
+
+## Task 9: Update `CLAUDE-ANKER.md`
+
+**Files:**
+- Modify: `CLAUDE-ANKER.md`
+
+- [ ] **Step 1: Update PageHeader and DetailPageTemplate entries**
+
+Find the table row for `<PageHeader>`:
+
+```markdown
+| `<PageHeader>` | Top-of-page chrome: breadcrumb, title, subtitle, actions. |
+```
+
+Replace with:
+
+```markdown
+| `<PageHeader>` | Three-row page header band (breadcrumb · detail · tabs). Props: `breadcrumbs`, `title`, `subtitle`, `eyebrow`, `actions`, `avatar`, `badges`, `meta`, `tabs`. Each row is independently optional except title. See `docs/page-patterns.md` §Page header anatomy. |
+```
+
+Find the table row for `<DetailPageTemplate>`:
+
+```markdown
+| `<DetailPageTemplate>` | Single-entity pages — header + optional tabs + body |
+```
+
+Replace with:
+
+```markdown
+| `<DetailPageTemplate>` | Single-entity pages — registers a three-row header band via `usePageHeader`. New props: `avatar`, `badges`, `meta`, `tabs`. `subheader` and `bodyTabs` were removed in v2.2.0 — migrate to the slot props on PageHeader. |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE-ANKER.md
+git commit -m "docs(claude-anker): document three-row PageHeader props"
+```
+
+---
+
+## Task 10: Add `src/components/page-header.mdx`
+
+**Files:**
+- Create: `src/components/page-header.mdx`
+
+- [ ] **Step 1: Read an existing MDX file to mirror its conventions**
+
+Look at one of the existing component MDX files (e.g., `src/components/data-table/data-table.mdx` or `src/components/pagination.mdx`) to see the Storybook MDX format: how Meta, Story, ArgsTable, and prose blocks are used.
+
+- [ ] **Step 2: Create the new MDX file**
+
+Create `src/components/page-header.mdx` with the following content. Adjust the import paths and MDX directives to match the conventions you observed in step 1:
+
+```mdx
+import { Canvas, Meta, ArgTypes } from "@storybook/blocks";
+import * as PageHeaderStories from "./page-header.stories";
+
+<Meta of={PageHeaderStories} />
+
+# PageHeader
+
+The top-of-page chrome shared by every authenticated knkCMS page. Renders
+a single white-bg band with up to three vertically-stacked rows:
+
+1. **Breadcrumb** — trail to the current page. Last crumb is non-link.
+2. **Detail** — identity of the page or entity: optional avatar (left),
+   title with optional badges (center), optional meta line below the
+   title, optional actions (right).
+3. **Tabs** — in-page navigation or filter state. Sits flush with the
+   band's bottom border.
+
+Each row is independently optional except the title. Pages register the
+component via `usePageHeader` from a page template (`IndexPageTemplate`,
+`DetailPageTemplate`, `SettingsPageTemplate`) — see `app-shell.tsx` and
+`docs/page-patterns.md` for the slot mechanism.
+
+## Title-only
+
+The minimum useful case — a single title in the detail row.
+
+<Canvas of={PageHeaderStories.Default} />
+
+## With breadcrumb and actions
+
+<Canvas of={PageHeaderStories.WithBreadcrumbs} />
+
+## Detail slots — avatar, badges, meta
+
+When the page is about a specific entity (a user, an org, a workspace),
+populate the detail row with the entity's identifying chrome.
+
+<Canvas of={PageHeaderStories.WithDetailSlots} />
+
+## Tabs
+
+Tabs go in the third row of the band. Use them for in-page navigation
+(detail pages) or filter state (index pages).
+
+<Canvas of={PageHeaderStories.WithTabs} />
+
+## All three rows together
+
+A detail page with full identity and tabs.
+
+<Canvas of={PageHeaderStories.FullBand} />
+
+## Props
+
+<ArgTypes of={PageHeaderStories} />
+
+## When to use which row
+
+- **Breadcrumb** — always, except on top-level dashboard pages.
+- **Avatar / badges / meta** — only on entity detail pages. Index pages,
+  settings pages, and dashboards skip these.
+- **Tabs** — when the page has multiple views that share the same identity
+  (the entity, the workspace, the filter). If each destination has its
+  own page header / title, it's not a tab — it's a separate page.
+
+See `docs/page-patterns.md` §Page header anatomy for the full design
+reference.
+```
+
+If the stories you added in Task 3 (`WithDetailSlots`, `WithTabs`, `FullBand`) use different names, adjust the `<Canvas of={...}>` references accordingly. If `Default` / `WithBreadcrumbs` don't exist in `page-header.stories.tsx`, remove those Canvas blocks.
+
+- [ ] **Step 3: Verify by running Storybook (optional, manual)**
+
+Run: `pnpm storybook`
+Manual check: navigate to "Components → PageHeader" — the MDX page renders with prose, canvas blocks, and the prop table. Stop Storybook.
+
+This step is optional verification; no automated assertion. If you cannot run Storybook in the current environment, skip it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/page-header.mdx
+git commit -m "docs(stories): add MDX docs page for PageHeader"
+```
+
+---
+
+## Task 11: Full verification before release
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: all tests pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `pnpm lint`
+Expected: no new errors. Pre-existing warnings in `src/forms/` and `src/components/data-table/__tests__/` are acceptable as long as the count hasn't grown.
+
+- [ ] **Step 4: Build the package**
+
+Run: `pnpm build`
+Expected: build succeeds. Inspect `dist/components/index.d.ts` and verify the new props (`avatar`, `badges`, `meta`, `tabs`) appear on `PageHeaderProps`.
+
+- [ ] **Step 5: Sync the lockfile (if any change)**
+
+If `package-lock.json` or `pnpm-lock.yaml` was incidentally modified, stage and commit:
+
+```bash
+git status -sb
+# if lockfile changed:
+git add package-lock.json   # or pnpm-lock.yaml
+git commit -m "chore(deps): sync lockfile"
+```
+
+- [ ] **Step 6: Push the branch and open the PR**
+
+```bash
+git push -u origin feature/page-header-redesign
+gh pr create --title "feat: three-row page header band (breadcrumb · detail · tabs)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `<PageHeader>` grows four optional slots: \`avatar\`, \`badges\`, \`meta\`, \`tabs\`.
+- Page templates (\`IndexPageTemplate\`, \`DetailPageTemplate\`, \`SettingsPageTemplate\`) pipe their existing \`tabs\` prop into the header band instead of rendering it as a separate row in the body.
+- \`DetailPageTemplate\`'s \`subheader\` and \`bodyTabs\` props removed (breaking).
+- Design docs and Storybook MDX updated.
+
+Spec: \`docs/superpowers/specs/2026-05-13-page-header-redesign-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-13-page-header-redesign.md\`
+
+## Test plan
+
+- [ ] CI green
+- [ ] Storybook visual check: PageHeader / WithDetailSlots, WithTabs, FullBand
+- [ ] After merge: cut v2.2.0, then bump anker in odon
+EOF
+)"
+```
+
+- [ ] **Step 7: Wait for CI, then merge and tag**
+
+Wait for the PR check to pass:
+
+```bash
+gh pr checks --watch
+```
+
+Then squash-merge and tag:
+
+```bash
+gh pr merge --squash --delete-branch
+git checkout main && git pull --ff-only
+git tag v2.2.0 && git push origin v2.2.0
+```
+
+The CI publish workflow handles npm + GitHub Packages publication on the tag push. Wait for the publish workflow to complete:
+
+```bash
+gh run watch
+```
+
+Verify on npm:
+
+```bash
+npm view @knkcs/anker version   # should print 2.2.0
+```
+
+---
+
+## Task 12: Odon — delete `UserIdentityCard`, rewrite `UserDetailLayout`
+
+**Repo:** `/Users/jeskoiwanovski/repo/odon`
+
+**Files:**
+- Delete: `web/src/components/user/UserIdentityCard.tsx`
+- Modify: `web/src/components/user/UserDetailLayout.tsx`
+- Test: `web/src/__tests__/components/settings/*` (may need adjustments)
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+cd /Users/jeskoiwanovski/repo/odon
+git checkout main && git pull --ff-only
+git checkout -b feature/anker-2.2-header-band
+```
+
+- [ ] **Step 2: Rewrite `UserDetailLayout`**
+
+Replace the entire contents of `web/src/components/user/UserDetailLayout.tsx` with:
+
+```tsx
+import { Badge, Box, Flex, Tabs, Text } from "@knkcs/anker/primitives";
+import { DetailPageTemplate } from "@knkcs/anker/templates";
+import { Hash, Mail } from "lucide-react";
+import type { ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { UserAvatar } from "@/components/admin/UserAvatar";
+
+const STATUS_COLORS = {
+    active: "green",
+    invited: "yellow",
+    suspended: "red",
+} as const;
+
+type StatusKind = keyof typeof STATUS_COLORS;
+
+export type IdentityCardUser = {
+    id: string;
+    email: string;
+    displayName?: string;
+    emailVerified: boolean;
+    active: boolean;
+};
+
+function statusFromUser(u: IdentityCardUser): StatusKind {
+    if (!u.active) return "suspended";
+    if (!u.emailVerified) return "invited";
+    return "active";
+}
+
+export interface UserDetailLayoutTab {
+    value: string;
+    label: string;
+    to: string;
+}
+
+export interface UserDetailLayoutProps {
+    user: IdentityCardUser;
+    mode: "self" | "admin";
+    pageHeader: { breadcrumbs: { label: string }[]; title: string };
+    identityCardActions: { primary?: ReactNode; secondary?: ReactNode };
+    tabs: UserDetailLayoutTab[];
+    activeTab: string;
+    children: ReactNode;
+}
+
+export function UserDetailLayout({
+    user,
+    mode: _mode,
+    pageHeader,
+    identityCardActions,
+    tabs,
+    activeTab,
+    children,
+}: UserDetailLayoutProps) {
+    const { t } = useTranslation();
+    const status = statusFromUser(user);
+    const display = user.displayName || user.email || "";
+
+    const avatar = <UserAvatar name={display} size="lg" />;
+
+    const badges = (
+        <Badge colorPalette={STATUS_COLORS[status]} size="sm">
+            {t(`userDetail.status.${status}`)}
+        </Badge>
+    );
+
+    const meta = (
+        <Flex align="center" gap="4" flexWrap="wrap">
+            <Flex align="center" gap="1">
+                <Mail size={13} color="var(--chakra-colors-fg-muted)" />
+                <Text fontFamily="mono" fontSize="xs" color="fg.muted">
+                    {user.email}
+                </Text>
+            </Flex>
+            <Flex align="center" gap="1">
+                <Hash size={13} color="var(--chakra-colors-fg-muted)" />
+                <Text fontFamily="mono" fontSize="xs" color="fg.muted">
+                    {user.id}
+                </Text>
+            </Flex>
+        </Flex>
+    );
+
+    const actions = (
+        <Flex gap="2">
+            {identityCardActions.secondary}
+            {identityCardActions.primary}
+        </Flex>
+    );
+
+    const tabsNode = (
+        <Tabs.Root value={activeTab}>
+            <Tabs.List>
+                {tabs.map((tab) => (
+                    <Tabs.Trigger key={tab.value} value={tab.value}>
+                        <NavLink
+                            to={tab.to}
+                            style={{ textDecoration: "none", color: "inherit" }}
+                        >
+                            {tab.label}
+                        </NavLink>
+                    </Tabs.Trigger>
+                ))}
+            </Tabs.List>
+        </Tabs.Root>
+    );
+
+    return (
+        <DetailPageTemplate
+            breadcrumbs={pageHeader.breadcrumbs}
+            title={pageHeader.title}
+            avatar={avatar}
+            badges={badges}
+            meta={meta}
+            actions={actions}
+            tabs={tabsNode}
+        >
+            {children}
+        </DetailPageTemplate>
+    );
+}
+```
+
+The visual chrome that previously lived in `<UserIdentityCard>` (status badge, avatar, email/ID meta line, actions row) is now built inline as local nodes and passed as four discrete props.
+
+- [ ] **Step 3: Delete `UserIdentityCard`**
+
+```bash
+rm web/src/components/user/UserIdentityCard.tsx
+```
+
+Then search for any remaining import of it and remove them:
+
+```bash
+grep -rn "UserIdentityCard" web/src/ 2>/dev/null
+```
+
+Expected: no matches (only the file we just deleted referenced it). If matches remain (e.g., in tests), edit those files to drop the import.
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+npm run --workspace=web test
+```
+
+Expected: PASS. Likely some tests in `web/src/__tests__/components/settings/` use `UserDetailLayout` or `<UserIdentityCard>` directly — update them to either render `<UserDetailLayout>` (with the new props) or query for the new DOM (the badge is now in the page header instead of an "identity card" container).
+
+- [ ] **Step 5: Run typecheck and build**
+
+```bash
+npm run --workspace=web build
+```
+
+Expected: build succeeds. (`tsc -b` runs first; if it errors, fix the typing issues in step 2's code.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/user/UserDetailLayout.tsx
+git rm web/src/components/user/UserIdentityCard.tsx
+git add web/src/__tests__/components/settings/   # if any tests changed
+git commit -m "refactor(web): inline UserDetailLayout identity slots, drop UserIdentityCard"
+```
+
+---
+
+## Task 13: Odon — bump anker to ^2.2.0
+
+**Files:**
+- Modify: `package.json`, `web/package.json`, `packages/odon-ui/package.json`, `package-lock.json`
+
+- [ ] **Step 1: Update version strings**
+
+Edit all three package.json files to use `"@knkcs/anker": "^2.2.0"`:
+
+```bash
+sed -i '' 's/"@knkcs\/anker": "[^"]*"/"@knkcs\/anker": "^2.2.0"/g' \
+  /Users/jeskoiwanovski/repo/odon/package.json \
+  /Users/jeskoiwanovski/repo/odon/web/package.json \
+  /Users/jeskoiwanovski/repo/odon/packages/odon-ui/package.json
+```
+
+For `packages/odon-ui/package.json`, the `peerDependencies` entry should remain `"@knkcs/anker": "*"` — the sed above overwrites it; restore it manually:
+
+```bash
+# Open packages/odon-ui/package.json and ensure peerDependencies has
+# "@knkcs/anker": "*"  (not "^2.2.0").
+```
+
+Use the Edit tool to revert `peerDependencies.@knkcs/anker` to `"*"`.
+
+- [ ] **Step 2: Nuke node_modules and reinstall fresh**
+
+The previous bump (v2.0.10 → v2.1.0) revealed that npm leaves stale workspace-local copies behind. Do a clean install to avoid the bug:
+
+```bash
+cd /Users/jeskoiwanovski/repo/odon
+rm -rf node_modules web/node_modules packages/odon-ui/node_modules package-lock.json
+npm install
+```
+
+- [ ] **Step 3: Verify anker version**
+
+```bash
+grep '"version"' node_modules/@knkcs/anker/package.json
+ls web/node_modules/@knkcs/anker 2>/dev/null && echo "STALE WORKSPACE COPY — investigate" || echo "OK — hoisted to root"
+```
+
+Expected: root version is 2.2.0; no workspace-local copy.
+
+- [ ] **Step 4: Rebuild and run tests**
+
+```bash
+npm run --workspace=web build
+npm run --workspace=web test
+```
+
+Expected: build succeeds; tests pass (pre-existing `SignedOutConfirmPage` failure is unrelated and can be ignored).
+
+Spot-check the built bundle for the new symbols:
+
+```bash
+grep -oE "page-header-avatar|page-header-badges|page-header-meta|page-header-tabs" web/dist/assets/index-*.js | sort -u
+```
+
+Expected: all four data-testid strings appear.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json web/package.json packages/odon-ui/package.json package-lock.json
+git commit -m "chore(deps): bump @knkcs/anker to ^2.2.0
+
+Picks up the three-row page header band (breadcrumb · detail · tabs)
+and removes the subheader / bodyTabs props on DetailPageTemplate."
+```
+
+- [ ] **Step 6: Push the branch and open the PR**
+
+```bash
+git push -u origin feature/anker-2.2-header-band
+gh pr create --title "feat(web): adopt anker 2.2 three-row page header" \
+  --body "Bumps anker to ^2.2.0 and migrates UserDetailLayout to the new slot-based PageHeader props. Deletes UserIdentityCard."
+```
+
+Wait for CI; merge when green:
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+---
+
+## Task 14: Ship odon to the cluster
+
+**Repo:** `/Users/jeskoiwanovski/repo/knkcms-deploy`
+
+- [ ] **Step 1: Ship**
+
+```bash
+cd /Users/jeskoiwanovski/repo/knkcms-deploy
+make ship-odon
+```
+
+Expected: image builds, pushes, helm upgrade rolls out a new pod, rollout completes.
+
+- [ ] **Step 2: Visual smoke check**
+
+Hard-refresh `http://odon.localhost:8080/admin/users` and one user-detail page. Verify:
+- Header band visually contains breadcrumb · entity-row · tabs (detail) or breadcrumb · title-row · tabs (index).
+- Rail begins directly below the tabs row.
+- No "two-headers" look on user detail.
+- Tabs visually sit on the same white surface as the rest of the header.
+
+If anything looks off, capture a screenshot and triage. If everything looks right, the redesign is live.
+
+---
+
+## Notes on subagent dispatch order
+
+- **Tasks 1–11 are anker-only.** They can run sequentially; each task is small and independent enough that the implementer subagent can be dispatched per task.
+- **Tasks 12–14 are odon (and deploy)**; they depend on the anker v2.2.0 release being published (Task 11 step 7).
+- Within Tasks 4–6 (template migrations) and 7–10 (docs/stories), tasks are largely independent — but DO run them sequentially to keep the test suite green at each commit and to keep git history clean.

--- a/docs/superpowers/specs/2026-05-13-page-header-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-13-page-header-redesign-design.md
@@ -1,0 +1,145 @@
+# Page Header Redesign — three-row band with detail + tabs
+
+**Date:** 2026-05-13
+**Scope:** `@knkcs/anker` (design system) + `odon` (consumer). Other solutions consume the new shape automatically when they bump anker.
+**Predecessor:** builds on `2026-05-13-context-rail-position-design.md` (header band spans main + rail; rail starts under it). This change replaces the inner shape of that band with a richer, three-row structure.
+
+## Problem
+
+The current page header band displays only breadcrumb + title + actions. On detail pages, page authors render an "entity identity card" (avatar / name / badges / contact line) **below** the band as a separate visual block, plus a tab strip rendered **further below** as a third visually-distinct row. The result is three unrelated horizontal strips stacked on different background surfaces — visually it reads as "nearly two page headers plus disconnected tabs". On index pages, filter chips (e.g., `Alle / Aktiv / Eingeladen / Gesperrt`) appear inside the body as a fourth visual layer rather than being part of the page header.
+
+The goal: collapse all of that into one continuous white-bg band with three intentional rows — breadcrumb, detail, tabs — that spans the main + rail columns, with the rail starting below the entire band.
+
+## Reference design
+
+Three stacked rows on `bg-surface`, separated by spacing, in order:
+
+1. **Breadcrumb** — small muted text (`Identity › Users › Jana Schmid`).
+2. **Detail** — flex row containing optional avatar (left), title block with badges and a meta line (center, flex-1), and actions (right). On index pages the avatar/badges/meta are omitted; only title + actions are present.
+3. **Tabs** — text-only tab strip with an underline on the active tab and small count pills. Omitted entirely when a page has no tabs.
+
+All three rows live inside the same `<PageHeader>` Box (the existing `bg="bg-surface"` band). Spacing — not borders — separates the rows. The band's bottom border (already present) marks the transition to the body / rail.
+
+## Goals
+
+1. Update `<PageHeader>` to render the three-row structure when its new optional props are provided.
+2. Migrate `IndexPageTemplate` and `DetailPageTemplate` so the existing `tabs` prop and (Detail's) `subheader` content reach `<PageHeader>` via the new props instead of being rendered as separate rows in the template body.
+3. Update odon's `UserDetailLayout` to consume the new props directly, retiring the `<UserIdentityCard>` abstraction.
+4. Update odon's index pages (e.g., `AdminUsersPage`) to pass their filter chips to `tabs`.
+
+## Non-goals
+
+- AppShell grid / slot mechanism — unchanged. The header band still spans main + rail via the existing `usePageHeader` slot.
+- ContextRail — unchanged.
+- Tab body components in odon (`features/user-detail/tabs/*`) — unchanged; only the shell that hosts them moves.
+- Pages that don't use page templates — unchanged.
+- A new "rich-detail" widget on the index page (avatar/meta on index) — out of scope; index header only carries title + actions + tabs.
+
+## Design
+
+### 1. `<PageHeader>` — new shape
+
+Props (changes marked `NEW`; existing props unchanged):
+
+```ts
+export interface PageHeaderProps {
+  breadcrumbs?: PageHeaderBreadcrumb[];
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  eyebrow?: React.ReactNode;
+  actions?: React.ReactNode;
+  avatar?: React.ReactNode;   // NEW — rendered left of the title in the detail row
+  badges?: React.ReactNode;   // NEW — inline next to the title
+  meta?: React.ReactNode;     // NEW — secondary line below the title (email · dept · id, …)
+  tabs?: React.ReactNode;     // NEW — tab-strip row at the bottom of the band
+}
+```
+
+Internal layout (one `<Box bg="bg-surface" borderBottomWidth=1px borderBottomColor=border>`):
+
+- **Row 1 (breadcrumb)** — rendered only when `breadcrumbs?.length > 0`. Existing styling.
+- **Row 2 (detail)** — always rendered (the page has a title). A `<Flex align="flex-start" gap="4">` containing:
+  - `avatar` slot (omitted if not provided),
+  - title block: `<Heading>` + `badges` (inline, gap=2) on one line; `meta` on the line below; existing `subtitle` if provided sits between heading and meta,
+  - `actions` slot (right, `flexShrink=0`), aligned to top of the row.
+- **Row 3 (tabs)** — rendered only when `tabs` is provided. Sits flush at the bottom of the band; the underline on the active tab visually meets the bottom border of the band.
+
+Spacing tokens used: `py` on the outer box (existing), `mb` between rows. `eyebrow` (rare) stays in its existing position above the breadcrumb.
+
+### 2. Page-template migration
+
+**`IndexPageTemplate`**
+- `tabs` prop's render location moves: instead of rendering `{tabs ? <Box>{tabs}</Box> : null}` between PageHeader and toolbar, the template passes `tabs` into the registered `<PageHeader tabs={tabs}>`.
+- `toolbar` prop unchanged — still rendered in the body, below the header band, on the canvas.
+- The template body now renders only `toolbar` + `children`.
+
+**`DetailPageTemplate`**
+- Remove the `subheader` prop. Add `avatar`, `badges`, `meta` props that pipe directly into `<PageHeader>`.
+- `tabs` prop: flows into `<PageHeader tabs={tabs}>` (was: rendered as a separate row in the template body).
+- `bodyTabs` prop: **removed.** It conflicts with the new design — `bodyTabs` worked by owning a single `<Tabs.Root>` whose `<Tabs.List>` and `<Tabs.Content>` were sibling descendants of the template. Under the new design, the tab list renders inside the header band (registered via the slot store, rendered by AppShell in a different part of the React tree) and the panels render in the template body; one `Tabs.Root` ancestor cannot wrap both, so context-based tab state can't bridge them. Pages that previously used `bodyTabs` migrate to nav-link tabs (the pattern odon's `UserDetailLayout` already uses): build a `<Tabs.Root value={activeTabFromUrl}>` with only `<Tabs.List>` inside, pass it to `tabs`, and let the router (or local state) render the active panel as `children`. This is structurally simpler and matches how every existing `bodyTabs` consumer actually uses it.
+
+**`SettingsPageTemplate`**
+- Same treatment as `DetailPageTemplate` if it currently uses a `subheader` or renders tabs separately. (Most settings pages won't carry avatars/badges, so the new props default to `undefined` and the detail row collapses to title-only.)
+
+### 3. odon migration
+
+**`web/src/components/user/UserDetailLayout.tsx`**
+- Delete the `<UserIdentityCard>` import and usage.
+- Build the avatar / badges / meta nodes inline (or extract into local helpers if useful) and pass them as `avatar`, `badges`, `meta` props on `DetailPageTemplate`.
+- The existing `tabs` prop continues to be passed as before — only the rendering location changes (handled by anker).
+
+**`web/src/components/user/UserIdentityCard.tsx`**
+- Delete. Any logic worth keeping (admin-mode vs self-mode visual differences, fallbacks for missing data) moves into the helpers in `UserDetailLayout`.
+
+**`web/src/pages/AdminUsersPage.tsx` and other index pages with filter chips**
+- Move the filter-chip strip from the body / toolbar into the `tabs` prop on `IndexPageTemplate`.
+- Search bar + filter buttons remain in the body (passed as `toolbar` or as children, matching current usage).
+
+### 4. Empty / edge cases
+
+- **Pages with no avatar/badges/meta** (most index pages, simple detail pages): detail row collapses to title + actions. Row 1 (breadcrumb) and row 3 (tabs) are independently optional.
+- **Pages with no tabs**: row 3 is omitted; the band has just breadcrumb + detail.
+- **Personal area pages in odon** (`/settings/profile`, `/settings/security`, etc.): no `tabs` prop — these pages stand alone, the sidebar provides navigation between them. No special-casing needed in anker.
+- **`bodyTabs` flow**: `<Tabs.Root>` must wrap both the tab list (in the header) and the tab panels (in the body). The template renders one `Tabs.Root` that spans both regions. The `tabs` slot on `PageHeader` receives a `<Tabs.List>` element; the body receives `<Tabs.Content>` panels. This works because `Tabs.Root` reads its state from React context, not from DOM proximity.
+
+## Documentation updates
+
+Anker's docs are the authoritative description of the shell shape used by every knkCMS solution. The new three-row band needs to be reflected in every place a solution author looks for "what does a page header look like":
+
+- **`docs/page-patterns.md` § App-shell composition** — update the ASCII diagram of the header band to show three rows (breadcrumb · detail · tabs).
+- **`docs/page-patterns.md` — new section "Page header anatomy"** placed between the App-shell composition section and the Sidebar section. Describes the three optional rows, what each `PageHeader` prop renders, and which rows collapse when their props are absent. Includes one snippet for a typical detail page (avatar/badges/meta/tabs) and one for an index page (title + tabs).
+- **`docs/page-patterns.md` § Tabs vs sub-section nav** (currently around lines 282–287) — update the rule of thumb: the new design makes tabs a first-class slot on `PageHeader`, so the "if each item has its own page header, they're sub-section nav" guidance needs a refresh. Specifically: tabs are now part of the page header band; pages whose top-level identity differs should still be separate index pages, but within a single index/detail page the tab row is the right tool for in-page navigation.
+- **`docs/page-patterns.md` § ContextRail patterns** — clarify that the rail's vertical origin is "below the entire header band (including the tabs row when present)". The earlier `2026-05-13-context-rail-position-design.md` spec said "below the header"; that wording stays correct but the rail-below-tabs implication is worth calling out explicitly.
+- **`CLAUDE-ANKER.md`** — update the `<PageHeader>` summary (the one-line table entry) to mention the new `avatar` / `badges` / `meta` / `tabs` props. Update the `<DetailPageTemplate>` entry to remove `subheader` and mention `avatar` / `badges` / `meta`.
+- **`src/components/page-header.mdx` (new file)** — `PageHeader` currently has no MDX docs page (only `.tsx` stories). Add an MDX page that documents the three rows, prop reference, and provides MDX-embedded stories for each combination. This gives Storybook readers a Cmd-K-searchable "PageHeader" entry alongside the other component docs.
+- **`src/templates/app-shell.tsx` header comment** — the ASCII diagram at the top of the file (last updated by the rail-position work) needs a small refresh: the header band's interior is now three rows instead of one.
+
+We intentionally do NOT update `docs/design-system.md` — that file covers tokens / primitives, not page-level patterns, and currently doesn't mention `PageHeader`. Adding `PageHeader` there would duplicate `page-patterns.md`'s coverage.
+
+## Testing
+
+- `page-header.test.tsx` — add cases:
+  - renders avatar / badges / meta when provided
+  - omits the detail row's secondary line when `meta` is absent
+  - renders the tabs row when `tabs` is provided
+  - omits the tabs row when `tabs` is absent
+  - renders all three rows together
+- `index-page-template.test.tsx` — assert that a `tabs` prop is registered into the header (under `app-shell-header`) and is NOT a sibling of the template body.
+- `detail-page-template.test.tsx` — same, plus `avatar` / `badges` / `meta` reach the header.
+- `app-shell.stories.tsx` — extend the `WithHeaderAndRail` story to show the new three-row band.
+- `page-header.stories.tsx` — add a story per row combination (breadcrumb-only, breadcrumb + detail, breadcrumb + detail + tabs).
+
+## Risks
+
+- **Visual regression for consumers that haven't updated their detail/index pages.** Mitigated by SemVer minor bump: new props are additive; old props (`title`, `breadcrumbs`, `actions`) continue to work. Existing pages that DON'T pass `avatar`/`badges`/`meta`/`tabs` render exactly as they do today.
+- **`subheader` removal is a breaking change for `DetailPageTemplate`.** Mitigated by keeping `subheader` as a deprecated alias for one release (renders the same content below the title row, with a `console.warn` in dev mode). The deprecation is removed in the next minor.
+- **`bodyTabs` split-rendering** (tab list in header, panels in body) is a structural change. Mitigated by tests asserting the tab list reaches the header slot and panels reach the body.
+
+## Rollout
+
+1. Implement and merge in anker; cut `v2.2.0` (minor — additive props, plus deprecated `subheader`).
+2. Bump anker in odon to `^2.2.0`.
+3. Migrate `UserDetailLayout` (delete `UserIdentityCard`, pass new props).
+4. Migrate `AdminUsersPage` (move filter chips into `tabs`).
+5. Visual smoke-check the user index and user detail pages.
+6. Optionally migrate other admin index pages (audit log, OAuth clients, webhooks) to use `tabs` for any existing filter strips.

--- a/src/components/page-header.mdx
+++ b/src/components/page-header.mdx
@@ -1,0 +1,57 @@
+import { Canvas, Meta, ArgTypes } from "@storybook/blocks";
+import * as PageHeaderStories from "./page-header.stories";
+
+<Meta of={PageHeaderStories} />
+
+# PageHeader
+
+The top-of-page chrome shared by every authenticated knkCMS page. Renders
+a single white-bg band with up to three vertically-stacked rows:
+
+1. **Breadcrumb** — trail to the current page. Last crumb is non-link.
+2. **Detail** — identity of the page or entity: optional avatar (left),
+   title with optional badges (center), optional meta line below the
+   title, optional actions (right).
+3. **Tabs** — in-page navigation or filter state. Sits flush with the
+   band's bottom border.
+
+Each row is independently optional except the title. Pages register the
+component via `usePageHeader` from a page template (`IndexPageTemplate`,
+`DetailPageTemplate`, `SettingsPageTemplate`) — see `app-shell.tsx` and
+`docs/page-patterns.md` for the slot mechanism.
+
+## Detail slots — avatar, badges, meta
+
+When the page is about a specific entity (a user, an org, a workspace),
+populate the detail row with the entity's identifying chrome.
+
+<Canvas of={PageHeaderStories.WithDetailSlots} />
+
+## Tabs
+
+Tabs go in the third row of the band. Use them for in-page navigation
+(detail pages) or filter state (index pages).
+
+<Canvas of={PageHeaderStories.WithTabs} />
+
+## All three rows together
+
+A detail page with full identity and tabs.
+
+<Canvas of={PageHeaderStories.FullBand} />
+
+## Props
+
+<ArgTypes of={PageHeaderStories} />
+
+## When to use which row
+
+- **Breadcrumb** — always, except on top-level dashboard pages.
+- **Avatar / badges / meta** — only on entity detail pages. Index pages,
+  settings pages, and dashboards skip these.
+- **Tabs** — when the page has multiple views that share the same identity
+  (the entity, the workspace, the filter). If each destination has its
+  own page header / title, it's not a tab — it's a separate page.
+
+See `docs/page-patterns.md` §Page header anatomy for the full design
+reference.

--- a/src/components/page-header.stories.tsx
+++ b/src/components/page-header.stories.tsx
@@ -4,7 +4,7 @@ import { Edit, Upload, UserPlus } from "lucide-react";
 import { Button } from "../atoms/button";
 import { Avatar } from "../primitives/avatar";
 import { Badge } from "../primitives/badge";
-import { Box, Flex } from "../primitives/layout";
+import { Flex } from "../primitives/layout";
 import { Tabs } from "../primitives/tabs";
 import { Text } from "../primitives/typography";
 import { PageHeader } from "./page-header";
@@ -65,11 +65,13 @@ export const WithEyebrow: Story = {
 
 export const WithDetailSlots: Story = {
 	args: {
-		breadcrumbs: [{ label: "Identity" }, { label: "Users" }, { label: "Jan Schmidt" }],
+		breadcrumbs: [
+			{ label: "Identity" },
+			{ label: "Users" },
+			{ label: "Jan Schmidt" },
+		],
 		title: "Jan Schmidt",
-		avatar: (
-			<Avatar name="Jan Schmidt" size="xl" />
-		),
+		avatar: <Avatar name="Jan Schmidt" size="xl" />,
 		badges: (
 			<>
 				<Badge colorPalette="green">Aktiv</Badge>
@@ -79,16 +81,26 @@ export const WithDetailSlots: Story = {
 		meta: (
 			<Flex align="center" gap="3" fontSize="sm" color="muted">
 				<Text as="span">jan.schmidt@example.com</Text>
-				<Text as="span" color="muted">·</Text>
+				<Text as="span" color="muted">
+					·
+				</Text>
 				<Text as="span">Entwicklung</Text>
-				<Text as="span" color="muted">·</Text>
-				<Text as="span" fontFamily="mono" fontSize="xs">usr_01HXYZ1234ABCD</Text>
+				<Text as="span" color="muted">
+					·
+				</Text>
+				<Text as="span" fontFamily="mono" fontSize="xs">
+					usr_01HXYZ1234ABCD
+				</Text>
 			</Flex>
 		),
 		actions: (
 			<>
-				<Button variant="outline" size="sm">Bearbeiten</Button>
-				<Button variant="solid" colorPalette="primary" size="sm">Zugang sperren</Button>
+				<Button variant="outline" size="sm">
+					Bearbeiten
+				</Button>
+				<Button variant="solid" colorPalette="primary" size="sm">
+					Zugang sperren
+				</Button>
 			</>
 		),
 	},
@@ -123,14 +135,14 @@ export const WithTabs: Story = {
 
 export const FullBand: Story = {
 	args: {
-		breadcrumbs: [{ label: "Identity" }, { label: "Users" }, { label: "Maria Müller" }],
+		breadcrumbs: [
+			{ label: "Identity" },
+			{ label: "Users" },
+			{ label: "Maria Müller" },
+		],
 		title: "Maria Müller",
-		avatar: (
-			<Avatar name="Maria Müller" size="xl" />
-		),
-		badges: (
-			<Badge colorPalette="green">Aktiv</Badge>
-		),
+		avatar: <Avatar name="Maria Müller" size="xl" />,
+		badges: <Badge colorPalette="green">Aktiv</Badge>,
 		meta: (
 			<Flex align="center" gap="2" fontSize="sm" color="muted">
 				<Text as="span">maria.mueller@example.com</Text>

--- a/src/components/page-header.stories.tsx
+++ b/src/components/page-header.stories.tsx
@@ -1,7 +1,12 @@
 // src/components/page-header.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
-import { Upload, UserPlus } from "lucide-react";
+import { Edit, Upload, UserPlus } from "lucide-react";
 import { Button } from "../atoms/button";
+import { Avatar } from "../primitives/avatar";
+import { Badge } from "../primitives/badge";
+import { Box, Flex } from "../primitives/layout";
+import { Tabs } from "../primitives/tabs";
+import { Text } from "../primitives/typography";
 import { PageHeader } from "./page-header";
 
 const meta = {
@@ -55,5 +60,95 @@ export const WithEyebrow: Story = {
 		eyebrow: "BETA",
 		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
 		title: "Users",
+	},
+};
+
+export const WithDetailSlots: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }, { label: "Jan Schmidt" }],
+		title: "Jan Schmidt",
+		avatar: (
+			<Avatar name="Jan Schmidt" size="xl" />
+		),
+		badges: (
+			<>
+				<Badge colorPalette="green">Aktiv</Badge>
+				<Badge colorPalette="blue">Admin</Badge>
+			</>
+		),
+		meta: (
+			<Flex align="center" gap="3" fontSize="sm" color="muted">
+				<Text as="span">jan.schmidt@example.com</Text>
+				<Text as="span" color="muted">·</Text>
+				<Text as="span">Entwicklung</Text>
+				<Text as="span" color="muted">·</Text>
+				<Text as="span" fontFamily="mono" fontSize="xs">usr_01HXYZ1234ABCD</Text>
+			</Flex>
+		),
+		actions: (
+			<>
+				<Button variant="outline" size="sm">Bearbeiten</Button>
+				<Button variant="solid" colorPalette="primary" size="sm">Zugang sperren</Button>
+			</>
+		),
+	},
+};
+
+export const WithTabs: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }],
+		title: "Users",
+		actions: (
+			<>
+				<Button variant="outline" size="sm">
+					<Upload size={14} /> CSV importieren
+				</Button>
+				<Button variant="solid" colorPalette="primary" size="sm">
+					<UserPlus size={14} /> Nutzer einladen
+				</Button>
+			</>
+		),
+		tabs: (
+			<Tabs.Root defaultValue="all" variant="line">
+				<Tabs.List px="8">
+					<Tabs.Trigger value="all">Alle</Tabs.Trigger>
+					<Tabs.Trigger value="active">Aktiv</Tabs.Trigger>
+					<Tabs.Trigger value="invited">Eingeladen</Tabs.Trigger>
+					<Tabs.Trigger value="suspended">Gesperrt</Tabs.Trigger>
+				</Tabs.List>
+			</Tabs.Root>
+		),
+	},
+};
+
+export const FullBand: Story = {
+	args: {
+		breadcrumbs: [{ label: "Identity" }, { label: "Users" }, { label: "Maria Müller" }],
+		title: "Maria Müller",
+		avatar: (
+			<Avatar name="Maria Müller" size="xl" />
+		),
+		badges: (
+			<Badge colorPalette="green">Aktiv</Badge>
+		),
+		meta: (
+			<Flex align="center" gap="2" fontSize="sm" color="muted">
+				<Text as="span">maria.mueller@example.com</Text>
+			</Flex>
+		),
+		actions: (
+			<Button variant="outline" size="sm">
+				<Edit size={14} /> Bearbeiten
+			</Button>
+		),
+		tabs: (
+			<Tabs.Root defaultValue="overview" variant="line">
+				<Tabs.List px="8">
+					<Tabs.Trigger value="overview">Übersicht</Tabs.Trigger>
+					<Tabs.Trigger value="apps">Anwendungen</Tabs.Trigger>
+					<Tabs.Trigger value="sessions">Sitzungen</Tabs.Trigger>
+				</Tabs.List>
+			</Tabs.Root>
+		),
 	},
 };

--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -76,4 +76,59 @@ describe("PageHeader", () => {
 			screen.queryByTestId("page-header-breadcrumbs"),
 		).not.toBeInTheDocument();
 	});
+
+	it("renders avatar to the left of the title when provided", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Jana Schmid"
+				avatar={<div data-testid="avatar">JS</div>}
+			/>,
+		);
+		const avatar = screen.getByTestId("avatar");
+		const title = screen.getByRole("heading", { name: "Jana Schmid" });
+		expect(avatar).toBeInTheDocument();
+		expect(
+			avatar.compareDocumentPosition(title) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("renders badges inline with the title", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Jana Schmid"
+				badges={
+					<>
+						<span data-testid="b1">Aktiv</span>
+						<span data-testid="b2">Admin</span>
+					</>
+				}
+			/>,
+		);
+		expect(screen.getByTestId("b1")).toBeInTheDocument();
+		expect(screen.getByTestId("b2")).toBeInTheDocument();
+	});
+
+	it("renders the meta line below the title", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Jana Schmid"
+				meta={<span data-testid="meta">jana@example.test</span>}
+			/>,
+		);
+		const meta = screen.getByTestId("meta");
+		const title = screen.getByRole("heading", { name: "Jana Schmid" });
+		expect(meta).toBeInTheDocument();
+		expect(
+			title.compareDocumentPosition(meta) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("does not render avatar/badges/meta containers when those props are absent", () => {
+		renderWithChakra(<PageHeader title="Plain" />);
+		expect(screen.queryByTestId("page-header-avatar")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("page-header-badges")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("page-header-meta")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -131,4 +131,31 @@ describe("PageHeader", () => {
 		expect(screen.queryByTestId("page-header-badges")).not.toBeInTheDocument();
 		expect(screen.queryByTestId("page-header-meta")).not.toBeInTheDocument();
 	});
+
+	it("renders a tabs row at the bottom of the band when tabs is provided", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Users"
+				tabs={
+					<div data-testid="tabs-strip">
+						<button type="button">All</button>
+						<button type="button">Active</button>
+					</div>
+				}
+			/>,
+		);
+		const tabsRow = screen.getByTestId("page-header-tabs");
+		const tabsStrip = screen.getByTestId("tabs-strip");
+		const title = screen.getByRole("heading", { name: "Users" });
+		expect(tabsRow).toContainElement(tabsStrip);
+		expect(
+			title.compareDocumentPosition(tabsRow) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+
+	it("does not render a tabs row when tabs prop is absent", () => {
+		renderWithChakra(<PageHeader title="Users" />);
+		expect(screen.queryByTestId("page-header-tabs")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -88,8 +88,7 @@ describe("PageHeader", () => {
 		const title = screen.getByRole("heading", { name: "Jana Schmid" });
 		expect(avatar).toBeInTheDocument();
 		expect(
-			avatar.compareDocumentPosition(title) &
-				Node.DOCUMENT_POSITION_FOLLOWING,
+			avatar.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 	});
 
@@ -120,8 +119,7 @@ describe("PageHeader", () => {
 		const title = screen.getByRole("heading", { name: "Jana Schmid" });
 		expect(meta).toBeInTheDocument();
 		expect(
-			title.compareDocumentPosition(meta) &
-				Node.DOCUMENT_POSITION_FOLLOWING,
+			title.compareDocumentPosition(meta) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 	});
 
@@ -149,8 +147,7 @@ describe("PageHeader", () => {
 		const title = screen.getByRole("heading", { name: "Users" });
 		expect(tabsRow).toContainElement(tabsStrip);
 		expect(
-			title.compareDocumentPosition(tabsRow) &
-				Node.DOCUMENT_POSITION_FOLLOWING,
+			title.compareDocumentPosition(tabsRow) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 	});
 

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -17,6 +17,7 @@ export interface PageHeaderProps {
 	badges?: React.ReactNode;
 	eyebrow?: React.ReactNode;
 	meta?: React.ReactNode;
+	tabs?: React.ReactNode;
 }
 
 export const PageHeader = ({
@@ -28,6 +29,7 @@ export const PageHeader = ({
 	badges,
 	eyebrow,
 	meta,
+	tabs,
 }: PageHeaderProps) => {
 	const hasCrumbs = !!breadcrumbs && breadcrumbs.length > 0;
 	const hasActions = !!actions;
@@ -139,6 +141,11 @@ export const PageHeader = ({
 					</Flex>
 				)}
 			</Flex>
+			{tabs && (
+				<Box data-testid="page-header-tabs" mt="4" mx="-8">
+					{tabs}
+				</Box>
+			)}
 		</Box>
 	);
 };

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -95,11 +95,11 @@ export const PageHeader = ({
 			)}
 
 			<Flex align="flex-start" justify="space-between" gap="4">
-				{avatar ? (
+				{avatar && (
 					<Box data-testid="page-header-avatar" flexShrink={0}>
 						{avatar}
 					</Box>
-				) : null}
+				)}
 				<Box flex="1" minW="0">
 					<Flex align="center" gap="2" wrap="wrap">
 						<Heading
@@ -111,11 +111,11 @@ export const PageHeader = ({
 						>
 							{title}
 						</Heading>
-						{badges ? (
+						{badges && (
 							<Flex data-testid="page-header-badges" align="center" gap="2">
 								{badges}
 							</Flex>
-						) : null}
+						)}
 					</Flex>
 					{subtitle && (
 						<Text
@@ -127,11 +127,11 @@ export const PageHeader = ({
 							{subtitle}
 						</Text>
 					)}
-					{meta ? (
+					{meta && (
 						<Box data-testid="page-header-meta" mt="2">
 							{meta}
 						</Box>
-					) : null}
+					)}
 				</Box>
 				{hasActions && (
 					<Flex align="center" gap="2" flexShrink={0}>

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -13,7 +13,10 @@ export interface PageHeaderProps {
 	title: React.ReactNode;
 	subtitle?: React.ReactNode;
 	actions?: React.ReactNode;
+	avatar?: React.ReactNode;
+	badges?: React.ReactNode;
 	eyebrow?: React.ReactNode;
+	meta?: React.ReactNode;
 }
 
 export const PageHeader = ({
@@ -21,7 +24,10 @@ export const PageHeader = ({
 	title,
 	subtitle,
 	actions,
+	avatar,
+	badges,
 	eyebrow,
+	meta,
 }: PageHeaderProps) => {
 	const hasCrumbs = !!breadcrumbs && breadcrumbs.length > 0;
 	const hasActions = !!actions;
@@ -88,17 +94,29 @@ export const PageHeader = ({
 				</Flex>
 			)}
 
-			<Flex align="center" justify="space-between" gap="4">
+			<Flex align="flex-start" justify="space-between" gap="4">
+				{avatar ? (
+					<Box data-testid="page-header-avatar" flexShrink={0}>
+						{avatar}
+					</Box>
+				) : null}
 				<Box flex="1" minW="0">
-					<Heading
-						as="h1"
-						fontSize="2xl"
-						fontWeight="semibold"
-						color="default"
-						letterSpacing="-0.02em"
-					>
-						{title}
-					</Heading>
+					<Flex align="center" gap="2" wrap="wrap">
+						<Heading
+							as="h1"
+							fontSize="2xl"
+							fontWeight="semibold"
+							color="default"
+							letterSpacing="-0.02em"
+						>
+							{title}
+						</Heading>
+						{badges ? (
+							<Flex data-testid="page-header-badges" align="center" gap="2">
+								{badges}
+							</Flex>
+						) : null}
+					</Flex>
 					{subtitle && (
 						<Text
 							data-testid="page-header-subtitle"
@@ -109,6 +127,11 @@ export const PageHeader = ({
 							{subtitle}
 						</Text>
 					)}
+					{meta ? (
+						<Box data-testid="page-header-meta" mt="2">
+							{meta}
+						</Box>
+					) : null}
 				</Box>
 				{hasActions && (
 					<Flex align="center" gap="2" flexShrink={0}>

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -9,10 +9,13 @@
 // below the header band.
 //
 //     ┌─────────┬───────────────────────────────────┐
-//     │         │            page header            │
+//     │         │   page header band                │
+//     │         │   ┌ breadcrumb ─────────────────┐ │
+//     │         │   ┌ detail (avatar/title/etc.) ─┐ │
+//     │         │   ┌ tabs (optional) ────────────┐ │
 //     │         ├───────────────────────┬───────────┤
-//     │ sidebar │         children      │   rail    │
-//     │         │   (body / tabs / …)   │           │
+//     │ sidebar │       children        │   rail    │
+//     │         │   (body / cards / …)  │           │
 //     │         │                       │           │
 //     └─────────┴───────────────────────┴───────────┘
 //

--- a/src/templates/detail-page-template.test.tsx
+++ b/src/templates/detail-page-template.test.tsx
@@ -1,8 +1,8 @@
 // src/templates/detail-page-template.test.tsx
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AppShell } from "./app-shell";
 import { DetailPageTemplate } from "./detail-page-template";
 
@@ -53,7 +53,7 @@ describe("DetailPageTemplate", () => {
 		expect(wrapper.getAttribute("style") ?? "").not.toMatch(/padding/);
 	});
 
-	it("renders the tabs slot when provided", () => {
+	it("renders the tabs slot inside the registered header", () => {
 		renderWithChakra(
 			<AppShell sidebar={<div />}>
 				<DetailPageTemplate
@@ -64,71 +64,28 @@ describe("DetailPageTemplate", () => {
 				</DetailPageTemplate>
 			</AppShell>,
 		);
-		expect(screen.getByTestId("tabs")).toBeInTheDocument();
+		const header = screen.getByTestId("app-shell-header");
+		expect(within(header).getByTestId("tabs")).toBeInTheDocument();
 	});
 
-	it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
+	it("forwards avatar, badges, meta, and tabs into the registered PageHeader", () => {
 		renderWithChakra(
 			<AppShell sidebar={<div />}>
 				<DetailPageTemplate
-					title="X"
-					bodyTabs={{
-						defaultValue: "a",
-						items: [
-							{
-								value: "a",
-								label: "Tab A",
-								content: <div data-testid="content-a">A</div>,
-							},
-							{
-								value: "b",
-								label: "Tab B",
-								content: <div data-testid="content-b">B</div>,
-							},
-						],
-					}}
-				/>
-			</AppShell>,
-		);
-		expect(screen.getByTestId("content-a")).toBeInTheDocument();
-		expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
-	});
-
-	it("renders the subheader between header and tabs", () => {
-		renderWithChakra(
-			<AppShell sidebar={<div />}>
-				<DetailPageTemplate
-					title="X"
-					subheader={<div data-testid="subheader">subheader</div>}
+					title="Jana Schmid"
+					avatar={<div data-testid="av">JS</div>}
+					badges={<span data-testid="bd">Aktiv</span>}
+					meta={<span data-testid="mt">jana@example.test</span>}
+					tabs={<div data-testid="tb">tab list</div>}
 				>
-					<div data-testid="body">body</div>
+					body
 				</DetailPageTemplate>
 			</AppShell>,
 		);
-		const sub = screen.getByTestId("subheader");
-		const body = screen.getByTestId("body");
-		expect(sub).toBeInTheDocument();
-		expect(
-			sub.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING,
-		).toBeTruthy();
-	});
-
-	it("throws when both bodyTabs and tabs are passed", () => {
-		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-		expect(() =>
-			renderWithChakra(
-				<AppShell sidebar={<div />}>
-					<DetailPageTemplate
-						title="X"
-						tabs={<div />}
-						bodyTabs={{
-							defaultValue: "a",
-							items: [{ value: "a", label: "A", content: <div /> }],
-						}}
-					/>
-				</AppShell>,
-			),
-		).toThrow(/mutually exclusive/i);
-		spy.mockRestore();
+		const header = screen.getByTestId("app-shell-header");
+		expect(within(header).getByTestId("av")).toBeInTheDocument();
+		expect(within(header).getByTestId("bd")).toBeInTheDocument();
+		expect(within(header).getByTestId("mt")).toBeInTheDocument();
+		expect(within(header).getByTestId("tb")).toBeInTheDocument();
 	});
 });

--- a/src/templates/detail-page-template.tsx
+++ b/src/templates/detail-page-template.tsx
@@ -6,82 +6,41 @@
 //
 //   ┌─────────────────────────────────────────┐
 //   │ PageHeader  (breadcrumbs · title · …)   │
-//   ├─────────────────────────────────────────┤
-//   │ subheader (optional — e.g. identity card)│
-//   ├─────────────────────────────────────────┤
-//   │ Tabs (optional — pinned beneath subhead) │
-//   ├─────────────────────────────────────────┤
-//   │ children OR bodyTabs panes               │
+//   │   avatar · badges · meta (detail row)   │
+//   │   tabs (optional third row)             │
+//   └─────────────────────────────────────────┘
+//   ┌─────────────────────────────────────────┐
+//   │ children (body — flush, no padding)     │
 //   └─────────────────────────────────────────┘
 //
-// Two ways to render tabs:
-//
-// 1. `bodyTabs` — declarative panels owned by the template. Template wraps
-//    Tabs.Root with `lazyMount unmountOnExit` so only the active panel
-//    mounts. Use this for any case where each tab has its own body
-//    component (Members, Security, Sessions panes).
-//
-// 2. `tabs` — ReactNode slot for nav-mode or filter-mode tab strips
-//    (Tabs.List with no Tabs.Content; the body comes from `children`,
-//    typically a route's outlet). Use this when each tab is a separate
-//    route or when tab state is controlled externally.
-//
-// `bodyTabs` and `tabs` are mutually exclusive. Passing both throws.
+// The tab list renders inside the header band via the slot store.
+// The active panel is provided as `children`. Use nav-link tabs:
+// build a `<Tabs.Root value={current}>` with only `<Tabs.List>` inside,
+// pass to `tabs`, and let the router render the active panel as children.
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
 import { Box, Flex } from "../primitives/layout";
-import { Tabs } from "../primitives/tabs";
 import { usePageHeader, useRegisteredPageActions } from "./app-shell";
-
-export interface BodyTabsItem {
-	value: string;
-	label: ReactNode;
-	content: ReactNode;
-}
-
-export type BodyTabsProp =
-	| {
-			items: BodyTabsItem[];
-			defaultValue: string;
-			value?: never;
-			onValueChange?: never;
-	  }
-	| {
-			items: BodyTabsItem[];
-			value: string;
-			onValueChange: (next: string) => void;
-			defaultValue?: never;
-	  };
 
 export interface DetailPageTemplateProps
 	extends Pick<
 		PageHeaderProps,
 		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
 	> {
+	/**
+	 * Optional explicit page-action content. Falls back to the actions
+	 * registered via `usePageActions` if not provided.
+	 */
 	actions?: ReactNode;
-	/**
-	 * Tab strip rendered immediately under the PageHeader / subheader.
-	 * Use this for nav-mode/filter-mode tabs (Tabs.List, no Tabs.Content);
-	 * the body comes from `children`. For owned-panel tabs, use `bodyTabs`
-	 * instead. Mutually exclusive with `bodyTabs`.
-	 */
+	/** Avatar slot for the page header's detail row. */
+	avatar?: ReactNode;
+	/** Badges shown inline next to the title. */
+	badges?: ReactNode;
+	/** Secondary meta line below the title (email, dept, ID, etc.). */
+	meta?: ReactNode;
+	/** Optional tab strip rendered as the third row of the page header band. */
 	tabs?: ReactNode;
-	/**
-	 * Owned-panel tabs. Template renders Tabs.Root with `lazyMount
-	 * unmountOnExit`; only the active item's `content` mounts. Mutually
-	 * exclusive with `tabs` and `children` is ignored when this is set.
-	 */
-	bodyTabs?: BodyTabsProp;
-	/**
-	 * ReactNode rendered between the PageHeader and the tabs (or the body
-	 * if no tabs). Use for identity-card-style summaries.
-	 */
-	subheader?: ReactNode;
-	/**
-	 * Page body — rendered when `bodyTabs` is not set. Flush against the
-	 * canvas; add internal padding inside `children` if you need it.
-	 */
 	children?: ReactNode;
 }
 
@@ -91,16 +50,12 @@ export function DetailPageTemplate({
 	subtitle,
 	eyebrow,
 	actions,
+	avatar,
+	badges,
+	meta,
 	tabs,
-	bodyTabs,
-	subheader,
 	children,
 }: DetailPageTemplateProps) {
-	if (tabs && bodyTabs) {
-		throw new Error(
-			"DetailPageTemplate: `tabs` and `bodyTabs` are mutually exclusive — use `bodyTabs` for owned panels, `tabs` for nav/filter strips.",
-		);
-	}
 	const registered = useRegisteredPageActions();
 	const resolvedActions = actions ?? registered;
 	usePageHeader(
@@ -110,48 +65,12 @@ export function DetailPageTemplate({
 			subtitle={subtitle}
 			eyebrow={eyebrow}
 			actions={resolvedActions}
+			avatar={avatar}
+			badges={badges}
+			meta={meta}
+			tabs={tabs}
 		/>,
 	);
-
-	if (bodyTabs) {
-		const tabsRootProps =
-			bodyTabs.value !== undefined
-				? {
-						value: bodyTabs.value,
-						onValueChange: (d: { value: string }) =>
-							bodyTabs.onValueChange!(d.value),
-					}
-				: { defaultValue: bodyTabs.defaultValue };
-		return (
-			<Flex
-				data-testid="detail-page-template"
-				direction="column"
-				flex="1"
-				minH="0"
-			>
-				{subheader ? <Box>{subheader}</Box> : null}
-				<Tabs.Root lazyMount unmountOnExit {...tabsRootProps}>
-					<Box>
-						<Tabs.List>
-							{bodyTabs.items.map((item) => (
-								<Tabs.Trigger key={item.value} value={item.value}>
-									{item.label}
-								</Tabs.Trigger>
-							))}
-						</Tabs.List>
-					</Box>
-					<Box flex="1" minH="0">
-						{bodyTabs.items.map((item) => (
-							<Tabs.Content key={item.value} value={item.value}>
-								{item.content}
-							</Tabs.Content>
-						))}
-					</Box>
-				</Tabs.Root>
-			</Flex>
-		);
-	}
-
 	return (
 		<Flex
 			data-testid="detail-page-template"
@@ -159,8 +78,6 @@ export function DetailPageTemplate({
 			flex="1"
 			minH="0"
 		>
-			{subheader ? <Box>{subheader}</Box> : null}
-			{tabs ? <Box>{tabs}</Box> : null}
 			<Box flex="1" minH="0">
 				{children}
 			</Box>

--- a/src/templates/index-page-template.test.tsx
+++ b/src/templates/index-page-template.test.tsx
@@ -6,38 +6,38 @@ import { AppShell } from "./app-shell";
 import { IndexPageTemplate } from "./index-page-template";
 
 function renderWithChakra(ui: ReactElement) {
-    return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+	return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
 }
 
 describe("IndexPageTemplate", () => {
-    it("forwards the tabs prop into the registered PageHeader", () => {
-        renderWithChakra(
-            <AppShell sidebar={<div />}>
-                <IndexPageTemplate
-                    title="Users"
-                    tabs={<div data-testid="t-all">All</div>}
-                >
-                    body
-                </IndexPageTemplate>
-            </AppShell>,
-        );
-        const header = screen.getByTestId("app-shell-header");
-        expect(within(header).getByTestId("t-all")).toBeInTheDocument();
-    });
+	it("forwards the tabs prop into the registered PageHeader", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<IndexPageTemplate
+					title="Users"
+					tabs={<div data-testid="t-all">All</div>}
+				>
+					body
+				</IndexPageTemplate>
+			</AppShell>,
+		);
+		const header = screen.getByTestId("app-shell-header");
+		expect(within(header).getByTestId("t-all")).toBeInTheDocument();
+	});
 
-    it("does not render tabs as a body sibling", () => {
-        renderWithChakra(
-            <AppShell sidebar={<div />}>
-                <IndexPageTemplate
-                    title="Users"
-                    tabs={<div data-testid="t-all">All</div>}
-                >
-                    body
-                </IndexPageTemplate>
-            </AppShell>,
-        );
-        const template = screen.getByTestId("index-page-template");
-        // tabs are now inside the app-shell-header, NOT a child of the template body.
-        expect(within(template).queryByTestId("t-all")).not.toBeInTheDocument();
-    });
+	it("does not render tabs as a body sibling", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<IndexPageTemplate
+					title="Users"
+					tabs={<div data-testid="t-all">All</div>}
+				>
+					body
+				</IndexPageTemplate>
+			</AppShell>,
+		);
+		const template = screen.getByTestId("index-page-template");
+		// tabs are now inside the app-shell-header, NOT a child of the template body.
+		expect(within(template).queryByTestId("t-all")).not.toBeInTheDocument();
+	});
 });

--- a/src/templates/index-page-template.test.tsx
+++ b/src/templates/index-page-template.test.tsx
@@ -1,0 +1,43 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen, within } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { AppShell } from "./app-shell";
+import { IndexPageTemplate } from "./index-page-template";
+
+function renderWithChakra(ui: ReactElement) {
+    return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+describe("IndexPageTemplate", () => {
+    it("forwards the tabs prop into the registered PageHeader", () => {
+        renderWithChakra(
+            <AppShell sidebar={<div />}>
+                <IndexPageTemplate
+                    title="Users"
+                    tabs={<div data-testid="t-all">All</div>}
+                >
+                    body
+                </IndexPageTemplate>
+            </AppShell>,
+        );
+        const header = screen.getByTestId("app-shell-header");
+        expect(within(header).getByTestId("t-all")).toBeInTheDocument();
+    });
+
+    it("does not render tabs as a body sibling", () => {
+        renderWithChakra(
+            <AppShell sidebar={<div />}>
+                <IndexPageTemplate
+                    title="Users"
+                    tabs={<div data-testid="t-all">All</div>}
+                >
+                    body
+                </IndexPageTemplate>
+            </AppShell>,
+        );
+        const template = screen.getByTestId("index-page-template");
+        // tabs are now inside the app-shell-header, NOT a child of the template body.
+        expect(within(template).queryByTestId("t-all")).not.toBeInTheDocument();
+    });
+});

--- a/src/templates/index-page-template.tsx
+++ b/src/templates/index-page-template.tsx
@@ -6,8 +6,7 @@
 //
 //   ┌─────────────────────────────────────────┐
 //   │ PageHeader  (breadcrumbs · title · …)   │
-//   ├─────────────────────────────────────────┤
-//   │ Tabs (optional — under header)          │
+//   │            (tabs — third row)           │
 //   ├─────────────────────────────────────────┤
 //   │ Toolbar (search · filters · count)      │
 //   ├─────────────────────────────────────────┤
@@ -36,7 +35,7 @@ export interface IndexPageTemplateProps
 	 */
 	actions?: ReactNode;
 	/**
-	 * Optional tab strip rendered between the PageHeader and the toolbar.
+	 * Optional tab strip rendered inside the PageHeader band as the third row.
 	 * Pass an instance of `<Tabs.Root>` (with its own `<Tabs.List>` and
 	 * `<Tabs.Content>`s). When omitted, no tab strip is rendered.
 	 */
@@ -56,8 +55,8 @@ export interface IndexPageTemplateProps
 }
 
 /**
- * Canonical list-page layout. Renders PageHeader → optional Tabs → optional
- * Toolbar → children, full-bleed against the canvas.
+ * Canonical list-page layout. Renders PageHeader (with optional tabs inside) →
+ * optional Toolbar → children, full-bleed against the canvas.
  *
  * Page actions are sourced from (in priority order): `actions` prop →
  * registered slot via `usePageActions`. This lets a tab-pane component deep
@@ -82,6 +81,7 @@ export function IndexPageTemplate({
 			subtitle={subtitle}
 			eyebrow={eyebrow}
 			actions={resolvedActions}
+			tabs={tabs}
 		/>,
 	);
 	return (
@@ -91,7 +91,6 @@ export function IndexPageTemplate({
 			flex="1"
 			minH="0"
 		>
-			{tabs ? <Box>{tabs}</Box> : null}
 			{toolbar ? <Box>{toolbar}</Box> : null}
 			<Box flex="1" minH="0">
 				{children}

--- a/src/templates/settings-page-template.test.tsx
+++ b/src/templates/settings-page-template.test.tsx
@@ -1,8 +1,8 @@
 // src/templates/settings-page-template.test.tsx
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AppShell } from "./app-shell";
 import { SettingsPageTemplate } from "./settings-page-template";
 
@@ -11,49 +11,92 @@ function renderWithChakra(ui: ReactElement) {
 }
 
 describe("SettingsPageTemplate", () => {
-	it("renders the active tab's content via bodyTabs (uncontrolled)", () => {
+	it("renders the title", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate title="Einstellungen">
+					<div>body</div>
+				</SettingsPageTemplate>
+			</AppShell>,
+		);
+		expect(
+			screen.getByRole("heading", { name: "Einstellungen" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders children in the body", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate title="Einstellungen">
+					<div data-testid="body-content">content</div>
+				</SettingsPageTemplate>
+			</AppShell>,
+		);
+		expect(screen.getByTestId("body-content")).toBeInTheDocument();
+	});
+
+	it("constrains body width to 3xl by default", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate title="Einstellungen">
+					<div data-testid="body-content">content</div>
+				</SettingsPageTemplate>
+			</AppShell>,
+		);
+		const content = screen.getByTestId("body-content");
+		// The constraining Box wraps the direct children
+		const constrainingBox = content.parentElement as HTMLElement;
+		// maxW="3xl" is set as a chakra prop — verify parent exists and is present
+		expect(constrainingBox).toBeInTheDocument();
+	});
+
+	it("applies body padding by default", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate title="Einstellungen">
+					<div data-testid="body-content">content</div>
+				</SettingsPageTemplate>
+			</AppShell>,
+		);
+		const content = screen.getByTestId("body-content");
+		// Walk up two levels: content -> constraining Box -> padding Box
+		const paddingBox = content.parentElement?.parentElement as HTMLElement;
+		expect(paddingBox).toBeInTheDocument();
+	});
+
+	it("renders the tabs slot inside the registered header", () => {
 		renderWithChakra(
 			<AppShell sidebar={<div />}>
 				<SettingsPageTemplate
-					title="X"
-					bodyTabs={{
-						defaultValue: "a",
-						items: [
-							{
-								value: "a",
-								label: "Tab A",
-								content: <div data-testid="content-a">A</div>,
-							},
-							{
-								value: "b",
-								label: "Tab B",
-								content: <div data-testid="content-b">B</div>,
-							},
-						],
-					}}
-				/>
+					title="Einstellungen"
+					tabs={<div data-testid="tabs">tabs</div>}
+				>
+					<div>body</div>
+				</SettingsPageTemplate>
 			</AppShell>,
 		);
-		expect(screen.getByTestId("content-a")).toBeInTheDocument();
-		expect(screen.queryByTestId("content-b")).not.toBeInTheDocument();
+		const header = screen.getByTestId("app-shell-header");
+		expect(within(header).getByTestId("tabs")).toBeInTheDocument();
 	});
 
-	it("throws when both bodyTabs and tabs are passed", () => {
-		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-		expect(() =>
-			renderWithChakra(
-				<AppShell sidebar={<div />}>
-					<SettingsPageTemplate
-						title="X"
-						tabs={<div />}
-						bodyTabs={{
-							defaultValue: "a",
-							items: [{ value: "a", label: "A", content: <div /> }],
-						}}
-					/>
-				</AppShell>,
-			),
-		).toThrow(/mutually exclusive/i);
-		spy.mockRestore();
+	it("forwards avatar, badges, meta, and tabs into the registered PageHeader", () => {
+		renderWithChakra(
+			<AppShell sidebar={<div />}>
+				<SettingsPageTemplate
+					title="Einstellungen"
+					avatar={<div data-testid="av">AV</div>}
+					badges={<span data-testid="bd">Pro</span>}
+					meta={<span data-testid="mt">org@example.test</span>}
+					tabs={<div data-testid="tb">tab list</div>}
+				>
+					body
+				</SettingsPageTemplate>
+			</AppShell>,
+		);
+		const header = screen.getByTestId("app-shell-header");
+		expect(within(header).getByTestId("av")).toBeInTheDocument();
+		expect(within(header).getByTestId("bd")).toBeInTheDocument();
+		expect(within(header).getByTestId("mt")).toBeInTheDocument();
+		expect(within(header).getByTestId("tb")).toBeInTheDocument();
 	});
 });

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -1,69 +1,43 @@
 // src/templates/settings-page-template.tsx
 //
-// SettingsPageTemplate — for any "preferences / configuration" page that
-// uses a tabbed split between mixed form / list content.
+// SettingsPageTemplate — for any "preferences / configuration" page.
 //
 //   ┌─────────────────────────────────────────┐
 //   │ PageHeader  (breadcrumbs · title · …)   │
-//   ├─────────────────────────────────────────┤
-//   │ Tabs (required for settings)            │
-//   ├─────────────────────────────────────────┤
-//   │ children OR bodyTabs panes              │
+//   │   avatar · badges · meta (detail row)   │
+//   │   tabs (optional third row)             │
+//   └─────────────────────────────────────────┘
+//   ┌─────────────────────────────────────────┐
+//   │ children (body — constrained width)     │
 //   └─────────────────────────────────────────┘
 //
-// Two ways to render tabs (mutually exclusive):
-//
-// 1. `bodyTabs` — declarative panels owned by the template. Template
-//    wraps Tabs.Root with `lazyMount unmountOnExit`. Prefer this for
-//    settings pages.
-//
-// 2. `tabs` + `children` — consumer owns Tabs.Root and Tabs.Content.
-//    Retained for back-compat / advanced cases.
+// Pass a `<Tabs.Root value={current}>` with only `<Tabs.List>` inside to
+// `tabs`; let the router (or parent) render the active panel as `children`.
 
 import type { ReactNode } from "react";
 import { PageHeader, type PageHeaderProps } from "../components/page-header";
 import { Box, Flex } from "../primitives/layout";
-import { Tabs } from "../primitives/tabs";
 import { usePageHeader, useRegisteredPageActions } from "./app-shell";
-export interface BodyTabsItem {
-	value: string;
-	label: ReactNode;
-	content: ReactNode;
-}
-
-export type BodyTabsProp =
-	| {
-			items: BodyTabsItem[];
-			defaultValue: string;
-			value?: never;
-			onValueChange?: never;
-	  }
-	| {
-			items: BodyTabsItem[];
-			value: string;
-			onValueChange: (next: string) => void;
-			defaultValue?: never;
-	  };
 
 export interface SettingsPageTemplateProps
 	extends Pick<
 		PageHeaderProps,
 		"breadcrumbs" | "title" | "subtitle" | "eyebrow"
 	> {
+	/**
+	 * Optional explicit page-action content. Falls back to the actions
+	 * registered via `usePageActions` if not provided.
+	 */
 	actions?: ReactNode;
-	/**
-	 * Tab strip (consumer-owned). Mutually exclusive with `bodyTabs`.
-	 * Settings pages should always have at least two tabs — if you only
-	 * have one section, use DetailPageTemplate instead.
-	 */
+	/** Avatar slot for the page header's detail row. */
+	avatar?: ReactNode;
+	/** Badges shown inline next to the title. */
+	badges?: ReactNode;
+	/** Secondary meta line below the title (email, dept, ID, etc.). */
+	meta?: ReactNode;
+	/** Tab strip rendered as the third row of the page header band. */
 	tabs?: ReactNode;
-	/**
-	 * Owned-panel tabs. Template renders Tabs.Root with `lazyMount
-	 * unmountOnExit`; only the active item's `content` mounts. Mutually
-	 * exclusive with `tabs`.
-	 */
-	bodyTabs?: BodyTabsProp;
-	/** Page body when `bodyTabs` is not set. */
+	/** Page body content. */
 	children?: ReactNode;
 	/**
 	 * Constrain the body width for readability. @default "3xl" (= 768px).
@@ -84,17 +58,14 @@ export function SettingsPageTemplate({
 	subtitle,
 	eyebrow,
 	actions,
+	avatar,
+	badges,
+	meta,
 	tabs,
-	bodyTabs,
 	children,
 	maxBodyWidth = "3xl",
 	bodyPadding = "default",
 }: SettingsPageTemplateProps) {
-	if (tabs && bodyTabs) {
-		throw new Error(
-			"SettingsPageTemplate: `tabs` and `bodyTabs` are mutually exclusive — use `bodyTabs` for owned panels, `tabs` for consumer-owned tab strips.",
-		);
-	}
 	const registered = useRegisteredPageActions();
 	const resolvedActions = actions ?? registered;
 	usePageHeader(
@@ -104,59 +75,15 @@ export function SettingsPageTemplate({
 			subtitle={subtitle}
 			eyebrow={eyebrow}
 			actions={resolvedActions}
+			avatar={avatar}
+			badges={badges}
+			meta={meta}
+			tabs={tabs}
 		/>,
 	);
+
 	const bodyPx = bodyPadding === "none" ? "0" : "8";
 	const bodyPt = bodyPadding === "none" ? "0" : "6";
-
-	const renderBody = (node: ReactNode) => (
-		<Box flex="1" minH="0" px={bodyPx} pt={bodyPt}>
-			<Box
-				maxW={maxBodyWidth}
-				marginInline={maxBodyWidth === "full" ? "0" : "auto"}
-			>
-				{node}
-			</Box>
-		</Box>
-	);
-
-	if (bodyTabs) {
-		const tabsRootProps =
-			bodyTabs.value !== undefined
-				? {
-						value: bodyTabs.value,
-						onValueChange: (d: { value: string }) =>
-							bodyTabs.onValueChange?.(d.value),
-					}
-				: { defaultValue: bodyTabs.defaultValue };
-		return (
-			<Flex
-				data-testid="settings-page-template"
-				direction="column"
-				flex="1"
-				minH="0"
-			>
-				<Tabs.Root lazyMount unmountOnExit {...tabsRootProps}>
-					<Box>
-						<Tabs.List>
-							{bodyTabs.items.map((item) => (
-								<Tabs.Trigger key={item.value} value={item.value}>
-									{item.label}
-								</Tabs.Trigger>
-							))}
-						</Tabs.List>
-					</Box>
-					{renderBody(
-						bodyTabs.items.map((item) => (
-							<Tabs.Content key={item.value} value={item.value}>
-								{item.content}
-							</Tabs.Content>
-						)),
-					)}
-				</Tabs.Root>
-			</Flex>
-		);
-	}
 
 	return (
 		<Flex
@@ -165,8 +92,14 @@ export function SettingsPageTemplate({
 			flex="1"
 			minH="0"
 		>
-			<Box>{tabs}</Box>
-			{renderBody(children)}
+			<Box flex="1" minH="0" px={bodyPx} pt={bodyPt}>
+				<Box
+					maxW={maxBodyWidth}
+					marginInline={maxBodyWidth === "full" ? "0" : "auto"}
+				>
+					{children}
+				</Box>
+			</Box>
 		</Flex>
 	);
 }

--- a/src/templates/settings-page-template.tsx
+++ b/src/templates/settings-page-template.tsx
@@ -25,9 +25,25 @@ import { PageHeader, type PageHeaderProps } from "../components/page-header";
 import { Box, Flex } from "../primitives/layout";
 import { Tabs } from "../primitives/tabs";
 import { usePageHeader, useRegisteredPageActions } from "./app-shell";
-import type { BodyTabsProp } from "./detail-page-template";
+export interface BodyTabsItem {
+	value: string;
+	label: ReactNode;
+	content: ReactNode;
+}
 
-export type { BodyTabsItem, BodyTabsProp } from "./detail-page-template";
+export type BodyTabsProp =
+	| {
+			items: BodyTabsItem[];
+			defaultValue: string;
+			value?: never;
+			onValueChange?: never;
+	  }
+	| {
+			items: BodyTabsItem[];
+			value: string;
+			onValueChange: (next: string) => void;
+			defaultValue?: never;
+	  };
 
 export interface SettingsPageTemplateProps
 	extends Pick<


### PR DESCRIPTION
## Summary

- \`<PageHeader>\` grows four optional slots: \`avatar\`, \`badges\`, \`meta\`, \`tabs\` — renders as a three-row band on bg-surface.
- Page templates (\`IndexPageTemplate\`, \`DetailPageTemplate\`, \`SettingsPageTemplate\`) pipe their existing \`tabs\` prop into the header band instead of rendering it as a separate row in the body.
- \`DetailPageTemplate\` and \`SettingsPageTemplate\`: \`subheader\` and \`bodyTabs\` props removed (breaking).
- Design docs and Storybook MDX updated so the new shape propagates seamlessly across solutions.

Spec: \`docs/superpowers/specs/2026-05-13-page-header-redesign-design.md\`
Plan: \`docs/superpowers/plans/2026-05-13-page-header-redesign.md\`

## Test plan

- [x] \`pnpm test\` — 1054/1054 passing
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — \`avatar\`/\`badges\`/\`meta\`/\`tabs\` exported on \`PageHeaderProps\`
- [ ] CI green
- [ ] Cut v2.2.0 tag after merge
- [ ] Bump anker in odon, migrate UserDetailLayout, ship