### PR TITLE
fix(primitives): bump popover/menu/hover-card positioner z-index to 1800 (2.9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `@knkcs/anker` are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 2.9.3 — 2026-06-03
+
+### Fixed
+- `Popover`, `Menu`, `HoverCard`: positioner z-index bumped to `zIndex.tooltip` (1800) so popovers reliably render above drawers/modals. The 2.9.2 layer-aware calc resolved to 1500+0 on the positioner because Chakra's `--layer-index` is set on Content (not Positioner) and doesn't inherit upward; the positioner's `isolation: isolate` traps Content's z-index inside its own stacking context, so the body-level comparison was Positioner(1500) vs Drawer(1500), with drawer winning by DOM order.
+
 ## 2.9.2 — 2026-06-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knkcs/anker",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "UI component library for the knk software group",
   "repository": {
     "type": "git",

--- a/src/primitives/hover-card.test.tsx
+++ b/src/primitives/hover-card.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { HoverCard } from "./hover-card";
 
 describe("HoverCard z-index", () => {
-	it("Positioner z-index participates in Chakra's layer manager", () => {
+	it("Positioner z-index is 1800 (above drawer/modal layer)", () => {
 		render(
 			<ChakraProvider value={defaultSystem}>
 				<HoverCard open content={<span>card content</span>}>
@@ -17,7 +17,6 @@ describe("HoverCard z-index", () => {
 		) as HTMLElement | null;
 		expect(positioner).not.toBeNull();
 		const style = positioner?.getAttribute("style") ?? "";
-		expect(style).toMatch(/--layer-index/);
-		expect(style).toMatch(/1500/);
+		expect(style).toMatch(/1800/);
 	});
 });

--- a/src/primitives/hover-card.tsx
+++ b/src/primitives/hover-card.tsx
@@ -28,15 +28,13 @@ export const HoverCard = function HoverCard(props: HoverCardProps) {
 		<ChakraHoverCard.Root {...rest}>
 			<ChakraHoverCard.Trigger asChild>{children}</ChakraHoverCard.Trigger>
 			<Portal disabled={!portalled} container={portalRef}>
-				{/* Layer-aware z-index: starts at zIndex.popover (1500, above docked
-				    chrome) and adds Chakra's --layer-index offset so hover cards stack
-				    above modals/drawers when opened nested. */}
-				<ChakraHoverCard.Positioner
-					style={{
-						zIndex:
-							"calc(var(--hover-card-z-index, var(--chakra-z-index-popover, 1500)) + var(--layer-index, 0))",
-					}}
-				>
+				{/* Static z-index above drawer/modal layer. Chakra's --layer-index
+				    is only set on Content (not Positioner) and doesn't inherit
+				    upward; the Positioner has `isolation: isolate` which traps
+				    Content's z-index in a local stacking context. Using
+				    zIndex.tooltip (1800) reliably beats drawers/modals at
+				    zIndex.popover (1500). */}
+				<ChakraHoverCard.Positioner style={{ zIndex: 1800 }}>
 					<ChakraHoverCard.Content {...contentProps}>
 						{showArrow && (
 							<ChakraHoverCard.Arrow>

--- a/src/primitives/menu.test.tsx
+++ b/src/primitives/menu.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "./menu";
 
 describe("Menu z-index", () => {
-	it("Positioner z-index participates in Chakra's layer manager", () => {
+	it("Positioner z-index is 1800 (above drawer/modal layer)", () => {
 		render(
 			<ChakraProvider value={defaultSystem}>
 				<MenuRoot open>
@@ -20,7 +20,6 @@ describe("Menu z-index", () => {
 		) as HTMLElement | null;
 		expect(positioner).not.toBeNull();
 		const style = positioner?.getAttribute("style") ?? "";
-		expect(style).toMatch(/--layer-index/);
-		expect(style).toMatch(/1500/);
+		expect(style).toMatch(/1800/);
 	});
 });

--- a/src/primitives/menu.tsx
+++ b/src/primitives/menu.tsx
@@ -18,15 +18,13 @@ export const MenuContent = function MenuContent({
 	const { portalled = true, portalRef, ...rest } = props;
 	return (
 		<Portal disabled={!portalled} container={portalRef}>
-			{/* Layer-aware z-index: starts at zIndex.popover (1500, above docked
-			    chrome) and adds Chakra's --layer-index offset so menus stack
-			    above modals/drawers when opened nested. */}
-			<ChakraMenu.Positioner
-				style={{
-					zIndex:
-						"calc(var(--menu-z-index, var(--chakra-z-index-popover, 1500)) + var(--layer-index, 0))",
-				}}
-			>
+			{/* Static z-index above drawer/modal layer. Chakra's --layer-index
+			    is only set on Content (not Positioner) and doesn't inherit
+			    upward; the Positioner has `isolation: isolate` which traps
+			    Content's z-index in a local stacking context. Using
+			    zIndex.tooltip (1800) reliably beats drawers/modals at
+			    zIndex.popover (1500). */}
+			<ChakraMenu.Positioner style={{ zIndex: 1800 }}>
 				<ChakraMenu.Content ref={ref} {...rest} />
 			</ChakraMenu.Positioner>
 		</Portal>

--- a/src/primitives/popover.test.tsx
+++ b/src/primitives/popover.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 describe("Popover z-index", () => {
-	it("Positioner z-index participates in Chakra's layer manager", () => {
+	it("Positioner z-index is 1800 (above drawer/modal layer)", () => {
 		render(
 			<ChakraProvider value={defaultSystem}>
 				<Popover open>
@@ -18,7 +18,6 @@ describe("Popover z-index", () => {
 		) as HTMLElement | null;
 		expect(positioner).not.toBeNull();
 		const style = positioner?.getAttribute("style") ?? "";
-		expect(style).toMatch(/--layer-index/);
-		expect(style).toMatch(/1500/);
+		expect(style).toMatch(/1800/);
 	});
 });

--- a/src/primitives/popover.tsx
+++ b/src/primitives/popover.tsx
@@ -27,15 +27,14 @@ export const PopoverContent = function PopoverContent({
 	const { showArrow, portalled = true, portalRef, children, ...rest } = props;
 	return (
 		<Portal disabled={!portalled} container={portalRef}>
-			{/* Layer-aware z-index: starts at zIndex.popover (1500, above docked
-			    chrome) and adds Chakra's --layer-index offset so popovers stack
-			    above modals/drawers when opened nested. */}
-			<ChakraPopover.Positioner
-				style={{
-					zIndex:
-						"calc(var(--popover-z-index, var(--chakra-z-index-popover, 1500)) + var(--layer-index, 0))",
-				}}
-			>
+			{/* Static z-index above drawer/modal layer. Chakra's --layer-index
+			    is only set on Content (not Positioner) and doesn't inherit
+			    upward; the Positioner has `isolation: isolate` which traps
+			    Content's z-index in a local stacking context. So body-level
+			    stacking is decided by the Positioner's own z-index. Using
+			    zIndex.tooltip (1800) reliably beats drawers/modals which sit
+			    at zIndex.popover (1500) plus a small --layer-index offset. */}
+			<ChakraPopover.Positioner style={{ zIndex: 1800 }}>
 				<ChakraPopover.Content ref={ref} {...rest}>
 					{showArrow && (
 						<ChakraPopover.Arrow>


### PR DESCRIPTION
Follow-up to 2.9.2 which didn't actually fix the popover-inside-drawer layering.

Diagnosis via DOM elementsFromPoint in the deployed app:
- Popover.Positioner had `isolation: isolate` creating a local stacking context
- The Content's z=1501 (with --layer-index: 1) only competed inside that context
- At body level, Positioner (z=1500) tied with Drawer.Content (z=1500) and lost on DOM order

Fix: static z-index 1800 (zIndex.tooltip) on the Positioner. The 2.9.2 layer-aware calc resolved to 1500+0 because --layer-index is set by Chakra only on Content, never inherits up to Positioner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)