### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knkcs/anker",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chakra-react-select": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v2.3.0 — collapsed ContextRail atoms (#118).