### PR TITLE
fix(app-shell): sidebar stacks above sticky header (2.6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/templates/app-shell.test.tsx
+++ b/src/templates/app-shell.test.tsx
@@ -245,4 +245,17 @@ describe("AppShell — sticky page header", () => {
 			"true",
 		);
 	});
+
+	it("stacks the sidebar above the sticky header so its protruding controls remain clickable", () => {
+		// Regression: the Sidebar's collapse toggle protrudes via `right: -3.5`
+		// into the next column. With the sticky header at z-index `docked` (10),
+		// the sidebar Box must sit strictly above so its toggle isn't covered.
+		renderWithChakra(
+			<AppShell sidebar={<div data-testid="sb" />}>
+				<HeaderRegistrar />
+			</AppShell>,
+		);
+		const sidebarBox = screen.getByTestId("app-shell-sidebar");
+		expect(sidebarBox).toHaveStyle({ zIndex: "11" });
+	});
 });

--- a/src/templates/app-shell.tsx
+++ b/src/templates/app-shell.tsx
@@ -309,6 +309,10 @@ function AppShellInner({ sidebar, rail, children }: AppShellProps) {
 				top="0"
 				alignSelf="start"
 				maxH="100vh"
+				// One above Chakra's `docked` (10) so the Sidebar's collapse
+				// toggle — positioned with `right: -3.5` to protrude into the
+				// next column — renders above the sticky page-header band.
+				zIndex={11}
 			>
 				{sidebar}
 			</Box>


### PR DESCRIPTION
Sidebar toggle was rendered behind the new sticky page header. Bumps sidebar Box to zIndex={11}, one above docked.