### PR TITLE
feat(nav-list): bump density to comfortable (2.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 2.9.1 — 2026-06-03
+
+### Changed
+- `NavList.Group`: bumped item gap from 4px to 8px (was tight in 2.9.0).
+- `NavList.Item`: bumped vertical padding from 8px to 12px each side (item height rises from ~32px to ~40px — standard nav row size).
+
 ## 2.9.0 — 2026-06-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/components/nav-list/nav-list.tsx
+++ b/src/components/nav-list/nav-list.tsx
@@ -41,7 +41,7 @@ const NavListGroup = ({ label, children }: NavListGroupProps) => {
 					{label}
 				</Text>
 			)}
-			<Flex direction="column" gap="1" data-testid="nav-list-group-items">
+			<Flex direction="column" gap="2" data-testid="nav-list-group-items">
 				{children}
 			</Flex>
 		</Box>
@@ -78,7 +78,7 @@ const NavListItem = ({
 		justifyContent: collapsed ? "center" : "flex-start",
 		gap: "var(--chakra-spacing-2)",
 		paddingInline: "var(--chakra-spacing-3)",
-		paddingBlock: "var(--chakra-spacing-2)",
+		paddingBlock: "var(--chakra-spacing-3)",
 		borderRadius: "var(--chakra-radii-sm)",
 		fontSize: "var(--chakra-font-sizes-sm)",
 		fontWeight: active


### PR DESCRIPTION
Follow-up to 2.9.0 — 2026-06-03 NavList density was still too tight in practice.

- Group gap 4px → 8px
- Item paddingBlock 8px → 12px (item ~32px → ~40px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)