### PR TITLE
fix(page-header): tab row flush with band bottom border

### DIFF
--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -155,4 +155,20 @@ describe("PageHeader", () => {
 		renderWithChakra(<PageHeader title="Users" />);
 		expect(screen.queryByTestId("page-header-tabs")).not.toBeInTheDocument();
 	});
+
+	it("tab row sits flush with the band's bottom border (negative mb cancels outer pb)", () => {
+		renderWithChakra(
+			<PageHeader
+				title="Users"
+				tabs={<div data-testid="tabs-strip">tabs</div>}
+			/>,
+		);
+		const tabsRow = screen.getByTestId("page-header-tabs");
+		// The tabs wrapper applies `mb="-4"` so it negative-margins out the
+		// parent band's `pb="4"`. Chakra emits this as a CSS custom property
+		// multiplied by -1 inside calc().
+		const cs = window.getComputedStyle(tabsRow);
+		expect(cs.marginBottom).not.toBe("");
+		expect(cs.marginBottom).toMatch(/spacing-4|-4|calc/);
+	});
 });

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -142,7 +142,7 @@ export const PageHeader = ({
 				)}
 			</Flex>
 			{tabs && (
-				<Box data-testid="page-header-tabs" mt="4" mx="-8">
+				<Box data-testid="page-header-tabs" mt="4" mx="-8" mb="-4">
 					{tabs}
 				</Box>
 			)}


### PR DESCRIPTION
## Summary

The page header band has \`py="4"\` on its outer Box (16px top + 16px bottom padding). The tabs row wrapper used \`mt="4" mx="-8"\` but no negative bottom margin, so a 16px strip of \`bg-surface\` remained below the active-tab underline before the band's bottom border. Visually it read as a gap between the tabs and the body.

This change adds \`mb="-4"\` to the tabs wrapper so the tab strip sits flush against the band's bottom border.

Targeted for v2.2.1 patch release.

## Test plan

- [x] New test asserts \`marginBottom\` is set on \`page-header-tabs\`.
- [x] Full test suite green.
- [ ] Visual smoke check after deploy to confirm no white strip between tabs and body.