### PR TITLE
feat: unified unsaved-changes API (2.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 2.8.0 — 2026-05-29
+
+### Added
+- New `@knkcs/anker/navigation` namespace:
+  - `useUnsavedChangesBlocker(isDirty, opts)` — primitive hook returning a
+    react-router `Blocker`. Supports `safePathPrefix` to exempt sibling
+    paths (e.g. tabs of the same detail page) and `shouldBlock` for
+    arbitrary predicates.
+  - `<UnsavedChangesGuard isDirty={…} …/>` — non-form-aware leave-page
+    guard composing the hook with `<LeavePageConfirmation/>`.
+  - `<TabDirtyProvider/>` + `useTabDirty()` — multi-key registry of
+    per-tab dirty state. Use with `<DirtyDot/>` to surface unsaved work
+    on tab triggers.
+- `<DirtyFormGuard/>` now accepts `safePathPrefix` and `shouldBlock`.
+  Existing callers without these props behave identically.
+
+### Changed
+- `<DirtyFormGuard/>` internally delegates to `<UnsavedChangesGuard/>`
+  (transparent refactor; no API break).
+- `Forms/Dirty surfaces` storybook page expanded to cover all five
+  dirty surfaces (field visual, counter chip, tab dot, form guard,
+  generic guard).
+
+### Requirements
+- The leave-page guards require a react-router-dom **data router**
+  (`createBrowserRouter` / `createMemoryRouter` + `<RouterProvider/>`).
+
 ## 2.7.0 — 2026-05-29
 
 ### Added

--- a/docs/superpowers/plans/2026-05-29-unified-unsaved-changes-api.md
+++ b/docs/superpowers/plans/2026-05-29-unified-unsaved-changes-api.md
@@ -1,0 +1,1125 @@
+# Unified Unsaved-Changes API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `@knkcs/anker@2.8.0` with a new `src/navigation/` namespace exposing `useUnsavedChangesBlocker`, `<UnsavedChangesGuard/>`, `<TabDirtyProvider>`, and `useTabDirty()`. `DirtyFormGuard` refactored to delegate (backwards-compat). `Forms/Dirty surfaces` docs become the single dirty-UX reference.
+
+**Architecture:** Three new files in `src/navigation/`. `DirtyFormGuard` becomes a thin wrapper over `<UnsavedChangesGuard isDirty={useFormContext().formState.isDirty}/>`. Tests use `createMemoryRouter` + `RouterProvider` (required for `useBlocker` — the legacy `<MemoryRouter>` JSX form is NOT a data router and breaks `useBlocker`). Minor version bump, additive only.
+
+**Tech Stack:** React 19, react-router-dom v7 (data router APIs), Chakra v3 primitives, Vitest + `@testing-library/react`, tsup bundling, Storybook 8 mdx.
+
+**Spec:** `/Users/jeskoiwanovski/repo/anker/docs/superpowers/specs/2026-05-29-unified-unsaved-changes-api-design.md`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `src/navigation/use-unsaved-changes-blocker.ts` | `useUnsavedChangesBlocker(isDirty, opts) → Blocker` primitive hook + `UnsavedChangesBlockerOptions` type. |
+| `src/navigation/use-unsaved-changes-blocker.test.tsx` | Three vitest cases (clean / blocks external / allows safePathPrefix). |
+| `src/navigation/unsaved-changes-guard.tsx` | `<UnsavedChangesGuard/>` component + `UnsavedChangesGuardProps` type. |
+| `src/navigation/unsaved-changes-guard.test.tsx` | Renders dialog when blocked; confirm/cancel wires correctly. |
+| `src/navigation/tab-dirty-context.tsx` | `<TabDirtyProvider/>` + `useTabDirty()` + `TabDirtyState` type. |
+| `src/navigation/tab-dirty-context.test.tsx` | Three cases (per-key isolation / no-provider default / renders children). |
+| `src/navigation/index.ts` | Barrel for the four exports + their types. |
+| `src/forms/dirty-form-guard.tsx` | Refactor to delegate to `<UnsavedChangesGuard/>`; accept `safePathPrefix` / `shouldBlock`. |
+| `src/forms/dirty-form-guard.test.tsx` | New test confirming delegation + opts pass-through + backwards-compat default. |
+| `src/forms/dirty-surfaces.mdx` | Rewrite to cover all five surfaces. |
+| `package.json` | Add `./navigation` export entry; bump version 2.7.0 → 2.8.0. |
+| `tsup.config.ts` | Add `navigation/index` entry. |
+| `CHANGELOG.md` | Prepend 2.8.0 entry. |
+
+---
+
+### Task 1: Failing test for `useUnsavedChangesBlocker`
+
+**Files:**
+- Create: `src/navigation/use-unsaved-changes-blocker.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`useBlocker` requires a data router. Use `createMemoryRouter` + `RouterProvider`.
+
+```tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { useUnsavedChangesBlocker } from "./use-unsaved-changes-blocker";
+
+function makeRouter(opts: {
+	isDirty: boolean;
+	safePathPrefix?: string;
+	initial?: string;
+}) {
+	function Probe() {
+		const navigate = useNavigate();
+		const blocker = useUnsavedChangesBlocker(opts.isDirty, {
+			safePathPrefix: opts.safePathPrefix,
+		});
+		return (
+			<>
+				<span data-testid="state">{blocker.state}</span>
+				<button
+					type="button"
+					data-testid="goto-external"
+					onClick={() => navigate("/other")}
+				>
+					external
+				</button>
+				<button
+					type="button"
+					data-testid="goto-safe"
+					onClick={() => navigate("/detail/abc/editor")}
+				>
+					safe
+				</button>
+			</>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/detail/abc/general", element: <Probe /> },
+			{ path: "/detail/abc/editor", element: <span>editor</span> },
+			{ path: "/other", element: <span>other</span> },
+		],
+		{ initialEntries: [opts.initial ?? "/detail/abc/general"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("useUnsavedChangesBlocker", () => {
+	it("never blocks when isDirty is false", async () => {
+		const router = makeRouter({ isDirty: false });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-external").click();
+		});
+		expect(screen.getByText("other")).toBeTruthy();
+	});
+
+	it("blocks external navigation when isDirty is true", async () => {
+		const router = makeRouter({ isDirty: true });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-external").click();
+		});
+		expect(screen.getByTestId("state").textContent).toBe("blocked");
+	});
+
+	it("allows navigation to paths under safePathPrefix even when dirty", async () => {
+		const router = makeRouter({
+			isDirty: true,
+			safePathPrefix: "/detail/abc/",
+		});
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-safe").click();
+		});
+		expect(screen.getByText("editor")).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/navigation/use-unsaved-changes-blocker.test.tsx`
+Expected: FAIL — `Failed to resolve import "./use-unsaved-changes-blocker"`.
+
+- [ ] **Step 3: Commit failing test**
+
+Branch is already `feat/unified-unsaved-changes-api` (spec commit `772d0e6` is on it). Do NOT create a new branch.
+
+```bash
+git add src/navigation/use-unsaved-changes-blocker.test.tsx
+git commit -m "test(navigation): add failing tests for useUnsavedChangesBlocker"
+```
+
+---
+
+### Task 2: Implement `useUnsavedChangesBlocker`
+
+**Files:**
+- Create: `src/navigation/use-unsaved-changes-blocker.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+import type { Blocker, Location } from "react-router-dom";
+import { useBlocker } from "react-router-dom";
+
+export interface UnsavedChangesBlockerOptions {
+	/**
+	 * Pathname prefix considered "safe" — navigation to a path starting with
+	 * this prefix does NOT trigger the block. Use for sibling tabs of the
+	 * same detail page (e.g. `/foo/bar/${id}/`). Trailing slash matters.
+	 */
+	safePathPrefix?: string;
+	/**
+	 * Custom predicate. Receives react-router's blocker args. Takes
+	 * precedence over `safePathPrefix`. Default: block iff
+	 * `isDirty && nextLocation.pathname !== currentLocation.pathname`.
+	 */
+	shouldBlock?: (args: {
+		currentLocation: Location;
+		nextLocation: Location;
+	}) => boolean;
+}
+
+/**
+ * Block in-app navigation while there are unsaved changes.
+ *
+ * Returns the raw react-router `Blocker` so the caller can render their own
+ * dialog. For the conventional dialog UX use `<UnsavedChangesGuard/>` (which
+ * composes this hook with `<LeavePageConfirmation/>`).
+ *
+ * Requires a react-router-dom **data router** (`createBrowserRouter` /
+ * `createMemoryRouter` + `<RouterProvider/>`). The legacy `<BrowserRouter>` /
+ * `<MemoryRouter>` JSX routers do not implement `useBlocker`.
+ */
+export function useUnsavedChangesBlocker(
+	isDirty: boolean,
+	opts?: UnsavedChangesBlockerOptions,
+): Blocker {
+	const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+		if (!isDirty) return false;
+		if (opts?.shouldBlock) {
+			return opts.shouldBlock({ currentLocation, nextLocation });
+		}
+		if (
+			opts?.safePathPrefix &&
+			nextLocation.pathname.startsWith(opts.safePathPrefix)
+		) {
+			return false;
+		}
+		if (nextLocation.pathname === currentLocation.pathname) return false;
+		return true;
+	});
+	return blocker;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/navigation/use-unsaved-changes-blocker.test.tsx`
+Expected: PASS — 3/3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/navigation/use-unsaved-changes-blocker.ts
+git commit -m "feat(navigation): add useUnsavedChangesBlocker primitive"
+```
+
+---
+
+### Task 3: Failing test for `<UnsavedChangesGuard/>`
+
+**Files:**
+- Create: `src/navigation/unsaved-changes-guard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { UnsavedChangesGuard } from "./unsaved-changes-guard";
+
+function makeRouter(isDirty: boolean) {
+	function Probe() {
+		const navigate = useNavigate();
+		return (
+			<>
+				<UnsavedChangesGuard
+					isDirty={isDirty}
+					title="Test title"
+					message="Test message"
+					confirmLabel="Leave!"
+					cancelLabel="Stay!"
+				/>
+				<button
+					type="button"
+					data-testid="leave"
+					onClick={() => navigate("/elsewhere")}
+				>
+					leave
+				</button>
+			</>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/start", element: <Probe /> },
+			{ path: "/elsewhere", element: <span>elsewhere</span> },
+		],
+		{ initialEntries: ["/start"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("UnsavedChangesGuard", () => {
+	it("does not interrupt navigation when isDirty is false", async () => {
+		const router = makeRouter(false);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("renders the dialog with supplied labels when dirty navigation is attempted", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		expect(screen.getByText("Test title")).toBeTruthy();
+		expect(screen.getByText("Test message")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Leave!" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Stay!" })).toBeTruthy();
+	});
+
+	it("proceeds with navigation when the user confirms", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		await act(async () => {
+			screen.getByRole("button", { name: "Leave!" }).click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("stays on the page when the user cancels", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		await act(async () => {
+			screen.getByRole("button", { name: "Stay!" }).click();
+		});
+		expect(screen.queryByText("elsewhere")).toBeNull();
+		expect(screen.getByTestId("leave")).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/navigation/unsaved-changes-guard.test.tsx`
+Expected: FAIL — `Failed to resolve import "./unsaved-changes-guard"`.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add src/navigation/unsaved-changes-guard.test.tsx
+git commit -m "test(navigation): add failing tests for UnsavedChangesGuard"
+```
+
+---
+
+### Task 4: Implement `<UnsavedChangesGuard/>`
+
+**Files:**
+- Create: `src/navigation/unsaved-changes-guard.tsx`
+
+- [ ] **Step 1: Implement**
+
+```tsx
+import { LeavePageConfirmation } from "../primitives/leave-page-confirmation";
+import {
+	type UnsavedChangesBlockerOptions,
+	useUnsavedChangesBlocker,
+} from "./use-unsaved-changes-blocker";
+
+export interface UnsavedChangesGuardProps
+	extends UnsavedChangesBlockerOptions {
+	/** Source of truth for whether there's unsaved work. */
+	isDirty: boolean;
+	/** Dialog title. @default "You have unsaved changes" */
+	title?: string;
+	/** Dialog message body. @default "Are you sure you want to leave this page? You have unsaved changes." */
+	message?: string;
+	/** Confirm/leave label. @default "Leave" */
+	confirmLabel?: string;
+	/** Cancel/stay label. @default "Stay" */
+	cancelLabel?: string;
+}
+
+/**
+ * Blocks in-app navigation while `isDirty` is true and renders
+ * `LeavePageConfirmation` to ask the user to confirm. Non-form-aware —
+ * pass any boolean (form `formState.isDirty`, Monaco buffer state, etc.).
+ * For react-hook-form pages use `<DirtyFormGuard/>` which sources `isDirty`
+ * from `useFormContext()` automatically.
+ *
+ * Use `safePathPrefix` to exempt sibling tabs of the same detail page:
+ *
+ * ```tsx
+ * <UnsavedChangesGuard
+ *   isDirty={editor.hasAnyDirty}
+ *   safePathPrefix={`/template/templates/${templateId}/`}
+ * />
+ * ```
+ */
+export function UnsavedChangesGuard({
+	isDirty,
+	safePathPrefix,
+	shouldBlock,
+	title,
+	message,
+	confirmLabel,
+	cancelLabel,
+}: UnsavedChangesGuardProps) {
+	const blocker = useUnsavedChangesBlocker(isDirty, {
+		safePathPrefix,
+		shouldBlock,
+	});
+	return (
+		<LeavePageConfirmation
+			blocked={blocker.state === "blocked"}
+			onConfirmLeave={() => blocker.proceed?.()}
+			onCancelLeave={() => blocker.reset?.()}
+			title={title}
+			message={message}
+			confirmLabel={confirmLabel}
+			cancelLabel={cancelLabel}
+		/>
+	);
+}
+UnsavedChangesGuard.displayName = "UnsavedChangesGuard";
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/navigation/unsaved-changes-guard.test.tsx`
+Expected: PASS — 4/4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/navigation/unsaved-changes-guard.tsx
+git commit -m "feat(navigation): add UnsavedChangesGuard component"
+```
+
+---
+
+### Task 5: Failing test for `TabDirtyContext`
+
+**Files:**
+- Create: `src/navigation/tab-dirty-context.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+(Port of the existing template-side tests, no router needed.)
+
+```tsx
+import { act, render, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TabDirtyProvider, useTabDirty } from "./tab-dirty-context";
+
+describe("TabDirtyContext", () => {
+	it("starts clean for any key and flips per key independently", () => {
+		const { result } = renderHook(() => useTabDirty(), {
+			wrapper: ({ children }) => (
+				<TabDirtyProvider>{children}</TabDirtyProvider>
+			),
+		});
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(result.current.isTabDirty("general")).toBe(false);
+
+		act(() => result.current.setTabDirty("editor", true));
+		expect(result.current.isTabDirty("editor")).toBe(true);
+		expect(result.current.isTabDirty("general")).toBe(false);
+
+		act(() => result.current.setTabDirty("general", true));
+		expect(result.current.isTabDirty("editor")).toBe(true);
+		expect(result.current.isTabDirty("general")).toBe(true);
+
+		act(() => result.current.setTabDirty("editor", false));
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(result.current.isTabDirty("general")).toBe(true);
+	});
+
+	it("default (no provider) returns clean state and no-op setter", () => {
+		const { result } = renderHook(() => useTabDirty());
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(() => result.current.setTabDirty("editor", true)).not.toThrow();
+	});
+
+	it("renders children", () => {
+		const { getByText } = render(
+			<TabDirtyProvider>
+				<span>hello</span>
+			</TabDirtyProvider>,
+		);
+		expect(getByText("hello")).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/navigation/tab-dirty-context.test.tsx`
+Expected: FAIL — `Failed to resolve import "./tab-dirty-context"`.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add src/navigation/tab-dirty-context.test.tsx
+git commit -m "test(navigation): add failing tests for TabDirtyContext"
+```
+
+---
+
+### Task 6: Implement `TabDirtyContext`
+
+**Files:**
+- Create: `src/navigation/tab-dirty-context.tsx`
+
+- [ ] **Step 1: Implement**
+
+(Verbatim from template's working implementation, with anker tab/comment style.)
+
+```tsx
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+export interface TabDirtyState {
+	/** Returns true if a tab key has been marked dirty. */
+	isTabDirty: (key: string) => boolean;
+	/** Mark a tab key as dirty (true) or clean (false). */
+	setTabDirty: (key: string, dirty: boolean) => void;
+}
+
+const Ctx = createContext<TabDirtyState>({
+	isTabDirty: () => false,
+	setTabDirty: () => undefined,
+});
+
+/**
+ * Multi-key registry for per-tab dirty state. Mount at the layout level
+ * of a tabbed detail page; have each tab's content publish its dirty
+ * state via `setTabDirty(tabKey, isDirty)` and render `<DirtyDot
+ * active={isTabDirty(tab.value)}/>` inside each `Tabs.Trigger`.
+ *
+ * The no-provider fallback returns clean state and a no-op setter so
+ * consumers don't have to defensively check.
+ */
+export function TabDirtyProvider({ children }: { children: ReactNode }) {
+	const [dirty, setDirty] = useState<Record<string, boolean>>({});
+
+	const setTabDirty = useCallback((key: string, v: boolean) => {
+		setDirty((prev) => (prev[key] === v ? prev : { ...prev, [key]: v }));
+	}, []);
+
+	const isTabDirty = useCallback(
+		(key: string) => Boolean(dirty[key]),
+		[dirty],
+	);
+
+	const value = useMemo<TabDirtyState>(
+		() => ({ isTabDirty, setTabDirty }),
+		[isTabDirty, setTabDirty],
+	);
+
+	return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useTabDirty(): TabDirtyState {
+	return useContext(Ctx);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/navigation/tab-dirty-context.test.tsx`
+Expected: PASS — 3/3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/navigation/tab-dirty-context.tsx
+git commit -m "feat(navigation): add TabDirtyProvider + useTabDirty"
+```
+
+---
+
+### Task 7: Navigation barrel + tsup entry + sub-path export
+
+**Files:**
+- Create: `src/navigation/index.ts`
+- Modify: `tsup.config.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Create barrel**
+
+`src/navigation/index.ts`:
+
+```ts
+// useUnsavedChangesBlocker
+export {
+	useUnsavedChangesBlocker,
+	type UnsavedChangesBlockerOptions,
+} from "./use-unsaved-changes-blocker";
+
+// UnsavedChangesGuard
+export {
+	UnsavedChangesGuard,
+	type UnsavedChangesGuardProps,
+} from "./unsaved-changes-guard";
+
+// TabDirtyContext
+export {
+	TabDirtyProvider,
+	useTabDirty,
+	type TabDirtyState,
+} from "./tab-dirty-context";
+```
+
+- [ ] **Step 2: Add tsup entry**
+
+In `tsup.config.ts`, append to the `entry` map (alongside `forms/index`, `feedback/index`, etc.):
+
+```ts
+		"navigation/index": "src/navigation/index.ts",
+```
+
+The relevant block becomes:
+
+```ts
+	entry: {
+		"theme/index": "src/theme/index.ts",
+		"primitives/index": "src/primitives/index.ts",
+		"components/index": "src/components/index.ts",
+		"atoms/index": "src/atoms/index.ts",
+		"forms/index": "src/forms/index.ts",
+		"feedback/index": "src/feedback/index.ts",
+		"templates/index": "src/templates/index.ts",
+		"navigation/index": "src/navigation/index.ts",
+	},
+```
+
+- [ ] **Step 3: Add sub-path export to package.json**
+
+In `package.json`'s `exports` map (alongside `./forms`, `./feedback`, etc.) add:
+
+```json
+		"./navigation": {
+			"import": "./dist/navigation/index.js",
+			"types": "./dist/navigation/index.d.ts"
+		},
+```
+
+- [ ] **Step 4: Build + verify-exports**
+
+Run: `npm run build && npm run verify-exports`
+Expected: clean. The verify-exports output should mention 8 tsup entries (was 7), and `useUnsavedChangesBlocker`, `UnsavedChangesGuard`, `TabDirtyProvider`, `useTabDirty` resolve from `@knkcs/anker/navigation`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/navigation/index.ts tsup.config.ts package.json
+git commit -m "feat(navigation): wire navigation sub-path export"
+```
+
+---
+
+### Task 8: Refactor `DirtyFormGuard` to delegate
+
+**Files:**
+- Modify: `src/forms/dirty-form-guard.tsx`
+- Create: `src/forms/dirty-form-guard.test.tsx`
+
+- [ ] **Step 1: Write the failing test for the new behaviour**
+
+```tsx
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { DirtyFormGuard } from "./dirty-form-guard";
+
+function makeRouter(opts: {
+	defaultDirty: boolean;
+	safePathPrefix?: string;
+}) {
+	function FormHost() {
+		const form = useForm<{ name: string }>({
+			defaultValues: { name: opts.defaultDirty ? "" : "saved" },
+		});
+		// Make the form "dirty" by changing a value at mount if requested.
+		if (opts.defaultDirty) {
+			form.setValue("name", "typed", { shouldDirty: true });
+		}
+		const navigate = useNavigate();
+		return (
+			<FormProvider {...form}>
+				<DirtyFormGuard
+					safePathPrefix={opts.safePathPrefix}
+					title="Form title"
+					message="Form message"
+					confirmLabel="Leave"
+					cancelLabel="Stay"
+				/>
+				<button
+					type="button"
+					data-testid="external"
+					onClick={() => navigate("/elsewhere")}
+				>
+					external
+				</button>
+				<button
+					type="button"
+					data-testid="safe"
+					onClick={() => navigate("/detail/abc/editor")}
+				>
+					safe
+				</button>
+			</FormProvider>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/detail/abc/general", element: <FormHost /> },
+			{ path: "/detail/abc/editor", element: <span>editor</span> },
+			{ path: "/elsewhere", element: <span>elsewhere</span> },
+		],
+		{ initialEntries: ["/detail/abc/general"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("DirtyFormGuard", () => {
+	it("blocks external navigation when the form is dirty (no opts)", async () => {
+		const router = makeRouter({ defaultDirty: true });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("external").click();
+		});
+		expect(screen.getByText("Form title")).toBeTruthy();
+	});
+
+	it("does not block when the form is clean", async () => {
+		const router = makeRouter({ defaultDirty: false });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("external").click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("allows safePathPrefix navigation even when dirty", async () => {
+		const router = makeRouter({
+			defaultDirty: true,
+			safePathPrefix: "/detail/abc/",
+		});
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("safe").click();
+		});
+		expect(screen.getByText("editor")).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify the safePathPrefix case fails on current impl**
+
+Run: `npx vitest run src/forms/dirty-form-guard.test.tsx`
+Expected: tests #1 and #2 PASS (existing behaviour); test #3 FAILS (current `DirtyFormGuard` ignores `safePathPrefix`).
+
+- [ ] **Step 3: Refactor DirtyFormGuard to delegate**
+
+Replace the full contents of `src/forms/dirty-form-guard.tsx`:
+
+```tsx
+import type React from "react";
+import { useFormContext } from "react-hook-form";
+import {
+	UnsavedChangesGuard,
+	type UnsavedChangesGuardProps,
+} from "../navigation/unsaved-changes-guard";
+
+export interface DirtyFormGuardProps
+	extends Omit<UnsavedChangesGuardProps, "isDirty"> {
+	// Inherits title/message/confirmLabel/cancelLabel/safePathPrefix/shouldBlock
+	// from UnsavedChangesGuardProps; `isDirty` is resolved from
+	// `useFormContext().formState.isDirty`.
+}
+
+/**
+ * Form-aware shortcut for `<UnsavedChangesGuard/>`: sources `isDirty` from
+ * the surrounding `useFormContext()`. Must be mounted inside a
+ * `<FormProvider/>`. For non-form dirty sources (Monaco buffer, custom
+ * hook) use `<UnsavedChangesGuard isDirty={…}/>` directly.
+ *
+ * Pass `safePathPrefix` to exempt sibling tabs of the same detail page
+ * from the leave-confirmation modal.
+ */
+export const DirtyFormGuard: React.FC<DirtyFormGuardProps> = (props) => {
+	const { formState } = useFormContext();
+	return <UnsavedChangesGuard isDirty={formState.isDirty} {...props} />;
+};
+DirtyFormGuard.displayName = "DirtyFormGuard";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/forms/dirty-form-guard.test.tsx`
+Expected: PASS — 3/3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/forms/dirty-form-guard.tsx src/forms/dirty-form-guard.test.tsx
+git commit -m "refactor(forms): DirtyFormGuard delegates to UnsavedChangesGuard"
+```
+
+---
+
+### Task 9: Update `dirty-surfaces.mdx`
+
+**Files:**
+- Modify: `src/forms/dirty-surfaces.mdx`
+
+- [ ] **Step 1: Rewrite the page**
+
+Replace the file contents with this expanded version covering all five surfaces:
+
+```mdx
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Forms/Dirty surfaces" />
+
+# Dirty surfaces
+
+knkCMS surfaces unsaved changes in five coordinated ways. Use the
+matching component for the surface you need — don't invent new dirty
+visuals.
+
+| Surface | Component | Where it fires |
+|---|---|---|
+| **Field-level dirty visual** | yellow input border + dot on label | automatic on `InputField` / `SelectField` / `SwitchField` / `TextareaField` / `ArrayField` / `RadioGroupField` / `CheckboxField` via `formState.dirtyFields`. Opt out with `showDirtyState={false}`. |
+| **Header counter chip** | `<DirtyCounter />` | reads dirty count from `useFormContext`. Mount in the page header via `usePageActions`. |
+| **Tab-trigger dot** | `<DirtyDot active={…} />` + `useTabDirty()` | publishes/consumes per-tab dirty state. Mount inside each `Tabs.Trigger`. |
+| **Leave-page guard (form)** | `<DirtyFormGuard />` | inside a `<FormProvider/>`. Intercepts navigation when the form is dirty. |
+| **Leave-page guard (any)** | `<UnsavedChangesGuard isDirty={…} />` | for non-form dirty sources (Monaco buffer, custom hook, etc.). |
+
+## Field-level dirty visual
+
+```tsx
+import { InputField } from "@knkcs/anker/forms";
+
+<InputField name="title" label="Title" />
+// Yellow border + label dot appear automatically when the field is dirty.
+```
+
+## Header counter chip
+
+```tsx
+import { DirtyCounter } from "@knkcs/anker/forms";
+import { usePageActions } from "@knkcs/anker/templates";
+
+usePageActions(<DirtyCounter />);
+```
+
+## Tab-trigger dot
+
+Wire any number of dirty sources to a tabbed detail page. Each
+content tab publishes its own dirty state; the layout's `Tabs.Trigger`
+renders `<DirtyDot/>` against the registry.
+
+```tsx
+import { DirtyDot } from "@knkcs/anker/atoms";
+import { TabDirtyProvider, useTabDirty } from "@knkcs/anker/navigation";
+
+// Layout
+function DetailLayout() {
+  return (
+    <TabDirtyProvider>
+      <DetailLayoutInner />
+    </TabDirtyProvider>
+  );
+}
+
+function DetailLayoutInner() {
+  const { isTabDirty } = useTabDirty();
+  return (
+    <Tabs.Root>
+      <Tabs.List>
+        {tabs.map((t) => (
+          <Tabs.Trigger key={t.value} value={t.value}>
+            {t.label}
+            <DirtyDot active={isTabDirty(t.value)} />
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+    </Tabs.Root>
+  );
+}
+
+// A tab that publishes its dirty state (form example)
+function GeneralTab() {
+  const { setTabDirty } = useTabDirty();
+  const { formState } = useFormContext();
+  useEffect(() => {
+    setTabDirty("general", formState.isDirty);
+    return () => setTabDirty("general", false);
+  }, [formState.isDirty, setTabDirty]);
+  // …
+}
+```
+
+## Leave-page guard
+
+Block in-app navigation while there are unsaved changes. Use
+`safePathPrefix` to exempt sibling tabs of the same detail page so
+intra-page tab switches don't trigger the modal.
+
+**Form-aware (most common):**
+
+```tsx
+import { DirtyFormGuard } from "@knkcs/anker/forms";
+
+<FormProvider {...form}>
+  <DirtyFormGuard
+    safePathPrefix={`/template/templates/${templateId}/`}
+    title="Ungespeicherte Änderungen"
+    message="Möchten Sie die Seite verlassen? Ihre Änderungen gehen verloren."
+    confirmLabel="Verlassen"
+    cancelLabel="Bleiben"
+  />
+  {/* fields… */}
+</FormProvider>
+```
+
+**Any dirty source (Monaco buffer, custom hook, …):**
+
+```tsx
+import { UnsavedChangesGuard } from "@knkcs/anker/navigation";
+
+<UnsavedChangesGuard
+  isDirty={editor.hasAnyDirty}
+  safePathPrefix={`/template/templates/${templateId}/`}
+  title="Ungespeicherte Änderungen"
+/>
+```
+
+> **Data-router requirement.** Both guards rely on
+> `react-router-dom`'s `useBlocker`, which only works inside a data
+> router (`createBrowserRouter` / `createMemoryRouter` +
+> `<RouterProvider/>`). The legacy `<BrowserRouter>` / `<MemoryRouter>`
+> JSX routers do not implement `useBlocker`.
+
+## Advanced: primitive hook
+
+If you need to build a non-dialog UX (e.g. a toast, an inline banner),
+use the hook directly:
+
+```tsx
+import { useUnsavedChangesBlocker } from "@knkcs/anker/navigation";
+
+const blocker = useUnsavedChangesBlocker(isDirty, {
+  safePathPrefix: `/foo/bar/${id}/`,
+});
+// blocker.state === "blocked" | "proceeding" | "unblocked"
+// blocker.proceed(), blocker.reset()
+```
+```
+
+- [ ] **Step 2: Build storybook to verify**
+
+Run: `npm run build-storybook`
+Expected: builds clean; `Forms/Dirty surfaces` still appears in `storybook-static/index.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/forms/dirty-surfaces.mdx
+git commit -m "docs(forms): expand dirty-surfaces to cover navigation guards"
+```
+
+---
+
+### Task 10: Full verify
+
+- [ ] **Step 1: Lint**
+
+Run: `npm run lint`
+Expected: clean.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npm test`
+Expected: all green (existing tests + 3 new for blocker + 4 new for guard + 3 new for tab-dirty + 3 new for DirtyFormGuard = 13 new cases).
+
+- [ ] **Step 4: Build + verify-exports**
+
+Run: `npm run build && npm run verify-exports`
+Expected: clean; 8 tsup entries (was 7); `@knkcs/anker/navigation` resolves the four new exports.
+
+- [ ] **Step 5: If anything failed, fix + commit**
+
+Use project conventions to address failures. If you cannot fix, escalate as BLOCKED with the exact error.
+
+```bash
+git add -A
+git commit -m "fix(navigation): address lint/typecheck/build feedback"
+```
+
+(Skip if everything passed on first run.)
+
+---
+
+### Task 11: Version bump + PR
+
+**Files:**
+- Modify: `package.json` (version)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump version**
+
+Edit `package.json`:
+
+```json
+"version": "2.8.0",
+```
+
+- [ ] **Step 2: Update changelog**
+
+Prepend under a new heading:
+
+```markdown
+## 2.8.0 — 2026-05-29
+
+### Added
+- New `@knkcs/anker/navigation` namespace:
+  - `useUnsavedChangesBlocker(isDirty, opts)` — primitive hook returning a
+    react-router `Blocker`. Supports `safePathPrefix` to exempt sibling
+    paths (e.g. tabs of the same detail page) and `shouldBlock` for
+    arbitrary predicates.
+  - `<UnsavedChangesGuard isDirty={…} …/>` — non-form-aware leave-page
+    guard composing the hook with `<LeavePageConfirmation/>`.
+  - `<TabDirtyProvider/>` + `useTabDirty()` — multi-key registry of
+    per-tab dirty state. Use with `<DirtyDot/>` to surface unsaved work
+    on tab triggers.
+- `<DirtyFormGuard/>` now accepts `safePathPrefix` and `shouldBlock`.
+  Existing callers without these props behave identically.
+
+### Changed
+- `<DirtyFormGuard/>` internally delegates to `<UnsavedChangesGuard/>`
+  (transparent refactor; no API break).
+- `Forms/Dirty surfaces` storybook page expanded to cover all five
+  dirty surfaces (field visual, counter chip, tab dot, form guard,
+  generic guard).
+
+### Requirements
+- The leave-page guards require a react-router-dom **data router**
+  (`createBrowserRouter` / `createMemoryRouter` + `<RouterProvider/>`).
+```
+
+- [ ] **Step 3: Commit version bump**
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "chore(release): 2.8.0"
+```
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin feat/unified-unsaved-changes-api
+gh pr create --title "feat: unified unsaved-changes API (2.8.0)" --body "$(cat <<'EOF'
+## Summary
+- New `@knkcs/anker/navigation` namespace: `useUnsavedChangesBlocker`, `UnsavedChangesGuard`, `TabDirtyProvider`, `useTabDirty`.
+- `DirtyFormGuard` accepts `safePathPrefix` / `shouldBlock` and internally delegates to `UnsavedChangesGuard`. Backwards-compat for existing callers.
+- `Forms/Dirty surfaces` docs cover all five surfaces.
+- Version bump 2.7.0 → 2.8.0, additive only.
+
+Spec: `docs/superpowers/specs/2026-05-29-unified-unsaved-changes-api-design.md`.
+
+## Test Plan
+- [ ] `npm test` green (incl. 13 new tests)
+- [ ] `npm run lint` / `typecheck` / `build` / `verify-exports` clean
+- [ ] Storybook shows `Forms/Dirty surfaces` with the expanded matrix + snippets
+
+## Adoption
+Template service adopts in a follow-up PR (drops project-local `tab-dirty-context.tsx` + `template-detail-dirty-guard.tsx`).
+EOF
+)"
+```
+
+- [ ] **Step 5: After merge, tag + verify publish**
+
+Once the PR merges, on `main`:
+
+```bash
+git checkout main
+git pull
+git tag v2.8.0
+git push origin v2.8.0
+```
+
+Watch the publish workflow (`gh run watch <id>`). When green:
+
+```bash
+npm view @knkcs/anker@2.8.0 version
+```
+
+Expected output: `2.8.0`.
+
+---
+
+## Acceptance criteria check (from spec §9)
+
+- [ ] `@knkcs/anker@2.8.0` published with `useUnsavedChangesBlocker`, `UnsavedChangesGuard`, `TabDirtyProvider`, `useTabDirty` exported from `@knkcs/anker/navigation`.
+- [ ] `DirtyFormGuard` accepts `safePathPrefix` / `shouldBlock`; existing callers without those props behave identically.
+- [ ] `Forms/Dirty surfaces` mdx covers all five surfaces with runnable snippets.
+- [ ] vitest suite green; lint/typecheck/build/verify-exports clean.

--- a/docs/superpowers/specs/2026-05-29-unified-unsaved-changes-api-design.md
+++ b/docs/superpowers/specs/2026-05-29-unified-unsaved-changes-api-design.md
@@ -1,0 +1,253 @@
+# Unified Unsaved-Changes API — Design
+
+**Date:** 2026-05-29
+**Status:** Draft — awaiting review
+**Services:** anker (additive 2.8.0), template (small follow-up adoption PR)
+
+## 1. Problem
+
+The template service shipped a clean tabbed-detail dirty UX in PRs #19–#24:
+
+- A multi-key `TabDirtyContext` so any tab trigger can render `<DirtyDot/>`.
+- A `TemplateDetailDirtyGuard` that uses `useBlocker` with a same-page-prefix bypass, so intra-page tab switches don't trigger the leave-confirmation modal.
+- Several state-persistence providers so tab unmounts don't lose unsaved work.
+
+odon, layout, and core will need the same UX as they grow tabbed detail pages. Today they would copy the template's project-local files, which guarantees drift. We want this to be the canonical knkCMS pattern, owned by anker.
+
+Anker already ships `DirtyDot` (2.7.0), `DirtyCounter`, `DirtyFormGuard`, and `LeavePageConfirmation`. What's missing is (a) the multi-key registry, (b) a navigation guard that's NOT tied to react-hook-form, and (c) a primitive blocker hook for advanced cases (Monaco editor, custom dirty sources).
+
+## 2. Decision
+
+Anker `2.8.0` ships a `src/navigation/` namespace with three new pieces and refactors `DirtyFormGuard` to delegate to them. The `Forms/Dirty surfaces` storybook page becomes the single dirty-UX reference. Template adopts the new pieces in a follow-up PR.
+
+## 3. Anker changes
+
+### 3.1 New folder layout
+
+```
+src/navigation/
+  use-unsaved-changes-blocker.ts
+  unsaved-changes-guard.tsx
+  tab-dirty-context.tsx
+  index.ts
+```
+
+Sub-path export `@knkcs/anker/navigation` added to `package.json`. The existing locations (`DirtyDot` in `src/atoms/`, `DirtyCounter`/`DirtyFormGuard` in `src/forms/`, `LeavePageConfirmation` in `src/primitives/`) stay put — backwards compat — and pick up internal imports from the new folder.
+
+### 3.2 `useUnsavedChangesBlocker(isDirty, opts)`
+
+Primitive hook wrapping react-router's `useBlocker` with a sensible default predicate. Returns the raw `Blocker` so advanced callers can render their own dialog.
+
+```ts
+import type { Blocker, Location } from "react-router";
+
+export interface UnsavedChangesBlockerOptions {
+  /** Pathname prefix considered "safe". Navigation to a path starting with
+   *  this prefix does NOT trigger the block. Use for sibling tabs of the
+   *  same detail page (`/foo/bar/${id}/`). Trailing slash matters. */
+  safePathPrefix?: string;
+  /** Custom predicate. Receives react-router's blocker args. Takes
+   *  precedence over `safePathPrefix`. Default: block iff
+   *  `isDirty && nextLocation.pathname !== currentLocation.pathname`. */
+  shouldBlock?: (args: {
+    currentLocation: Location;
+    nextLocation: Location;
+  }) => boolean;
+}
+
+export function useUnsavedChangesBlocker(
+  isDirty: boolean,
+  opts?: UnsavedChangesBlockerOptions,
+): Blocker;
+```
+
+Internal logic:
+
+```ts
+const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+  if (!isDirty) return false;
+  if (opts?.shouldBlock) return opts.shouldBlock({ currentLocation, nextLocation });
+  if (opts?.safePathPrefix && nextLocation.pathname.startsWith(opts.safePathPrefix)) {
+    return false;
+  }
+  if (nextLocation.pathname === currentLocation.pathname) return false;
+  return true;
+});
+return blocker;
+```
+
+### 3.3 `<UnsavedChangesGuard isDirty={…} …/>`
+
+Component composing the hook + `LeavePageConfirmation`. Non-form-aware — works for Monaco buffers, custom hooks, anything with a boolean.
+
+```ts
+export interface UnsavedChangesGuardProps
+  extends UnsavedChangesBlockerOptions {
+  /** Source of truth for whether there's unsaved work. */
+  isDirty: boolean;
+  /** Dialog title. @default "You have unsaved changes" */
+  title?: string;
+  /** Dialog message. @default "Are you sure you want to leave this page? You have unsaved changes." */
+  message?: string;
+  /** Confirm/leave label. @default "Leave" */
+  confirmLabel?: string;
+  /** Cancel/stay label. @default "Stay" */
+  cancelLabel?: string;
+}
+
+export function UnsavedChangesGuard(props: UnsavedChangesGuardProps) {
+  const { isDirty, safePathPrefix, shouldBlock, ...dialog } = props;
+  const blocker = useUnsavedChangesBlocker(isDirty, { safePathPrefix, shouldBlock });
+  return (
+    <LeavePageConfirmation
+      blocked={blocker.state === "blocked"}
+      onConfirmLeave={() => blocker.proceed?.()}
+      onCancelLeave={() => blocker.reset?.()}
+      {...dialog}
+    />
+  );
+}
+```
+
+### 3.4 `<DirtyFormGuard …>` becomes a thin wrapper
+
+Existing call sites (`<DirtyFormGuard title="…" …/>` without opts) keep working unchanged. New `safePathPrefix` / `shouldBlock` props added.
+
+```ts
+export interface DirtyFormGuardProps
+  extends UnsavedChangesBlockerOptions {
+  title?: string;
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export function DirtyFormGuard(props: DirtyFormGuardProps) {
+  const { formState } = useFormContext();
+  return <UnsavedChangesGuard isDirty={formState.isDirty} {...props} />;
+}
+```
+
+The current `useBlocker` import (`react-router-dom`) is dropped — the import now lives in `useUnsavedChangesBlocker` and uses `react-router` (consistent with the rest of anker).
+
+### 3.5 `<TabDirtyProvider>` + `useTabDirty()`
+
+Lifted verbatim from template's `web/src/pages/templates/tab-dirty-context.tsx`. API unchanged:
+
+```ts
+interface TabDirtyState {
+  isTabDirty: (key: string) => boolean;
+  setTabDirty: (key: string, dirty: boolean) => void;
+}
+```
+
+Implementation:
+
+```tsx
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+const Ctx = createContext<TabDirtyState>({
+  isTabDirty: () => false,
+  setTabDirty: () => undefined,
+});
+
+export function TabDirtyProvider({ children }: { children: ReactNode }) {
+  const [dirty, setDirty] = useState<Record<string, boolean>>({});
+  const setTabDirty = useCallback((key: string, v: boolean) => {
+    setDirty((prev) => (prev[key] === v ? prev : { ...prev, [key]: v }));
+  }, []);
+  const isTabDirty = useCallback(
+    (key: string) => Boolean(dirty[key]),
+    [dirty],
+  );
+  const value = useMemo(
+    () => ({ isTabDirty, setTabDirty }),
+    [isTabDirty, setTabDirty],
+  );
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useTabDirty(): TabDirtyState {
+  return useContext(Ctx);
+}
+```
+
+## 4. Tests
+
+vitest + `@testing-library/react`. Each test wraps in `<MemoryRouter>` (or `createMemoryRouter`) as needed.
+
+- `use-unsaved-changes-blocker.test.ts` — three cases: (a) `isDirty=false` never blocks; (b) `isDirty=true` blocks external nav (no prefix match); (c) `isDirty=true` allows nav under `safePathPrefix`. Drive transitions via `useNavigate`.
+- `unsaved-changes-guard.test.tsx` — when `isDirty=true` and a blocked nav is attempted, `LeavePageConfirmation` renders with the supplied title/message; clicking confirm calls `blocker.proceed`; clicking cancel calls `blocker.reset`.
+- `tab-dirty-context.test.tsx` — port the 3 existing template-side tests verbatim (per-key isolation, no-provider fallback, children rendering).
+- `dirty-form-guard.test.tsx` — assert that the wrapper renders `UnsavedChangesGuard` with `isDirty` sourced from `useFormContext().formState`, and that `safePathPrefix`/`shouldBlock` pass through. (Existing behaviour smoke: a dirty form blocks navigation when no opts are passed.)
+
+## 5. Docs
+
+`src/forms/dirty-surfaces.mdx` becomes the single dirty-UX reference (it already lives at `Forms/Dirty surfaces` in storybook). Rewrites:
+
+- Update the **Tab-trigger dot** table row to mention `<TabDirtyProvider>` + `useTabDirty()`.
+- Add a **TabDirtyProvider** section with the full wiring example: provider at the layout level; consumers (form effect, editor `setTabDirty`) publish; `Tabs.Trigger` renders `<DirtyDot active={isTabDirty(tab.value)}/>`.
+- Add an **Intra-page navigation guard** section with two snippets:
+  - `<UnsavedChangesGuard isDirty={…} safePathPrefix={…}/>` for non-form sources (Monaco buffer).
+  - `<DirtyFormGuard safePathPrefix={…}/>` for react-hook-form pages — same `safePathPrefix` prop, form's `isDirty` resolved automatically.
+- A short "when to use which" matrix at the top:
+  | Surface | Component | Where it fires |
+  |---|---|---|
+  | Field-level visual | yellow border + label dot | automatic on `*Field` |
+  | Header counter chip | `<DirtyCounter/>` | mount via `usePageActions` |
+  | Tab-trigger dot | `<DirtyDot active={…}/>` + `useTabDirty()` | inside `Tabs.Trigger` |
+  | Leave-page guard (form) | `<DirtyFormGuard …/>` | inside a `FormProvider` |
+  | Leave-page guard (any) | `<UnsavedChangesGuard isDirty={…}/>` | anywhere with a dirty boolean |
+
+The doc stays in `src/forms/` (existing storybook URL preserved). Title remains `Forms/Dirty surfaces`.
+
+## 6. Release
+
+Minor bump `2.7.0 → 2.8.0`. Additive only — no breaking changes.
+
+- `package.json` version field
+- `CHANGELOG.md` entry under `## 2.8.0 — 2026-05-29` summarising the new navigation namespace
+- Tag `v2.8.0` after merge → triggers existing publish workflow → verify `npm view @knkcs/anker@2.8.0 version`
+
+## 7. Template adoption (separate PR, after 2.8.0 publishes)
+
+Net effect: 2 files deleted, ~6 import lines changed. Total diff is small.
+
+- Bump `web/package.json` → `@knkcs/anker: ^2.8.0`.
+- Delete `web/src/pages/templates/tab-dirty-context.tsx` + its test.
+- Delete `web/src/pages/templates/template-detail-dirty-guard.tsx`.
+- Update imports in `template-detail-layout.tsx`, `editor-tab.tsx`, `editor-state-provider.tsx`, `general-form-provider.tsx`:
+  - `from "./tab-dirty-context"` → `from "@knkcs/anker/navigation"`.
+- In `general-form-provider.tsx` swap:
+  ```tsx
+  <TemplateDetailDirtyGuard templateId={template.id} … />
+  ```
+  for:
+  ```tsx
+  <DirtyFormGuard
+    safePathPrefix={`/template/templates/${template.id}/`}
+    title="Ungespeicherte Änderungen"
+    message="Möchten Sie die Seite verlassen? Ihre Änderungen gehen verloren."
+    confirmLabel="Verlassen"
+    cancelLabel="Bleiben"
+  />
+  ```
+  Drop the import of `TemplateDetailDirtyGuard`; keep using `DirtyFormGuard` from `@knkcs/anker/forms`.
+
+The template-side `tab-dirty-context.test.tsx` is replaced by anker's equivalent — no test coverage lost.
+
+## 8. Out of scope
+
+- Auto-save in the Editor tab. Still requires explicit Speichern.
+- Generalising `TabDirtyContext` into a `DirtyRegistry` for sidebar items / breadcrumbs / arbitrary surfaces. The current per-buffer dirty in template's sidebar uses a local prop (`dirtyIds: Set<string>`); generalising it is YAGNI until a second consumer materialises.
+- Animations or transitions on `<DirtyDot/>`.
+- A `useBlocker`-based guard for Monaco unsaved state in the Editor tab — possible now (the new `<UnsavedChangesGuard isDirty={editor.hasAnyDirty}/>` would do it) but the team chose to rely on the tab dot as the in-page signal. Adding the modal is a one-line follow-up if desired.
+
+## 9. Acceptance criteria
+
+- [ ] `@knkcs/anker@2.8.0` published with `useUnsavedChangesBlocker`, `UnsavedChangesGuard`, `TabDirtyProvider`, `useTabDirty` exported from `@knkcs/anker/navigation`.
+- [ ] `DirtyFormGuard` accepts `safePathPrefix` / `shouldBlock`; existing callers without those props behave identically (block iff dirty).
+- [ ] `Forms/Dirty surfaces` mdx covers all five surfaces (field, counter, tab dot, form guard, generic guard) with runnable snippets.
+- [ ] vitest suite green; lint/typecheck/build/verify-exports clean.
+- [ ] Template follow-up PR: 2 project-local files deleted; existing manual acceptance (PR #21–#24 behaviour) unchanged after the swap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.4.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knkcs/anker",
-      "version": "2.4.0",
+      "version": "2.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chakra-react-select": "^6.0.0",
@@ -29,6 +29,7 @@
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/lodash.debounce": "^4.0.9",
+        "happy-dom": "^20.9.0",
         "i18next": "^23.0.0",
         "jsdom": "^25.0.0",
         "react": "^19.0.0",
@@ -2810,6 +2811,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -2855,6 +2866,23 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
@@ -5264,6 +5292,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-flag": {
@@ -9294,6 +9363,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/lodash.debounce": "^4.0.9",
+    "happy-dom": "^20.9.0",
     "i18next": "^23.0.0",
     "jsdom": "^25.0.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "./templates": {
       "import": "./dist/templates/index.js",
       "types": "./dist/templates/index.d.ts"
+    },
+    "./navigation": {
+      "import": "./dist/navigation/index.js",
+      "types": "./dist/navigation/index.d.ts"
     }
   },
   "files": [

--- a/src/forms/dirty-form-guard.test.tsx
+++ b/src/forms/dirty-form-guard.test.tsx
@@ -2,19 +2,17 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
+import { describe, expect, it } from "vitest";
 import { FormProvider, useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import {
 	RouterProvider,
 	createMemoryRouter,
+	useNavigate,
 } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+
 import { DirtyFormGuard } from "./dirty-form-guard";
 
-function makeRouter(opts: {
-	defaultDirty: boolean;
-	safePathPrefix?: string;
-}) {
+function makeRouter(opts: { defaultDirty: boolean; safePathPrefix?: string }) {
 	function FormHost() {
 		const form = useForm<{ name: string }>({
 			defaultValues: { name: opts.defaultDirty ? "" : "saved" },

--- a/src/forms/dirty-form-guard.test.tsx
+++ b/src/forms/dirty-form-guard.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { DirtyFormGuard } from "./dirty-form-guard";
+
+function makeRouter(opts: {
+	defaultDirty: boolean;
+	safePathPrefix?: string;
+}) {
+	function FormHost() {
+		const form = useForm<{ name: string }>({
+			defaultValues: { name: opts.defaultDirty ? "" : "saved" },
+		});
+		// Make the form "dirty" by changing a value at mount if requested.
+		if (opts.defaultDirty) {
+			form.setValue("name", "typed", { shouldDirty: true });
+		}
+		const navigate = useNavigate();
+		return (
+			<FormProvider {...form}>
+				<DirtyFormGuard
+					safePathPrefix={opts.safePathPrefix}
+					title="Form title"
+					message="Form message"
+					confirmLabel="Leave"
+					cancelLabel="Stay"
+				/>
+				<button
+					type="button"
+					data-testid="external"
+					onClick={() => navigate("/elsewhere")}
+				>
+					external
+				</button>
+				<button
+					type="button"
+					data-testid="safe"
+					onClick={() => navigate("/detail/abc/editor")}
+				>
+					safe
+				</button>
+			</FormProvider>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/detail/abc/general", element: <FormHost /> },
+			{ path: "/detail/abc/editor", element: <span>editor</span> },
+			{ path: "/elsewhere", element: <span>elsewhere</span> },
+		],
+		{ initialEntries: ["/detail/abc/general"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("DirtyFormGuard", () => {
+	it("blocks external navigation when the form is dirty (no opts)", async () => {
+		const router = makeRouter({ defaultDirty: true });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("external").click();
+		});
+		expect(screen.getByText("Form title")).toBeTruthy();
+	});
+
+	it("does not block when the form is clean", async () => {
+		const router = makeRouter({ defaultDirty: false });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("external").click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("allows safePathPrefix navigation even when dirty", async () => {
+		const router = makeRouter({
+			defaultDirty: true,
+			safePathPrefix: "/detail/abc/",
+		});
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("safe").click();
+		});
+		expect(screen.getByText("editor")).toBeTruthy();
+	});
+});

--- a/src/forms/dirty-form-guard.tsx
+++ b/src/forms/dirty-form-guard.tsx
@@ -1,38 +1,28 @@
 import type React from "react";
 import { useFormContext } from "react-hook-form";
-import { useBlocker } from "react-router-dom";
-import { LeavePageConfirmation } from "../primitives/leave-page-confirmation";
+import {
+	UnsavedChangesGuard,
+	type UnsavedChangesGuardProps,
+} from "../navigation/unsaved-changes-guard";
 
-export interface DirtyFormGuardProps {
-	/** Dialog title. @default "You have unsaved changes" */
-	title?: string;
-	/** Dialog message body. @default "Are you sure you want to leave this page? You have unsaved changes." */
-	message?: string;
-	/** Label for the confirm/leave button. @default "Leave" */
-	confirmLabel?: string;
-	/** Label for the cancel/stay button. @default "Stay" */
-	cancelLabel?: string;
+export interface DirtyFormGuardProps
+	extends Omit<UnsavedChangesGuardProps, "isDirty"> {
+	// Inherits title/message/confirmLabel/cancelLabel/safePathPrefix/shouldBlock
+	// from UnsavedChangesGuardProps; `isDirty` is resolved from
+	// `useFormContext().formState.isDirty`.
 }
 
-export const DirtyFormGuard: React.FC<DirtyFormGuardProps> = ({
-	title,
-	message,
-	confirmLabel,
-	cancelLabel,
-}) => {
+/**
+ * Form-aware shortcut for `<UnsavedChangesGuard/>`: sources `isDirty` from
+ * the surrounding `useFormContext()`. Must be mounted inside a
+ * `<FormProvider/>`. For non-form dirty sources (Monaco buffer, custom
+ * hook) use `<UnsavedChangesGuard isDirty={…}/>` directly.
+ *
+ * Pass `safePathPrefix` to exempt sibling tabs of the same detail page
+ * from the leave-confirmation modal.
+ */
+export const DirtyFormGuard: React.FC<DirtyFormGuardProps> = (props) => {
 	const { formState } = useFormContext();
-	const blocker = useBlocker(formState.isDirty);
-
-	return (
-		<LeavePageConfirmation
-			blocked={blocker.state === "blocked"}
-			onConfirmLeave={() => blocker.proceed?.()}
-			onCancelLeave={() => blocker.reset?.()}
-			title={title}
-			message={message}
-			confirmLabel={confirmLabel}
-			cancelLabel={cancelLabel}
-		/>
-	);
+	return <UnsavedChangesGuard isDirty={formState.isDirty} {...props} />;
 };
 DirtyFormGuard.displayName = "DirtyFormGuard";

--- a/src/forms/dirty-surfaces.mdx
+++ b/src/forms/dirty-surfaces.mdx
@@ -4,14 +4,17 @@ import { Meta } from "@storybook/blocks";
 
 # Dirty surfaces
 
-knkCMS surfaces unsaved changes in three coordinated ways. Use the matching
-component for the surface you need — don't invent new dirty visuals.
+knkCMS surfaces unsaved changes in five coordinated ways. Use the
+matching component for the surface you need — don't invent new dirty
+visuals.
 
 | Surface | Component | Where it fires |
 |---|---|---|
 | **Field-level dirty visual** | yellow input border + dot on label | automatic on `InputField` / `SelectField` / `SwitchField` / `TextareaField` / `ArrayField` / `RadioGroupField` / `CheckboxField` via `formState.dirtyFields`. Opt out with `showDirtyState={false}`. |
 | **Header counter chip** | `<DirtyCounter />` | reads dirty count from `useFormContext`. Mount in the page header via `usePageActions`. |
-| **Tab-trigger dot** | `<DirtyDot active={…} />` | when a tabbed page has editable content on one tab and the user might be on another. Mount inside the `Tabs.Trigger`. |
+| **Tab-trigger dot** | `<DirtyDot active={…} />` + `useTabDirty()` | publishes/consumes per-tab dirty state. Mount inside each `Tabs.Trigger`. |
+| **Leave-page guard (form)** | `<DirtyFormGuard />` | inside a `<FormProvider/>`. Intercepts navigation when the form is dirty. |
+| **Leave-page guard (any)** | `<UnsavedChangesGuard isDirty={…} />` | for non-form dirty sources (Monaco buffer, custom hook, etc.). |
 
 ## Field-level dirty visual
 
@@ -33,15 +36,103 @@ usePageActions(<DirtyCounter />);
 
 ## Tab-trigger dot
 
+Wire any number of dirty sources to a tabbed detail page. Each
+content tab publishes its own dirty state; the layout's `Tabs.Trigger`
+renders `<DirtyDot/>` against the registry.
+
 ```tsx
 import { DirtyDot } from "@knkcs/anker/atoms";
+import { TabDirtyProvider, useTabDirty } from "@knkcs/anker/navigation";
 
-<Tabs.Trigger value="editor">
-  Editor
-  <DirtyDot active={isDirty} />
-</Tabs.Trigger>
+// Layout
+function DetailLayout() {
+  return (
+    <TabDirtyProvider>
+      <DetailLayoutInner />
+    </TabDirtyProvider>
+  );
+}
+
+function DetailLayoutInner() {
+  const { isTabDirty } = useTabDirty();
+  return (
+    <Tabs.Root>
+      <Tabs.List>
+        {tabs.map((t) => (
+          <Tabs.Trigger key={t.value} value={t.value}>
+            {t.label}
+            <DirtyDot active={isTabDirty(t.value)} />
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+    </Tabs.Root>
+  );
+}
+
+// A tab that publishes its dirty state (form example)
+function GeneralTab() {
+  const { setTabDirty } = useTabDirty();
+  const { formState } = useFormContext();
+  useEffect(() => {
+    setTabDirty("general", formState.isDirty);
+    return () => setTabDirty("general", false);
+  }, [formState.isDirty, setTabDirty]);
+  // …
+}
 ```
 
-The dot is a 6px yellow circle with `ml="2"` and the aria-label
-"ungespeicherte Änderungen". Pass `active={false}` to hide it; use `boxProps`
-to override colour or margin if you really need to.
+## Leave-page guard
+
+Block in-app navigation while there are unsaved changes. Use
+`safePathPrefix` to exempt sibling tabs of the same detail page so
+intra-page tab switches don't trigger the modal.
+
+**Form-aware (most common):**
+
+```tsx
+import { DirtyFormGuard } from "@knkcs/anker/forms";
+
+<FormProvider {...form}>
+  <DirtyFormGuard
+    safePathPrefix={`/template/templates/${templateId}/`}
+    title="Ungespeicherte Änderungen"
+    message="Möchten Sie die Seite verlassen? Ihre Änderungen gehen verloren."
+    confirmLabel="Verlassen"
+    cancelLabel="Bleiben"
+  />
+  {/* fields… */}
+</FormProvider>
+```
+
+**Any dirty source (Monaco buffer, custom hook, …):**
+
+```tsx
+import { UnsavedChangesGuard } from "@knkcs/anker/navigation";
+
+<UnsavedChangesGuard
+  isDirty={editor.hasAnyDirty}
+  safePathPrefix={`/template/templates/${templateId}/`}
+  title="Ungespeicherte Änderungen"
+/>
+```
+
+> **Data-router requirement.** Both guards rely on
+> `react-router-dom`'s `useBlocker`, which only works inside a data
+> router (`createBrowserRouter` / `createMemoryRouter` +
+> `<RouterProvider/>`). The legacy `<BrowserRouter>` / `<MemoryRouter>`
+> JSX routers do not implement `useBlocker`.
+
+## Advanced: primitive hook
+
+If you need to build a non-dialog UX (e.g. a toast, an inline banner),
+use the hook directly:
+
+```tsx
+import { useUnsavedChangesBlocker } from "@knkcs/anker/navigation";
+
+const blocker = useUnsavedChangesBlocker(isDirty, {
+  safePathPrefix: `/foo/bar/${id}/`,
+});
+// blocker.state === "blocked" | "proceeding" | "unblocked"
+// blocker.proceed(), blocker.reset()
+```

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -1,0 +1,18 @@
+// useUnsavedChangesBlocker
+export {
+	useUnsavedChangesBlocker,
+	type UnsavedChangesBlockerOptions,
+} from "./use-unsaved-changes-blocker";
+
+// UnsavedChangesGuard
+export {
+	UnsavedChangesGuard,
+	type UnsavedChangesGuardProps,
+} from "./unsaved-changes-guard";
+
+// TabDirtyContext
+export {
+	TabDirtyProvider,
+	useTabDirty,
+	type TabDirtyState,
+} from "./tab-dirty-context";

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -1,18 +1,13 @@
-// useUnsavedChangesBlocker
-export {
-	useUnsavedChangesBlocker,
-	type UnsavedChangesBlockerOptions,
-} from "./use-unsaved-changes-blocker";
-
-// UnsavedChangesGuard
-export {
-	UnsavedChangesGuard,
-	type UnsavedChangesGuardProps,
-} from "./unsaved-changes-guard";
-
-// TabDirtyContext
 export {
 	TabDirtyProvider,
 	useTabDirty,
 	type TabDirtyState,
 } from "./tab-dirty-context";
+export {
+	UnsavedChangesGuard,
+	type UnsavedChangesGuardProps,
+} from "./unsaved-changes-guard";
+export {
+	useUnsavedChangesBlocker,
+	type UnsavedChangesBlockerOptions,
+} from "./use-unsaved-changes-blocker";

--- a/src/navigation/tab-dirty-context.test.tsx
+++ b/src/navigation/tab-dirty-context.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TabDirtyProvider, useTabDirty } from "./tab-dirty-context";
+
+describe("TabDirtyContext", () => {
+	it("starts clean for any key and flips per key independently", () => {
+		const { result } = renderHook(() => useTabDirty(), {
+			wrapper: ({ children }) => (
+				<TabDirtyProvider>{children}</TabDirtyProvider>
+			),
+		});
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(result.current.isTabDirty("general")).toBe(false);
+
+		act(() => result.current.setTabDirty("editor", true));
+		expect(result.current.isTabDirty("editor")).toBe(true);
+		expect(result.current.isTabDirty("general")).toBe(false);
+
+		act(() => result.current.setTabDirty("general", true));
+		expect(result.current.isTabDirty("editor")).toBe(true);
+		expect(result.current.isTabDirty("general")).toBe(true);
+
+		act(() => result.current.setTabDirty("editor", false));
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(result.current.isTabDirty("general")).toBe(true);
+	});
+
+	it("default (no provider) returns clean state and no-op setter", () => {
+		const { result } = renderHook(() => useTabDirty());
+		expect(result.current.isTabDirty("editor")).toBe(false);
+		expect(() => result.current.setTabDirty("editor", true)).not.toThrow();
+	});
+
+	it("renders children", () => {
+		const { getByText } = render(
+			<TabDirtyProvider>
+				<span>hello</span>
+			</TabDirtyProvider>,
+		);
+		expect(getByText("hello")).toBeTruthy();
+	});
+});

--- a/src/navigation/tab-dirty-context.tsx
+++ b/src/navigation/tab-dirty-context.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
 
 export interface TabDirtyState {
 	/** Returns true if a tab key has been marked dirty. */
@@ -29,10 +35,7 @@ export function TabDirtyProvider({ children }: { children: ReactNode }) {
 		setDirty((prev) => (prev[key] === v ? prev : { ...prev, [key]: v }));
 	}, []);
 
-	const isTabDirty = useCallback(
-		(key: string) => Boolean(dirty[key]),
-		[dirty],
-	);
+	const isTabDirty = useCallback((key: string) => Boolean(dirty[key]), [dirty]);
 
 	const value = useMemo<TabDirtyState>(
 		() => ({ isTabDirty, setTabDirty }),

--- a/src/navigation/tab-dirty-context.tsx
+++ b/src/navigation/tab-dirty-context.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+export interface TabDirtyState {
+	/** Returns true if a tab key has been marked dirty. */
+	isTabDirty: (key: string) => boolean;
+	/** Mark a tab key as dirty (true) or clean (false). */
+	setTabDirty: (key: string, dirty: boolean) => void;
+}
+
+const Ctx = createContext<TabDirtyState>({
+	isTabDirty: () => false,
+	setTabDirty: () => undefined,
+});
+
+/**
+ * Multi-key registry for per-tab dirty state. Mount at the layout level
+ * of a tabbed detail page; have each tab's content publish its dirty
+ * state via `setTabDirty(tabKey, isDirty)` and render `<DirtyDot
+ * active={isTabDirty(tab.value)}/>` inside each `Tabs.Trigger`.
+ *
+ * The no-provider fallback returns clean state and a no-op setter so
+ * consumers don't have to defensively check.
+ */
+export function TabDirtyProvider({ children }: { children: ReactNode }) {
+	const [dirty, setDirty] = useState<Record<string, boolean>>({});
+
+	const setTabDirty = useCallback((key: string, v: boolean) => {
+		setDirty((prev) => (prev[key] === v ? prev : { ...prev, [key]: v }));
+	}, []);
+
+	const isTabDirty = useCallback(
+		(key: string) => Boolean(dirty[key]),
+		[dirty],
+	);
+
+	const value = useMemo<TabDirtyState>(
+		() => ({ isTabDirty, setTabDirty }),
+		[isTabDirty, setTabDirty],
+	);
+
+	return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useTabDirty(): TabDirtyState {
+	return useContext(Ctx);
+}

--- a/src/navigation/tab-dirty-context.tsx
+++ b/src/navigation/tab-dirty-context.tsx
@@ -1,5 +1,5 @@
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 export interface TabDirtyState {
 	/** Returns true if a tab key has been marked dirty. */

--- a/src/navigation/unsaved-changes-guard.test.tsx
+++ b/src/navigation/unsaved-changes-guard.test.tsx
@@ -2,12 +2,13 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
-import { useNavigate } from "react-router-dom";
+import { describe, expect, it } from "vitest";
 import {
 	RouterProvider,
 	createMemoryRouter,
+	useNavigate,
 } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+
 import { UnsavedChangesGuard } from "./unsaved-changes-guard";
 
 function makeRouter(isDirty: boolean) {

--- a/src/navigation/unsaved-changes-guard.test.tsx
+++ b/src/navigation/unsaved-changes-guard.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { UnsavedChangesGuard } from "./unsaved-changes-guard";
+
+function makeRouter(isDirty: boolean) {
+	function Probe() {
+		const navigate = useNavigate();
+		return (
+			<>
+				<UnsavedChangesGuard
+					isDirty={isDirty}
+					title="Test title"
+					message="Test message"
+					confirmLabel="Leave!"
+					cancelLabel="Stay!"
+				/>
+				<button
+					type="button"
+					data-testid="leave"
+					onClick={() => navigate("/elsewhere")}
+				>
+					leave
+				</button>
+			</>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/start", element: <Probe /> },
+			{ path: "/elsewhere", element: <span>elsewhere</span> },
+		],
+		{ initialEntries: ["/start"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("UnsavedChangesGuard", () => {
+	it("does not interrupt navigation when isDirty is false", async () => {
+		const router = makeRouter(false);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("renders the dialog with supplied labels when dirty navigation is attempted", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		expect(screen.getByText("Test title")).toBeTruthy();
+		expect(screen.getByText("Test message")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Leave!" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Stay!" })).toBeTruthy();
+	});
+
+	it("proceeds with navigation when the user confirms", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		await act(async () => {
+			screen.getByRole("button", { name: "Leave!" }).click();
+		});
+		expect(screen.getByText("elsewhere")).toBeTruthy();
+	});
+
+	it("stays on the page when the user cancels", async () => {
+		const router = makeRouter(true);
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("leave").click();
+		});
+		await act(async () => {
+			screen.getByRole("button", { name: "Stay!" }).click();
+		});
+		expect(screen.queryByText("elsewhere")).toBeNull();
+		expect(screen.getByTestId("leave")).toBeTruthy();
+	});
+});

--- a/src/navigation/unsaved-changes-guard.tsx
+++ b/src/navigation/unsaved-changes-guard.tsx
@@ -1,0 +1,62 @@
+import { LeavePageConfirmation } from "../primitives/leave-page-confirmation";
+import {
+	type UnsavedChangesBlockerOptions,
+	useUnsavedChangesBlocker,
+} from "./use-unsaved-changes-blocker";
+
+export interface UnsavedChangesGuardProps
+	extends UnsavedChangesBlockerOptions {
+	/** Source of truth for whether there's unsaved work. */
+	isDirty: boolean;
+	/** Dialog title. @default "You have unsaved changes" */
+	title?: string;
+	/** Dialog message body. @default "Are you sure you want to leave this page? You have unsaved changes." */
+	message?: string;
+	/** Confirm/leave label. @default "Leave" */
+	confirmLabel?: string;
+	/** Cancel/stay label. @default "Stay" */
+	cancelLabel?: string;
+}
+
+/**
+ * Blocks in-app navigation while `isDirty` is true and renders
+ * `LeavePageConfirmation` to ask the user to confirm. Non-form-aware —
+ * pass any boolean (form `formState.isDirty`, Monaco buffer state, etc.).
+ * For react-hook-form pages use `<DirtyFormGuard/>` which sources `isDirty`
+ * from `useFormContext()` automatically.
+ *
+ * Use `safePathPrefix` to exempt sibling tabs of the same detail page:
+ *
+ * ```tsx
+ * <UnsavedChangesGuard
+ *   isDirty={editor.hasAnyDirty}
+ *   safePathPrefix={`/template/templates/${templateId}/`}
+ * />
+ * ```
+ */
+export function UnsavedChangesGuard({
+	isDirty,
+	safePathPrefix,
+	shouldBlock,
+	title,
+	message,
+	confirmLabel,
+	cancelLabel,
+}: UnsavedChangesGuardProps) {
+	const blocker = useUnsavedChangesBlocker(isDirty, {
+		safePathPrefix,
+		shouldBlock,
+	});
+	return (
+		<LeavePageConfirmation
+			blocked={blocker.state === "blocked"}
+			onConfirmLeave={() => blocker.proceed?.()}
+			onCancelLeave={() => blocker.reset?.()}
+			title={title}
+			message={message}
+			confirmLabel={confirmLabel}
+			cancelLabel={cancelLabel}
+		/>
+	);
+}
+UnsavedChangesGuard.displayName = "UnsavedChangesGuard";

--- a/src/navigation/unsaved-changes-guard.tsx
+++ b/src/navigation/unsaved-changes-guard.tsx
@@ -4,8 +4,7 @@ import {
 	useUnsavedChangesBlocker,
 } from "./use-unsaved-changes-blocker";
 
-export interface UnsavedChangesGuardProps
-	extends UnsavedChangesBlockerOptions {
+export interface UnsavedChangesGuardProps extends UnsavedChangesBlockerOptions {
 	/** Source of truth for whether there's unsaved work. */
 	isDirty: boolean;
 	/** Dialog title. @default "You have unsaved changes" */

--- a/src/navigation/use-unsaved-changes-blocker.test.tsx
+++ b/src/navigation/use-unsaved-changes-blocker.test.tsx
@@ -1,0 +1,90 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+	RouterProvider,
+	createMemoryRouter,
+} from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { useUnsavedChangesBlocker } from "./use-unsaved-changes-blocker";
+
+function makeRouter(opts: {
+	isDirty: boolean;
+	safePathPrefix?: string;
+	initial?: string;
+}) {
+	function Probe() {
+		const navigate = useNavigate();
+		const blocker = useUnsavedChangesBlocker(opts.isDirty, {
+			safePathPrefix: opts.safePathPrefix,
+		});
+		return (
+			<>
+				<span data-testid="state">{blocker.state}</span>
+				<button
+					type="button"
+					data-testid="goto-external"
+					onClick={() => navigate("/other")}
+				>
+					external
+				</button>
+				<button
+					type="button"
+					data-testid="goto-safe"
+					onClick={() => navigate("/detail/abc/editor")}
+				>
+					safe
+				</button>
+			</>
+		);
+	}
+	return createMemoryRouter(
+		[
+			{ path: "/detail/abc/general", element: <Probe /> },
+			{ path: "/detail/abc/editor", element: <span>editor</span> },
+			{ path: "/other", element: <span>other</span> },
+		],
+		{ initialEntries: [opts.initial ?? "/detail/abc/general"] },
+	);
+}
+
+function renderRouter(router: ReturnType<typeof createMemoryRouter>) {
+	return render(
+		<ChakraProvider value={defaultSystem}>
+			<RouterProvider router={router} />
+		</ChakraProvider>,
+	);
+}
+
+describe("useUnsavedChangesBlocker", () => {
+	it("never blocks when isDirty is false", async () => {
+		const router = makeRouter({ isDirty: false });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-external").click();
+		});
+		expect(screen.getByText("other")).toBeTruthy();
+	});
+
+	it("blocks external navigation when isDirty is true", async () => {
+		const router = makeRouter({ isDirty: true });
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-external").click();
+		});
+		expect(screen.getByTestId("state").textContent).toBe("blocked");
+	});
+
+	it("allows navigation to paths under safePathPrefix even when dirty", async () => {
+		const router = makeRouter({
+			isDirty: true,
+			safePathPrefix: "/detail/abc/",
+		});
+		renderRouter(router);
+		await act(async () => {
+			screen.getByTestId("goto-safe").click();
+		});
+		expect(screen.getByText("editor")).toBeTruthy();
+	});
+});

--- a/src/navigation/use-unsaved-changes-blocker.test.tsx
+++ b/src/navigation/use-unsaved-changes-blocker.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";

--- a/src/navigation/use-unsaved-changes-blocker.test.tsx
+++ b/src/navigation/use-unsaved-changes-blocker.test.tsx
@@ -2,12 +2,13 @@
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
-import { useNavigate } from "react-router-dom";
+import { describe, expect, it } from "vitest";
 import {
 	RouterProvider,
 	createMemoryRouter,
+	useNavigate,
 } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+
 import { useUnsavedChangesBlocker } from "./use-unsaved-changes-blocker";
 
 function makeRouter(opts: {

--- a/src/navigation/use-unsaved-changes-blocker.ts
+++ b/src/navigation/use-unsaved-changes-blocker.ts
@@ -1,0 +1,52 @@
+import type { Blocker, Location } from "react-router-dom";
+import { useBlocker } from "react-router-dom";
+
+export interface UnsavedChangesBlockerOptions {
+	/**
+	 * Pathname prefix considered "safe" — navigation to a path starting with
+	 * this prefix does NOT trigger the block. Use for sibling tabs of the
+	 * same detail page (e.g. `/foo/bar/${id}/`). Trailing slash matters.
+	 */
+	safePathPrefix?: string;
+	/**
+	 * Custom predicate. Receives react-router's blocker args. Takes
+	 * precedence over `safePathPrefix`. Default: block iff
+	 * `isDirty && nextLocation.pathname !== currentLocation.pathname`.
+	 */
+	shouldBlock?: (args: {
+		currentLocation: Location;
+		nextLocation: Location;
+	}) => boolean;
+}
+
+/**
+ * Block in-app navigation while there are unsaved changes.
+ *
+ * Returns the raw react-router `Blocker` so the caller can render their own
+ * dialog. For the conventional dialog UX use `<UnsavedChangesGuard/>` (which
+ * composes this hook with `<LeavePageConfirmation/>`).
+ *
+ * Requires a react-router-dom **data router** (`createBrowserRouter` /
+ * `createMemoryRouter` + `<RouterProvider/>`). The legacy `<BrowserRouter>` /
+ * `<MemoryRouter>` JSX routers do not implement `useBlocker`.
+ */
+export function useUnsavedChangesBlocker(
+	isDirty: boolean,
+	opts?: UnsavedChangesBlockerOptions,
+): Blocker {
+	const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+		if (!isDirty) return false;
+		if (opts?.shouldBlock) {
+			return opts.shouldBlock({ currentLocation, nextLocation });
+		}
+		if (
+			opts?.safePathPrefix &&
+			nextLocation.pathname.startsWith(opts.safePathPrefix)
+		) {
+			return false;
+		}
+		if (nextLocation.pathname === currentLocation.pathname) return false;
+		return true;
+	});
+	return blocker;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "forms/index": "src/forms/index.ts",
     "feedback/index": "src/feedback/index.ts",
     "templates/index": "src/templates/index.ts",
+    "navigation/index": "src/navigation/index.ts",
   },
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary
- New `@knkcs/anker/navigation` namespace: `useUnsavedChangesBlocker`, `UnsavedChangesGuard`, `TabDirtyProvider`, `useTabDirty`.
- `DirtyFormGuard` accepts `safePathPrefix` / `shouldBlock` and internally delegates to `UnsavedChangesGuard`. Backwards-compat for existing callers.
- `Forms/Dirty surfaces` docs cover all five surfaces.
- Version bump 2.7.0 → 2.8.0, additive only.

Spec: `docs/superpowers/specs/2026-05-29-unified-unsaved-changes-api-design.md`.

## Test Plan
- [x] `npm test` green (1134/1134 incl. 13 new tests)
- [x] `npm run lint` / `typecheck` / `build` / `verify-exports` clean
- [x] Storybook shows `Forms/Dirty surfaces` with the expanded matrix + snippets

## Adoption
Template service adopts in a follow-up PR (drops project-local `tab-dirty-context.tsx` + `template-detail-dirty-guard.tsx`).