### PR TITLE
fix(lint): biome formatting on subnav-density test files

### DIFF
--- a/src/components/nav-list/nav-list.test.tsx
+++ b/src/components/nav-list/nav-list.test.tsx
@@ -125,11 +125,17 @@ describe("NavList", () => {
 		const { container } = renderWithChakra(
 			<NavList aria-label="t">
 				<NavList.Group label="Group">
-					<NavList.Item><span>One</span></NavList.Item>
-					<NavList.Item><span>Two</span></NavList.Item>
+					<NavList.Item>
+						<span>One</span>
+					</NavList.Item>
+					<NavList.Item>
+						<span>Two</span>
+					</NavList.Item>
 				</NavList.Group>
 			</NavList>,
 		);
-		expect(container.querySelector('[data-testid="nav-list-group-items"]')).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-testid="nav-list-group-items"]'),
+		).toBeInTheDocument();
 	});
 });

--- a/src/templates/subnav-layout.test.tsx
+++ b/src/templates/subnav-layout.test.tsx
@@ -136,9 +136,13 @@ describe("SubNavLayout", () => {
 	it("Root wraps the Grid in a self-stretching flex column", () => {
 		const { container } = renderWithChakra(
 			<SubNavLayout>
-				<SubNavLayout.Nav><div /></SubNavLayout.Nav>
-				<SubNavLayout.Detail><div /></SubNavLayout.Detail>
-			</SubNavLayout>
+				<SubNavLayout.Nav>
+					<div />
+				</SubNavLayout.Nav>
+				<SubNavLayout.Detail>
+					<div />
+				</SubNavLayout.Detail>
+			</SubNavLayout>,
 		);
 		const grid = container.querySelector('[data-testid="subnav-layout"]');
 		expect(grid).toBeInTheDocument();


### PR DESCRIPTION
Trailing-format fixes flagged by biome in PR #139's test files. Unblocks the v2.9.0 publish workflow which failed on lint.

After this merges, retag v2.9.0 on the new HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)