### PR TITLE
fix(primitives): literal zIndex on portal positioners (2.6.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/primitives/hover-card.tsx
+++ b/src/primitives/hover-card.tsx
@@ -31,7 +31,7 @@ export const HoverCard = function HoverCard(props: HoverCardProps) {
 				{/* Explicit zIndex so hover cards render above sticky layout
 				    chrome (sidebar / page header) at `docked` (10). See the
 				    matching note in primitives/menu.tsx. */}
-				<ChakraHoverCard.Positioner zIndex="popover">
+				<ChakraHoverCard.Positioner zIndex={1500}>
 					<ChakraHoverCard.Content {...contentProps}>
 						{showArrow && (
 							<ChakraHoverCard.Arrow>

--- a/src/primitives/menu.tsx
+++ b/src/primitives/menu.tsx
@@ -24,7 +24,7 @@ export const MenuContent = function MenuContent({
 			    AccountPopup rendering when the AppShell sidebar was bumped
 			    above `docked` to keep its protruding collapse toggle above the
 			    sticky page header. */}
-			<ChakraMenu.Positioner zIndex="dropdown">
+			<ChakraMenu.Positioner zIndex={1500}>
 				<ChakraMenu.Content ref={ref} {...rest} />
 			</ChakraMenu.Positioner>
 		</Portal>

--- a/src/primitives/popover.tsx
+++ b/src/primitives/popover.tsx
@@ -30,7 +30,7 @@ export const PopoverContent = function PopoverContent({
 			{/* Explicit zIndex so popovers render above sticky layout chrome
 			    (sidebar / page header) at `docked` (10). See the matching
 			    note in primitives/menu.tsx. */}
-			<ChakraPopover.Positioner zIndex="popover">
+			<ChakraPopover.Positioner zIndex={1500}>
 				<ChakraPopover.Content ref={ref} {...rest}>
 					{showArrow && (
 						<ChakraPopover.Arrow>


### PR DESCRIPTION
Token-name 'dropdown'/'popover' from 2.6.2 didn't resolve in consumer themes. Switching to literal 1500.