### PR TITLE
fix(primitives): explicit zIndex on portaled menu/hover/popover positioners (2.6.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/primitives/hover-card.tsx
+++ b/src/primitives/hover-card.tsx
@@ -28,7 +28,10 @@ export const HoverCard = function HoverCard(props: HoverCardProps) {
 		<ChakraHoverCard.Root {...rest}>
 			<ChakraHoverCard.Trigger asChild>{children}</ChakraHoverCard.Trigger>
 			<Portal disabled={!portalled} container={portalRef}>
-				<ChakraHoverCard.Positioner>
+				{/* Explicit zIndex so hover cards render above sticky layout
+				    chrome (sidebar / page header) at `docked` (10). See the
+				    matching note in primitives/menu.tsx. */}
+				<ChakraHoverCard.Positioner zIndex="popover">
 					<ChakraHoverCard.Content {...contentProps}>
 						{showArrow && (
 							<ChakraHoverCard.Arrow>

--- a/src/primitives/menu.tsx
+++ b/src/primitives/menu.tsx
@@ -18,7 +18,13 @@ export const MenuContent = function MenuContent({
 	const { portalled = true, portalRef, ...rest } = props;
 	return (
 		<Portal disabled={!portalled} container={portalRef}>
-			<ChakraMenu.Positioner>
+			{/* Explicit zIndex on the positioner ensures menus render above
+			    layout chrome with `docked` z-index (10) — sidebar, sticky page
+			    header, etc. Chakra's default left this implicit, which broke
+			    AccountPopup rendering when the AppShell sidebar was bumped
+			    above `docked` to keep its protruding collapse toggle above the
+			    sticky page header. */}
+			<ChakraMenu.Positioner zIndex="dropdown">
 				<ChakraMenu.Content ref={ref} {...rest} />
 			</ChakraMenu.Positioner>
 		</Portal>

--- a/src/primitives/popover.tsx
+++ b/src/primitives/popover.tsx
@@ -27,7 +27,10 @@ export const PopoverContent = function PopoverContent({
 	const { showArrow, portalled = true, portalRef, children, ...rest } = props;
 	return (
 		<Portal disabled={!portalled} container={portalRef}>
-			<ChakraPopover.Positioner>
+			{/* Explicit zIndex so popovers render above sticky layout chrome
+			    (sidebar / page header) at `docked` (10). See the matching
+			    note in primitives/menu.tsx. */}
+			<ChakraPopover.Positioner zIndex="popover">
 				<ChakraPopover.Content ref={ref} {...rest}>
 					{showArrow && (
 						<ChakraPopover.Arrow>


### PR DESCRIPTION
After 2.6.1 bumped AppShell sidebar to z=11 (one above docked), portaled overlays whose positioner had implicit z-index began rendering behind the sidebar. This patch makes Menu use 'dropdown' and HoverCard/Popover use 'popover'.